### PR TITLE
Add section 3 man pages for init and exit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@ install: $(NAME).pc
 	$(INSTALL) -D -m 644 $(NAME).pc $(DESTDIR)$(libdevdir)/pkgconfig/$(NAME).pc
 	$(INSTALL) -m 755 -d $(DESTDIR)$(mandir)/man2
 	$(INSTALL) -m 644 man/*.2 $(DESTDIR)$(mandir)/man2
+	$(INSTALL) -m 755 -d $(DESTDIR)$(mandir)/man3
+	$(INSTALL) -m 644 man/*.3 $(DESTDIR)$(mandir)/man3
 
 install-tests:
 	@$(MAKE) -C test install prefix=$(DESTDIR)$(prefix) datadir=$(DESTDIR)$(datadir)

--- a/debian/liburing-dev.manpages
+++ b/debian/liburing-dev.manpages
@@ -1,3 +1,5 @@
 man/io_uring_setup.2
 man/io_uring_enter.2
 man/io_uring_register.2
+man/io_uring_queue_exit.3
+man/io_uring_queue_init.3

--- a/liburing.spec
+++ b/liburing.spec
@@ -44,6 +44,7 @@ for the Linux-native io_uring.
 %exclude %{_libdir}/liburing.a
 %{_libdir}/pkgconfig/*
 %{_mandir}/man2/*
+%{_mandir}/man3/*
 
 %changelog
 * Thu Oct 31 2019 Jeff Moyer <jmoyer@redhat.com> - 0.2-1

--- a/man/io_uring_queue_exit.3
+++ b/man/io_uring_queue_exit.3
@@ -1,0 +1,28 @@
+.\" Copyright (C) 2020 Jens Axboe <axboe@kernel.dk>
+.\" Copyright (C) 2020 Red Hat, Inc.
+.\"
+.\" SPDX-License-Identifier: LGPL-2.0-or-later
+.\"
+.\" TODO: Fix the version number/date here
+.TH io_uring_queue_exit 3 "September 11, 2020" "liburing 1.0.0" "liburing Manual"
+.SH NAME
+io_uring_queue_exit - tear down io_uring submission and completion queues
+.SH SYNOPSIS
+.nf
+.BR "#include <liburing.h>"
+.PP
+.BI "int io_uring_queue_exit(struct io_uring *" ring );
+.fi
+.PP
+.SH DESCRIPTION
+.PP
+.BR io_uring_queue_exit (3)
+will release all resources acquired and initialized by
+.BR io_uring_queue_init (3).
+It first unmaps the memory shared between the application and the kernel and then closes the io_uring file descriptor.
+.SH RETURN VALUE
+None
+.SH SEE ALSO
+.BR io_uring_setup (2),
+.BR mmap (2),
+.BR io_uring_queue_init (3)

--- a/man/io_uring_queue_init.3
+++ b/man/io_uring_queue_init.3
@@ -1,0 +1,45 @@
+.\" Copyright (C) 2020 Jens Axboe <axboe@kernel.dk>
+.\" Copyright (C) 2020 Red Hat, Inc.
+.\"
+.\" SPDX-License-Identifier: LGPL-2.0-or-later
+.\"
+.\" TODO: Fix the version number/date here
+.TH io_uring_queue_init 3 "September 11, 2020" "liburing 1.0.0" "liburing Manual"
+.SH NAME
+io_uring_queue_init - setup io_uring submission and completion queues
+.SH SYNOPSIS
+.nf
+.BR "#include <liburing.h>"
+.PP
+.BI "int io_uring_queue_init(unsigned " entries ", struct io_uring *" ring ,
+.BI "                        unsigned " flags );
+.fi
+.PP
+.SH DESCRIPTION
+.PP
+The io_uring_queue_init() function executes the io_uring_setup syscall to
+initialize the submission and completion queues in the kernel with at least
+.I entries
+entries and then maps the resulting file descriptor to memory shared between the
+application and the kernel.
+
+On success io_uring_queue_init() returns 0 and
+.I ring
+will point to the shared memory containing the io_uring queues. On failure
+-errno is returned.
+
+.I flags
+will be passed through to the io_uring_setup syscall (see 
+.BR io_uring_setup (2)).
+
+On success, the resources held by
+.I ring
+should be released via a corresponding call to
+.BR io_uring_queue_exit (3).
+.SH RETURN VALUE
+.BR io_uring_queue_init (3)
+returns 0 on success and -errno on failure.
+.SH SEE ALSO
+.BR io_uring_setup (2),
+.BR mmap (2),
+.BR io_uring_queue_exit (3)


### PR DESCRIPTION
This PR is to add the first two API reference man pages as requested in
https://github.com/axboe/liburing/issues/190

It may take a while to get through all of these so I think it makes more sense
to add them piecemeal.

Note the `TODO` comments. I looked at how another library (libcurl) formats its
title section and they put the release version and release date; however, that
would be a pain to keep updated without proper tooling. Let me know how you
would prefer that to be formatted for liburing.

Also, I'm not familiar with Debian packaging but did my best to update that as
well; it's currently untested as I'll need to figure out how to do that.
