### PR TITLE
Use __atomic builtins in barrier.h for better architecture support

### DIFF
--- a/src/include/liburing/barrier.h
+++ b/src/include/liburing/barrier.h
@@ -34,19 +34,6 @@ after the acquire operation executes. This is implemented using
 
 #if defined(__x86_64__) || defined(__i386__)
 /* Adapted from arch/x86/include/asm/barrier.h */
-#define io_uring_mb()		asm volatile("mfence" ::: "memory")
-#define io_uring_rmb()		asm volatile("lfence" ::: "memory")
-#define io_uring_wmb()		asm volatile("sfence" ::: "memory")
-#define io_uring_smp_rmb()	io_uring_barrier()
-#define io_uring_smp_wmb()	io_uring_barrier()
-#if defined(__i386__)
-#define io_uring_smp_mb()	asm volatile("lock; addl $0,0(%%esp)" \
-					     ::: "memory", "cc")
-#else
-#define io_uring_smp_mb()	asm volatile("lock; addl $0,-132(%%rsp)" \
-					     ::: "memory", "cc")
-#endif
-
 #define io_uring_smp_store_release(p, v)	\
 do {						\
 	io_uring_barrier();			\
@@ -60,49 +47,14 @@ do {						\
 	___p1;						\
 })
 
-#elif defined(__aarch64__)
-/* Adapted from arch/arm64/include/asm/barrier.h */
-#define io_uring_dmb(opt)	asm volatile("dmb " #opt : : : "memory")
-#define io_uring_dsb(opt)	asm volatile("dsb " #opt : : : "memory")
-
-#define io_uring_mb()		io_uring_dsb(sy)
-#define io_uring_rmb()		io_uring_dsb(ld)
-#define io_uring_wmb()		io_uring_dsb(st)
-#define io_uring_smp_mb()	io_uring_dmb(ish)
-#define io_uring_smp_rmb()	io_uring_dmb(ishld)
-#define io_uring_smp_wmb()	io_uring_dmb(ishst)
-
-#else /* defined(__x86_64__) || defined(__i386__) || defined(__aarch64__) */
+#else /* defined(__x86_64__) || defined(__i386__) */
 /*
- * Add arch appropriate definitions. Be safe and use full barriers for
+ * Add arch appropriate definitions. Use built-in atomic operations for
  * archs we don't have support for.
  */
-#define io_uring_smp_mb()	__sync_synchronize()
-#define io_uring_smp_rmb()	__sync_synchronize()
-#define io_uring_smp_wmb()	__sync_synchronize()
-
 #define io_uring_smp_store_release(p, v) \
 	__atomic_store_n(p, v, __ATOMIC_RELEASE)
 #define io_uring_smp_load_acquire(p) __atomic_load_n(p, __ATOMIC_ACQUIRE)
 #endif /* defined(__x86_64__) || defined(__i386__) */
-
-/* From tools/include/asm/barrier.h */
-
-#ifndef io_uring_smp_store_release
-#define io_uring_smp_store_release(p, v)	\
-do {						\
-	io_uring_smp_mb();			\
-	IO_URING_WRITE_ONCE(*p, v);		\
-} while (0)
-#endif
-
-#ifndef io_uring_smp_load_acquire
-#define io_uring_smp_load_acquire(p)			\
-({							\
-	__typeof(*p) ___p1 = IO_URING_READ_ONCE(*p);	\
-	io_uring_smp_mb();				\
-	___p1;						\
-})
-#endif
 
 #endif /* defined(LIBURING_BARRIER_H) */


### PR DESCRIPTION
`io_uring_smp_store_release()` and `io_uring_smp_load_acquire()` currently issue full sequentially consistent memory barriers (as opposed to release and acquire barriers, respectively) on every architecture except x86(-64) and 64-bit ARM.

These macros can instead be implemented using [GCC's `__atomic` builtins](https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html), which were [introduced in GCC 4.7](https://gcc.gnu.org/gcc-4.7/changes.html). This ensures that the proper, most optimal instructions are used for every architecture that GCC supports.

Given that io_uring first appeared in Linux 5.1, it seems very unlikely that anyone will need to compile liburing with any version of GCC prior to 4.7, which was released in 2012.

I haven't observed any regressions on my machine, although my kernel doesn't have full support for io_uring.