### PR TITLE
io_uring_queue_init will hang if the `entries=0`

### DIFF
--- a/src/setup.c
+++ b/src/setup.c
@@ -134,6 +134,9 @@ int io_uring_queue_init_params(unsigned entries, struct io_uring *ring,
 			       struct io_uring_params *p)
 {
 	int fd, ret;
+	
+	if (entries < 1)
+		return -1;
 
 	fd = __sys_io_uring_setup(entries, p);
 	if (fd < 0)


### PR DESCRIPTION
since `io_uring_queue_init` calls `io_uring_queue_init_params` internally, added code in `io_uring_queue_init_params` only.