### PR TITLE
syscall: make syscall.h independently includeable

### DIFF
--- a/src/syscall.c
+++ b/src/syscall.c
@@ -5,7 +5,6 @@
 #include <unistd.h>
 #include <sys/syscall.h>
 #include <sys/uio.h>
-#include <signal.h>
 #include "liburing/compat.h"
 #include "liburing/io_uring.h"
 #include "syscall.h"

--- a/src/syscall.h
+++ b/src/syscall.h
@@ -2,6 +2,10 @@
 #ifndef LIBURING_SYSCALL_H
 #define LIBURING_SYSCALL_H
 
+#include <signal.h>
+
+struct io_uring_params;
+
 /*
  * System calls
  */


### PR DESCRIPTION
To include `syscall.h` independently, `struct  io_uring_params` and `sigset_t` are missing. This PR adds them to compile.