### PR TITLE
for polled IO, do not miss the opportunity of getting completions whe…

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -187,7 +187,7 @@ static int __io_uring_submit(struct io_uring *ring, unsigned submitted,
 
 	flags = 0;
 	if (sq_ring_needs_enter(ring, &flags) || wait_nr) {
-		if (wait_nr)
+		if (wait_nr || (ring->flags & IORING_SETUP_IOPOLL))
 			flags |= IORING_ENTER_GETEVENTS;
 
 		ret = __sys_io_uring_enter(ring->ring_fd, submitted, wait_nr,


### PR DESCRIPTION
…n going to the kernel

Right now the IORING_ENTER_GETEVENTS flag is set automatically when
calling __io_uring_submit if the caller specifies requests to wait.

However, when using polled I/O it is still legal and common to specify
zero requests to wait for when we still want completions to happen if
there are any available.

One example of an application that would always specify zero requests is
the Seastar framework. We always submit existing new requests, if any,
and poll for I/O at pre-determined periods of time whether or not we
expect I/O to have been completed.

With the current behavior we are forced to issue a second system call if
we want to getevents, or worse: not to rely on liburing at all and craft
the queue magic by hand.

This patch changes the behavior of __io_uring_submit to always include
IORING_ENTER_GETEVENTS in case of polled I/O.

Signed-off-by: Glauber Costa <glauber@scylladb.com>