### PR TITLE
Build system fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@
 /test/splice
 /test/sq-full
 /test/sq-full-cpp
+/test/sq-poll-dup
 /test/sq-poll-kthread
 /test/sq-poll-share
 /test/sq-space_left

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,6 +1,8 @@
+CPPFLAGS ?=
+override CPPFLAGS += -D_GNU_SOURCE -I../src/include/
 CFLAGS ?= -g -O2
 XCFLAGS =
-override CFLAGS += -Wall -D_GNU_SOURCE -L../src/ -I../src/include/
+override CFLAGS += -Wall -L../src/
 
 include ../Makefile.quiet
 
@@ -17,7 +19,7 @@ test_srcs := io_uring-test.c io_uring-cp.c link-cp.c
 test_objs := $(patsubst %.c,%.ol,$(test_srcs))
 
 %: %.c
-	$(QUIET_CC)$(CC) $(CFLAGS) -o $@ $< -luring $(XCFLAGS)
+	$(QUIET_CC)$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ $< -luring $(XCFLAGS)
 
 clean:
 	@rm -f $(all_targets) $(test_objs)

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,9 +3,10 @@ includedir ?= $(prefix)/include
 libdir ?= $(prefix)/lib
 libdevdir ?= $(prefix)/lib
 
+CPPFLAGS ?=
+override CPPFLAGS += -Iinclude/ -include ../config-host.h
 CFLAGS ?= -g -fomit-frame-pointer -O2
-override CFLAGS += -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare\
-	-Iinclude/ -include ../config-host.h
+override CFLAGS += -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare
 SO_CFLAGS=-fPIC $(CFLAGS)
 L_CFLAGS=$(CFLAGS)
 LINK_FLAGS=
@@ -38,10 +39,10 @@ liburing_sobjs := $(patsubst %.c,%.os,$(liburing_srcs))
 $(liburing_objs) $(liburing_sobjs): include/liburing/io_uring.h
 
 %.os: %.c
-	$(QUIET_CC)$(CC) $(SO_CFLAGS) -c -o $@ $<
+	$(QUIET_CC)$(CC) $(CPPFLAGS) $(SO_CFLAGS) -c -o $@ $<
 
 %.ol: %.c
-	$(QUIET_CC)$(CC) $(L_CFLAGS) -c -o $@ $<
+	$(QUIET_CC)$(CC) $(CPPFLAGS) $(L_CFLAGS) -c -o $@ $<
 
 AR ?= ar
 RANLIB ?= ranlib

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,12 +3,15 @@ datadir ?= $(prefix)/share
 
 INSTALL=install
 
+CPPFLAGS ?=
+override CPPFLAGS += -D_GNU_SOURCE -D__SANE_USERSPACE_TYPES__ \
+	-I../src/include/ -include ../config-host.h
 CFLAGS ?= -g -O2
 XCFLAGS =
-override CFLAGS += -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare\
-	-D_GNU_SOURCE -D__SANE_USERSPACE_TYPES__ -L../src/ \
-	-I../src/include/ -include ../config-host.h
-CXXFLAGS += $(CFLAGS) -std=c++11
+override CFLAGS += -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare \
+	-L../src/
+CXXFLAGS ?=
+override CXXFLAGS += $(CFLAGS) -std=c++11
 
 test_targets += \
 	232c93d07b74-test \
@@ -122,10 +125,10 @@ all_targets += sq-full-cpp
 all: $(test_targets)
 
 %: %.c
-	$(QUIET_CC)$(CC) $(CFLAGS) -o $@ $< -luring $(XCFLAGS)
+	$(QUIET_CC)$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ $< -luring $(XCFLAGS)
 
 %: %.cc
-	$(QUIET_CXX)$(CXX) $(CXXFLAGS) -o $@ $< -luring $(XCFLAGS)
+	$(QUIET_CXX)$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ $< -luring $(XCFLAGS)
 
 test_srcs := \
 	232c93d07b74-test.c \


### PR DESCRIPTION
Fixes build flags settings, by honoring CPPFLAGS, and matches the CXXFLAGS handling with the other flags. In addition adds a missing ignore into .gitignore.