### PR TITLE
man/io_uring_enter.2: correct IORING_OP_STATX

### DIFF
--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -473,7 +473,7 @@ argument,
 should be the
 .I mask
 argument, and
-.I addr
+.I off
 must contain a pointer to the
 .I statxbuf
 to be filled in. See also


### PR DESCRIPTION
Signed-off-by: Carter Li <carter.li@eoitek.com>