### PR TITLE
liburing.map: Fix LIBURING_0.3 shared library version node

### DIFF
--- a/src/liburing.map
+++ b/src/liburing.map
@@ -35,36 +35,7 @@ LIBURING_0.2 {
 } LIBURING_0.1;
 
 LIBURING_0.3 {
-	global:
-		io_uring_queue_init;
-		io_uring_queue_mmap;
-		io_uring_queue_exit;
-		io_uring_peek_cqe;
-		io_uring_wait_cqe;
-		io_uring_submit;
-		io_uring_submit_and_wait;
-		io_uring_get_sqe;
-		io_uring_mmap;
-		io_uring_register_buffers;
-		io_uring_unregister_buffers;
-		io_uring_register_files;
-		io_uring_unregister_files;
-		io_uring_register_eventfd;
-		io_uring_unregister_eventfd;
-
-		io_uring_peek_batch_cqe;
-		io_uring_wait_cqe_timeout;
-		io_uring_wait_cqes;
-
-		__io_uring_get_cqe;
-
-		io_uring_queue_init_params;
-		io_uring_register_files_update;
-	local:
-		__sys_io_uring_setup;
-		__sys_io_uring_enter;
-		__sys_io_uring_register;
-};
+} LIBURING_0.2;
 
 LIBURING_0.4 {
 	global:


### PR DESCRIPTION
This version node is disconnected from LIBURING_0.2, and contains a
merged duplication of the LIBURING_0.1 and LIBURING_0.2 version nodes,
plus few local entries.

Remove its contents and link it to the LIBURING_0.2, as it will inherit
everything there in addition to the catchall local in LIBURING_0.1.

This leaves an empty version node around, and while it is a bit of an
oddity and it might be somewhat safe to remove, it could still break
users. So we leave it behind as a representation of what went on in
that release.