### PR TITLE
Take `sockaddr` immutably in io_uring_prep_connect

### DIFF
--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -322,7 +322,7 @@ static inline void io_uring_prep_link_timeout(struct io_uring_sqe *sqe,
 }
 
 static inline void io_uring_prep_connect(struct io_uring_sqe *sqe, int fd,
-					 struct sockaddr *addr,
+					 const struct sockaddr *addr,
 					 socklen_t addrlen)
 {
 	io_uring_prep_rw(IORING_OP_CONNECT, sqe, fd, addr, 0, addrlen);


### PR DESCRIPTION
This is the same as the underlying `connect` system call and fixes #151