### PR TITLE
Fix redefinition of statx_timestamp

### DIFF
--- a/test/statx.c
+++ b/test/statx.c
@@ -9,7 +9,6 @@
 #include <string.h>
 #include <fcntl.h>
 #include <sys/types.h>
-#include <sys/stat.h>
 #include <sys/syscall.h>
 #include <linux/stat.h>
 


### PR DESCRIPTION
statx_timestamp is defined in both linux/stat.h and sys/stat.h,
causing a build failure on some systems