### PR TITLE
Fix IORING_OP_CONNECT document

### DIFF
--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -341,7 +341,7 @@ system call.
 must be set to the socket file descriptor,
 .I addr
 must contains the pointer to the sockaddr structure, and
-.I len
+.I off
 must contain the socklen_t addrlen field. See also
 .BR connect(2)
 for the general description of the related system call.


### PR DESCRIPTION
The document for `IORING_OP_CONNECT` seems incorrect, addrlen should be stored in `off` instead of `len`.

I noticed that kernel [actually read `addr2`](https://github.com/torvalds/linux/blob/5cf9ad0e6b164a90581a59609dbf5bda3f5a089c/fs/io_uring.c#L2439), and I'm not sure which is better.