### PR TITLE
Make readme sensible

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 liburing
 --------
 
-This is the liburing library. liburing provides helpers to setup and
+This is the liburing source. liburing provides helpers to setup and
 teardown io_uring instances, and also a simplified interface for
 applications that don't need (or want) to deal with the full kernel
 side implementation.

--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 liburing
 --------
 
-This is the liburing source. liburing provides helpers to setup and
+This is the io_uring library, liburing. liburing provides helpers to setup and
 teardown io_uring instances, and also a simplified interface for
 applications that don't need (or want) to deal with the full kernel
 side implementation.


### PR DESCRIPTION
`liburing` library seems redundant, can be made readable to:

This is the `io_uring` library or This is the `liburing` source.

This pull proposes the latter.