### PR TITLE
Fix warnings when compiling tests on certain architectures

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -5,7 +5,7 @@ INSTALL=install
 
 CFLAGS ?= -g -O2
 XCFLAGS =
-override CFLAGS += -Wall -D_GNU_SOURCE -L../src/ -I../src/include/ -include ../config-host.h
+override CFLAGS += -Wall -D_GNU_SOURCE -L../src/ -I../src/include/ -include ../config-host.h -D__SANE_USERSPACE_TYPES__
 
 all_targets += poll poll-cancel ring-leak fsync io_uring_setup io_uring_register \
 	       io_uring_enter nop sq-full cq-full 35fa71a030ca-test \


### PR DESCRIPTION
On certain architectures, like ppc64, `__u64` is a typedef of `unsigned long` rather than `unsigned long long`, which causes warnings when compiling tests that use the `%llu` printf specifier:

```
link-timeout.c:594:29: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 3 has type ‘__u64’ {aka ‘long unsigned int’} [-Wformat=]
  594 |     fprintf(stderr, "Req %llu got %d\n", cqe->user_data,
      |                          ~~~^            ~~~~~~~~~~~~~~
      |                             |               |
      |                             |               __u64 {aka long unsigned int}
      |                             long long unsigned int
      |                          %lu
```

If `__SANE_USERSPACE_TYPES__` is defined before including \<linux/types.h\>, `__u64` will instead be a typedef of `unsigned long long`; see [arch/powerpc/include/uapi/asm/types.h](https://github.com/torvalds/linux/blob/378fee2e6b12f31ab3749e0aa4ed0a63be23e822/arch/powerpc/include/uapi/asm/types.h).