### PR TITLE
probes: provide our own free function

### DIFF
--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -77,6 +77,12 @@ extern struct io_uring_probe *io_uring_get_probe_ring(struct io_uring *ring);
 /* same as io_uring_get_probe_ring, but takes care of ring init and teardown */
 extern struct io_uring_probe *io_uring_get_probe(void);
 
+/*
+ * frees a probe allocated through io_uring_get_probe() or
+ * io_uring_get_probe_ring()
+ */
+extern void io_uring_free_probe(struct io_uring_probe *probe);
+
 static inline int io_uring_opcode_supported(struct io_uring_probe *p, int op)
 {
 	if (op > p->last_op)

--- a/src/liburing.map
+++ b/src/liburing.map
@@ -2,6 +2,7 @@ LIBURING_2.0 {
 	global:
 		io_uring_get_probe;
 		io_uring_get_probe_ring;
+		io_uring_free_probe;
 		io_uring_get_sqe;
 		io_uring_peek_batch_cqe;
 		io_uring_queue_exit;

--- a/src/setup.c
+++ b/src/setup.c
@@ -203,3 +203,8 @@ struct io_uring_probe *io_uring_get_probe(void)
 	io_uring_queue_exit(&ring);
 	return probe;
 }
+
+void io_uring_free_probe(struct io_uring_probe *probe)
+{
+	free(probe);
+}


### PR DESCRIPTION
liburing has a convenience function to get a io_uring_probe that can
be used to test for valid features. The function returns a probe that
the caller has to then deallocate.

That's not a problem if we are dealing with languanges like C and C++
but when trying to uring liburing bindings in languages with a more
well defined barrier into the C interface, calling free() can be at
best cumbersome and at worst just wrong as the language may be using
a different allocator under the hood.

Since we provide an allocated version of probe, provide users with
a way to deallocate it.