### PR TITLE
setup.c: add io_uring::features

### DIFF
--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -57,6 +57,7 @@ struct io_uring {
 	struct io_uring_sq sq;
 	struct io_uring_cq cq;
 	unsigned flags;
+	unsigned features;
 	int ring_fd;
 };
 

--- a/src/setup.c
+++ b/src/setup.c
@@ -91,6 +91,7 @@ int io_uring_queue_mmap(int fd, struct io_uring_params *p, struct io_uring *ring
 	ret = io_uring_mmap(fd, p, &ring->sq, &ring->cq);
 	if (!ret) {
 		ring->flags = p->flags;
+		ring->features = p->features;
 		ring->ring_fd = fd;
 	}
 	return ret;


### PR DESCRIPTION
The kernel returns features it supports, but there's no way for users to get it in liburing. I add a field `io_uring::features` to store it.

It breaks ABI. Another option is make `io_uring_queue_init` return the `features` value, which still violates the document and breaks code that assumes `io_uring_queue_init` returns 0 on success.

Signed-off-by: Carter Li <carter.li@eoitek.com>