### PR TITLE
test/lfs-openat: open dfd with O_PATH

### DIFF
--- a/test/lfs-openat.c
+++ b/test/lfs-openat.c
@@ -78,7 +78,7 @@ static int prepare_file(int dfd, const char* fn)
 int main(int argc, char *argv[])
 {
 	const char *fn = "io_uring_openat_test";
-	int dfd = open("/tmp", O_RDONLY | O_DIRECTORY);
+	int dfd = open("/tmp", O_PATH);
 	struct io_uring ring;
 	int ret;
 


### PR DESCRIPTION
This triggers a bug present until at least Linux 5.6.11, causing
EBADF, see https://lkml.org/lkml/2020/5/7/1287

Signed-off-by: Max Kellermann <mk@cm4all.com>