### PR TITLE
test: Use __NR_mmap2 when __NR_mmap is not defined

### DIFF
--- a/test/35fa71a030ca-test.c
+++ b/test/35fa71a030ca-test.c
@@ -260,8 +260,14 @@ static void loop(void)
 #ifndef __NR_io_uring_setup
 #define __NR_io_uring_setup 425
 #endif
-#ifndef __NR_mmap
-#define __NR_mmap 192
+
+/* We can use the same syscall, because our offset is 0. */
+#if defined(__NR_mmap)
+#define SYSCALL_mmap __NR_mmap
+#elif defined(__NR_mmap2)
+#define SYSCALL_mmap __NR_mmap2
+#else
+#error Missing mmap syscall.
 #endif
 
 uint64_t r[1] = {0xffffffffffffffff};
@@ -320,7 +326,7 @@ static void sig_int(int sig)
 int main(void)
 {
   signal(SIGINT, sig_int);
-  syscall(__NR_mmap, 0x20000000, 0x1000000, 3, 0x32, -1, 0);
+  syscall(SYSCALL_mmap, 0x20000000, 0x1000000, 3, 0x32, -1, 0);
   loop();
   return 0;
 }

--- a/test/917257daa0fe-test.c
+++ b/test/917257daa0fe-test.c
@@ -14,9 +14,18 @@
 #define __NR_io_uring_setup 425
 #endif
 
+/* We can use the same syscall, because our offset is 0. */
+#if defined(__NR_mmap)
+#define SYSCALL_mmap __NR_mmap
+#elif defined(__NR_mmap2)
+#define SYSCALL_mmap __NR_mmap2
+#else
+#error Missing mmap syscall.
+#endif
+
 int main(void)
 {
-  syscall(__NR_mmap, 0x20000000, 0x1000000, 3, 0x32, -1, 0);
+  syscall(SYSCALL_mmap, 0x20000000, 0x1000000, 3, 0x32, -1, 0);
 
   *(uint32_t*)0x20000000 = 0;
   *(uint32_t*)0x20000004 = 0;

--- a/test/a0908ae19763-test.c
+++ b/test/a0908ae19763-test.c
@@ -17,11 +17,20 @@
 #define __NR_io_uring_setup 425
 #endif
 
+/* We can use the same syscall, because our offset is 0. */
+#if defined(__NR_mmap)
+#define SYSCALL_mmap __NR_mmap
+#elif defined(__NR_mmap2)
+#define SYSCALL_mmap __NR_mmap2
+#else
+#error Missing mmap syscall.
+#endif
+
 uint64_t r[1] = {0xffffffffffffffff};
 
 int main(void)
 {
-  syscall(__NR_mmap, 0x20000000, 0x1000000, 3, 0x32, -1, 0);
+  syscall(SYSCALL_mmap, 0x20000000, 0x1000000, 3, 0x32, -1, 0);
   intptr_t res = 0;
   *(uint32_t*)0x20000080 = 0;
   *(uint32_t*)0x20000084 = 0;

--- a/test/a4c0b3decb33-test.c
+++ b/test/a4c0b3decb33-test.c
@@ -170,10 +170,19 @@ static void sig_int(int sig)
 	exit(0);
 }
 
+/* We can use the same syscall, because our offset is 0. */
+#if defined(__NR_mmap)
+#define SYSCALL_mmap __NR_mmap
+#elif defined(__NR_mmap2)
+#define SYSCALL_mmap __NR_mmap2
+#else
+#error Missing mmap syscall.
+#endif
+
 int main(void)
 {
 	signal(SIGINT, sig_int);
-	syscall(__NR_mmap, 0x20000000, 0x1000000, 3, 0x32, -1, 0);
+	syscall(SYSCALL_mmap, 0x20000000, 0x1000000, 3, 0x32, -1, 0);
 	loop();
 	return 0;
 }

--- a/test/b19062a56726-test.c
+++ b/test/b19062a56726-test.c
@@ -14,9 +14,18 @@
 #define __NR_io_uring_setup 425
 #endif
 
+/* We can use the same syscall, because our offset is 0. */
+#if defined(__NR_mmap)
+#define SYSCALL_mmap __NR_mmap
+#elif defined(__NR_mmap2)
+#define SYSCALL_mmap __NR_mmap2
+#else
+#error Missing mmap syscall.
+#endif
+
 int main(void)
 {
-  syscall(__NR_mmap, 0x20000000, 0x1000000, 3, 0x32, -1, 0);
+  syscall(SYSCALL_mmap, 0x20000000, 0x1000000, 3, 0x32, -1, 0);
 
   *(uint32_t*)0x20000200 = 0;
   *(uint32_t*)0x20000204 = 0;

--- a/test/fc2a85cb02ef-test.c
+++ b/test/fc2a85cb02ef-test.c
@@ -82,11 +82,20 @@ static int setup_fault()
 #define __NR_io_uring_setup 425
 #endif
 
+/* We can use the same syscall, because our offset is 0. */
+#if defined(__NR_mmap)
+#define SYSCALL_mmap __NR_mmap
+#elif defined(__NR_mmap2)
+#define SYSCALL_mmap __NR_mmap2
+#else
+#error Missing mmap syscall.
+#endif
+
 uint64_t r[2] = {0xffffffffffffffff, 0xffffffffffffffff};
 
 int main(void)
 {
-  syscall(__NR_mmap, 0x20000000ul, 0x1000000ul, 3ul, 0x32ul, -1, 0);
+  syscall(SYSCALL_mmap, 0x20000000ul, 0x1000000ul, 3ul, 0x32ul, -1, 0);
   if (setup_fault()) {
     printf("Test needs failslab/fail_futex/fail_page_alloc enabled, skipped\n");
     return 0;


### PR DESCRIPTION
This was found on the Debian build daemons <https://buildd.debian.org/status/logs.php?pkg=liburing&ver=0.6-1> once the package got accepted in the archive. Revision 0.6-2 includes this patch and builds now everywhere where it has been built <https://buildd.debian.org/status/package.php?p=liburing>. :)

On some new 32-bit architectures (such as armel and armhf), __NR_mmap
is not defined, but we can safely use __NR_mmap2 as we are passing an
offset of 0, so the different bases for that argument do not apply.

We need to stop defining __NR_mmap in one of the unit tests to be able
to properly fallback to the __NR_mmap2 case.

