### PR TITLE
configure: Fix unsafe temporary file creation

### DIFF
--- a/configure
+++ b/configure
@@ -1,13 +1,4 @@
 #!/bin/sh
-#
-# set temporary file name
-if test ! -z "$TMPDIR" ; then
-    TMPDIR1="${TMPDIR}"
-elif test ! -z "$TEMPDIR" ; then
-    TMPDIR1="${TEMPDIR}"
-else
-    TMPDIR1="/tmp"
-fi
 
 cc=${CC:-gcc}
 cxx=${CXX:-g++}
@@ -82,10 +73,10 @@ EOF
 exit 0
 fi
 
-TMPC="${TMPDIR1}/fio-conf-${RANDOM}-$$-${RANDOM}.c"
-TMPC2="${TMPDIR1}/fio-conf-${RANDOM}-$$-${RANDOM}-2.c"
-TMPO="${TMPDIR1}/fio-conf-${RANDOM}-$$-${RANDOM}.o"
-TMPE="${TMPDIR1}/fio-conf-${RANDOM}-$$-${RANDOM}.exe"
+TMPC="$(mktemp --tmpdir fio-conf-XXXXXXXXXX.c)"
+TMPC2="$(mktemp --tmpdir fio-conf-XXXXXXXXXX-2.c)"
+TMPO="$(mktemp --tmpdir fio-conf-XXXXXXXXXX.o)"
+TMPE="$(mktemp --tmpdir fio-conf-XXXXXXXXXX.exe)"
 
 # NB: do not call "exit" in the trap handler; this is buggy with some shells;
 # see <1285349658-3122-1-git-send-email-loic.minier@linaro.org>


### PR DESCRIPTION
The RANDOM variable is a bashism, but we are using a /bin/sh as a
shebang, which means the temporary files created when /bin/sh is not
bash will be using unsafe and predictable names.

Switch to use mktemp(1) and its built-in temporary directory handling
instead of open-coding it.