### PR TITLE
Issue: IORING_OP_READ_FIXED with IOSQE_IO_LINK always fails with -ECANCELED

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -10,7 +10,7 @@ all_targets += poll poll-cancel ring-leak fsync io_uring_setup io_uring_register
 		cq-size 8a9973408177-test a0908ae19763-test 232c93d07b74-test \
 		socket-rw accept timeout-overflow defer read-write io-cancel \
 		link-timeout cq-overflow link_drain fc2a85cb02ef-test \
-		poll-link accept-link
+		poll-link accept-link fixed-link
 
 include ../Makefile.quiet
 
@@ -28,7 +28,7 @@ test_srcs := poll.c poll-cancel.c ring-leak.c fsync.c io_uring_setup.c \
 	a0908ae19763-test.c 232c93d07b74-test.c socket-rw.c accept.c \
 	timeout-overflow.c defer.c read-write.c io-cancel.c link-timeout.c \
 	cq-overflow.c link_drain.c fc2a85cb02ef-test.c poll-link.c \
-	accept-link.c
+	accept-link.c fixed-link.c
 
 test_objs := $(patsubst %.c,%.ol,$(test_srcs))
 

--- a/test/fixed-link.c
+++ b/test/fixed-link.c
@@ -1,0 +1,66 @@
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <fcntl.h>
+#include <sys/types.h>
+
+#include "liburing.h"
+
+#define IOVECS_LEN 2
+
+int main() {
+	struct io_uring ring;
+	int fd = open("fixed-link.c", O_RDONLY);
+
+	if (fd < 0) {
+		perror("open");
+		assert(0);
+	}
+
+	if (io_uring_queue_init(32, &ring, 0) < 0) {
+		perror("io_uring_queue_init");
+		assert(0);
+	}
+
+	struct iovec iovecs[IOVECS_LEN];
+	for (int i = 0; i < IOVECS_LEN; ++i) {
+		iovecs[i] = (struct iovec){ .iov_base = malloc(64), .iov_len = 64 };
+	};
+
+	io_uring_register_buffers(&ring, iovecs, IOVECS_LEN);
+
+	for (int i = 0; i < IOVECS_LEN; ++i) {
+		struct io_uring_sqe *sqe = io_uring_get_sqe(&ring);
+		const char *str = "#include <errno.h>";
+		io_uring_prep_read_fixed(sqe, fd, iovecs[i].iov_base, strlen(str), 0, i);
+		io_uring_sqe_set_flags(sqe, IOSQE_IO_LINK);
+		io_uring_sqe_set_data(sqe, (void *)str);
+	}
+
+	io_uring_submit_and_wait(&ring, IOVECS_LEN);
+
+	for (int i = 0; i < IOVECS_LEN; ++i) {
+		struct io_uring_cqe *cqe;
+		io_uring_peek_cqe(&ring, &cqe);
+		const char *str = io_uring_cqe_get_data(cqe);
+		if (cqe->res < 0) {
+			errno = -cqe->res;
+			perror("cqe->res");
+			fprintf(stderr, "i = %d\n", i);
+			assert(0);
+		}
+		assert(strlen(str) == cqe->res);
+		assert(strcmp(str, iovecs[i].iov_base) == 0);
+		io_uring_cqe_seen(&ring, cqe);
+	}
+
+	close(fd);
+	io_uring_queue_exit(&ring);
+
+	for (int i = 0; i < IOVECS_LEN; ++i) {
+		free(iovecs[i].iov_base);
+	};
+}


### PR DESCRIPTION
My test fails with

```
Running test fixed-link
cqe->res: Operation canceled
i = 1
fixed-link: fixed-link.c:53: main: Assertion `0' failed.
```

If I remove `io_uring_sqe_set_flags(sqe, IOSQE_IO_LINK);` at Line 39, or define `IOVECS_LEN` to 1, the test passes successfully.

```bash
$ uname -a
Linux archlinux-pc 5.3.11-arch1-1 #1 SMP PREEMPT Tue, 12 Nov 2019 22:19:48 +0000 x86_64 GNU/Linux
```