### PR TITLE
Moves function calls out of assert() to run tests outside debug mode.

### DIFF
--- a/test/accept-reuse.c
+++ b/test/accept-reuse.c
@@ -1,5 +1,4 @@
 /* SPDX-License-Identifier: MIT */
-#include <assert.h>
 #include <liburing.h>
 #include <netdb.h>
 #include <string.h>

--- a/test/accept-test.c
+++ b/test/accept-test.c
@@ -37,8 +37,10 @@ int main(int argc, char *argv[])
 	addr.sun_family = AF_UNIX;
 	memcpy(addr.sun_path, "\0sock", 6);
 
-	assert(bind(fd, (struct sockaddr *)&addr, addrlen) != -1);
-	assert(listen(fd, 128) != -1);
+	ret = bind(fd, (struct sockaddr *)&addr, addrlen);
+	assert(ret != -1);
+	ret = listen(fd, 128);
+	assert(ret != -1);
 
 	sqe = io_uring_get_sqe(&ring);
 	if (!sqe) {

--- a/test/accept.c
+++ b/test/accept.c
@@ -62,9 +62,11 @@ static int accept_conn(struct io_uring *ring, int fd)
 	sqe = io_uring_get_sqe(ring);
 	io_uring_prep_accept(sqe, fd, NULL, NULL, 0);
 
-	assert(io_uring_submit(ring) != -1);
+	ret = io_uring_submit(ring);
+	assert(ret != -1);
 
-	assert(!io_uring_wait_cqe(ring, &cqe));
+	ret = io_uring_wait_cqe(ring, &cqe);
+	assert(!ret);
 	ret = cqe->res;
 	io_uring_cqe_seen(ring, cqe);
 	return ret;
@@ -72,13 +74,15 @@ static int accept_conn(struct io_uring *ring, int fd)
 
 static int start_accept_listen(struct sockaddr_in *addr, int port_off)
 {
-	int fd;
+	int fd, ret;
 
 	fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP);
 
 	int32_t val = 1;
-	assert(setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &val, sizeof(val)) != -1);
-	assert(setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val)) != -1);
+	ret = setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &val, sizeof(val));
+	assert(ret != -1);
+	ret = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
+	assert(ret != -1);
 
 	struct sockaddr_in laddr;
 
@@ -89,8 +93,10 @@ static int start_accept_listen(struct sockaddr_in *addr, int port_off)
 	addr->sin_port = 0x1235 + port_off;
 	addr->sin_addr.s_addr = 0x0100007fU;
 
-	assert(bind(fd, (struct sockaddr*)addr, sizeof(*addr)) != -1);
-	assert(listen(fd, 128) != -1);
+	ret = bind(fd, (struct sockaddr*)addr, sizeof(*addr));
+	assert(ret != -1);
+	ret = listen(fd, 128);
+	assert(ret != -1);
 
 	return fd;
 }
@@ -103,27 +109,32 @@ static int test(struct io_uring *ring, int accept_should_error)
 	uint32_t count = 0;
 	int done = 0;
 	int p_fd[2];
+        int ret;
 
 	int32_t val, recv_s0 = start_accept_listen(&addr, 0);
 
 	p_fd[1] = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP);
 
 	val = 1;
-	assert(setsockopt(p_fd[1], IPPROTO_TCP, TCP_NODELAY, &val, sizeof(val)) != -1);
+	ret = setsockopt(p_fd[1], IPPROTO_TCP, TCP_NODELAY, &val, sizeof(val));
+	assert(ret != -1);
 
 	int32_t flags = fcntl(p_fd[1], F_GETFL, 0);
 	assert(flags != -1);
 
 	flags |= O_NONBLOCK;
-	assert(fcntl(p_fd[1], F_SETFL, flags) != -1);
+	ret = fcntl(p_fd[1], F_SETFL, flags);
+	assert(ret != -1);
 
-	assert(connect(p_fd[1], (struct sockaddr*)&addr, sizeof(addr)) == -1);
+	ret = connect(p_fd[1], (struct sockaddr*)&addr, sizeof(addr));
+	assert(ret == -1);
 
 	flags = fcntl(p_fd[1], F_GETFL, 0);
 	assert(flags != -1);
 
 	flags &= ~O_NONBLOCK;
-	assert(fcntl(p_fd[1], F_SETFL, flags) != -1);
+	ret = fcntl(p_fd[1], F_SETFL, flags);
+	assert(ret != -1);
 
 	p_fd[0] = accept_conn(ring, recv_s0);
 	if (p_fd[0] == -EINVAL) {
@@ -143,7 +154,8 @@ static int test(struct io_uring *ring, int accept_should_error)
 	queue_send(ring, p_fd[1]);
 	queue_recv(ring, p_fd[0]);
 
-	assert(io_uring_submit_and_wait(ring, 2) != -1);
+	ret = io_uring_submit_and_wait(ring, 2);
+	assert(ret != -1);
 
 	while (count < 2) {
 		io_uring_for_each_cqe(ring, head, cqe) {
@@ -184,19 +196,22 @@ static int test_accept_pending_on_exit(void)
 	struct io_uring m_io_uring;
 	struct io_uring_cqe *cqe;
 	struct io_uring_sqe *sqe;
-	int fd;
+	int fd, ret;
 
-	assert(io_uring_queue_init(32, &m_io_uring, 0) >= 0);
+	ret = io_uring_queue_init(32, &m_io_uring, 0);
+	assert(ret >= 0);
 
 	fd = start_accept_listen(NULL, 0);
 
 	sqe = io_uring_get_sqe(&m_io_uring);
 	io_uring_prep_accept(sqe, fd, NULL, NULL, 0);
-	assert(io_uring_submit(&m_io_uring) != -1);
+	ret = io_uring_submit(&m_io_uring);
+	assert(ret != -1);
 
 	signal(SIGALRM, sig_alrm);
 	alarm(1);
-	assert(!io_uring_wait_cqe(&m_io_uring, &cqe));
+	ret = io_uring_wait_cqe(&m_io_uring, &cqe);
+	assert(!ret);
 	io_uring_cqe_seen(&m_io_uring, cqe);
 
 	io_uring_queue_exit(&m_io_uring);
@@ -213,7 +228,7 @@ static int test_accept_many(unsigned nr, unsigned usecs)
 	struct io_uring_sqe *sqe;
 	unsigned long cur_lim;
 	struct rlimit rlim;
-	int *fds, i, ret = 0;
+	int *fds, i, ret;
 
 	if (getrlimit(RLIMIT_NPROC, &rlim) < 0) {
 		perror("getrlimit");
@@ -228,7 +243,8 @@ static int test_accept_many(unsigned nr, unsigned usecs)
 		return 1;
 	}
 
-	assert(io_uring_queue_init(2 * nr, &m_io_uring, 0) >= 0);
+	ret = io_uring_queue_init(2 * nr, &m_io_uring, 0);
+	assert(ret >= 0);
 
 	fds = calloc(nr, sizeof(int));
 
@@ -239,7 +255,8 @@ static int test_accept_many(unsigned nr, unsigned usecs)
 		sqe = io_uring_get_sqe(&m_io_uring);
 		io_uring_prep_accept(sqe, fds[i], NULL, NULL, 0);
 		sqe->user_data = 1 + i;
-		assert(io_uring_submit(&m_io_uring) == 1);
+		ret = io_uring_submit(&m_io_uring);
+		assert(ret == 1);
 	}
 
 	if (usecs)
@@ -263,7 +280,7 @@ out:
 
 	free(fds);
 	io_uring_queue_exit(&m_io_uring);
-	return ret;
+	return 0;
 err:
 	ret = 1;
 	goto out;
@@ -274,16 +291,18 @@ static int test_accept_cancel(unsigned usecs)
 	struct io_uring m_io_uring;
 	struct io_uring_cqe *cqe;
 	struct io_uring_sqe *sqe;
-	int fd, i;
+	int fd, i, ret;
 
-	assert(io_uring_queue_init(32, &m_io_uring, 0) >= 0);
+	ret = io_uring_queue_init(32, &m_io_uring, 0);
+	assert(ret >= 0);
 
 	fd = start_accept_listen(NULL, 0);
 
 	sqe = io_uring_get_sqe(&m_io_uring);
 	io_uring_prep_accept(sqe, fd, NULL, NULL, 0);
 	sqe->user_data = 1;
-	assert(io_uring_submit(&m_io_uring) == 1);
+        ret = io_uring_submit(&m_io_uring);
+	assert(ret == 1);
 
 	if (usecs)
 		usleep(usecs);
@@ -291,10 +310,12 @@ static int test_accept_cancel(unsigned usecs)
 	sqe = io_uring_get_sqe(&m_io_uring);
 	io_uring_prep_cancel(sqe, (void *) 1, 0);
 	sqe->user_data = 2;
-	assert(io_uring_submit(&m_io_uring) == 1);
+	ret = io_uring_submit(&m_io_uring);
+	assert(ret == 1);
 
 	for (i = 0; i < 2; i++) {
-		assert(!io_uring_wait_cqe(&m_io_uring, &cqe));
+		ret = io_uring_wait_cqe(&m_io_uring, &cqe);
+		assert(!ret);
 		/*
 		 * Two cases here:
 		 *
@@ -331,7 +352,8 @@ static int test_accept(void)
 	struct io_uring m_io_uring;
 	int ret;
 
-	assert(io_uring_queue_init(32, &m_io_uring, 0) >= 0);
+	ret = io_uring_queue_init(32, &m_io_uring, 0);
+	assert(ret >= 0);
 	ret = test(&m_io_uring, 0);
 	io_uring_queue_exit(&m_io_uring);
 	return ret;

--- a/test/fixed-link.c
+++ b/test/fixed-link.c
@@ -4,7 +4,6 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 #include <fcntl.h>
 #include <sys/types.h>
 

--- a/test/poll-link.c
+++ b/test/poll-link.c
@@ -73,16 +73,19 @@ void *recv_thread(void *arg)
 	struct data *data = arg;
 	struct io_uring_sqe *sqe;
 	struct io_uring ring;
-	int i;
+	int i, ret;
 
-	assert(io_uring_queue_init(8, &ring, 0) == 0);
+	ret = io_uring_queue_init(8, &ring, 0);
+	assert(ret == 0);
 
 	int s0 = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 	assert(s0 != -1);
 
 	int32_t val = 1;
-        assert(setsockopt(s0, SOL_SOCKET, SO_REUSEPORT, &val, sizeof(val)) != -1);
-        assert(setsockopt(s0, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val)) != -1);
+	ret = setsockopt(s0, SOL_SOCKET, SO_REUSEPORT, &val, sizeof(val));
+	assert(ret != -1);
+	ret = setsockopt(s0, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
+	assert(ret != -1);
 
 	struct sockaddr_in addr;
 
@@ -105,7 +108,8 @@ void *recv_thread(void *arg)
 		goto out;
 	}
 
-        assert(listen(s0, 128) != -1);
+	ret = listen(s0, 128);
+	assert(ret != -1);
 
 	signal_var(&recv_thread_ready);
 
@@ -125,7 +129,8 @@ void *recv_thread(void *arg)
 	io_uring_prep_link_timeout(sqe, &ts, 0);
 	sqe->user_data = 2;
 
-	assert(io_uring_submit(&ring) == 2);
+	ret = io_uring_submit(&ring);
+	assert(ret == 2);
 
 	for (i = 0; i < 2; i++) {
 		struct io_uring_cqe *cqe;

--- a/test/socket-rw.c
+++ b/test/socket-rw.c
@@ -22,7 +22,7 @@
 
 int main(int argc, char *argv[])
 {
-	int p_fd[2];
+	int p_fd[2], ret;
 	int32_t recv_s0;
 	int32_t val = 1;
 	struct sockaddr_in addr;
@@ -32,35 +32,43 @@ int main(int argc, char *argv[])
 
 	recv_s0 = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP);
 
-	assert(setsockopt(recv_s0, SOL_SOCKET, SO_REUSEPORT, &val, sizeof(val)) != -1);
-	assert(setsockopt(recv_s0, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val)) != -1);
+	ret = setsockopt(recv_s0, SOL_SOCKET, SO_REUSEPORT, &val, sizeof(val));
+	assert(ret != -1);
+	ret = setsockopt(recv_s0, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
+	assert(ret != -1);
 
 	addr.sin_family = AF_INET;
 	addr.sin_port = 0x1235;
 	addr.sin_addr.s_addr = 0x0100007fU;
 
-	assert(bind(recv_s0, (struct sockaddr*)&addr, sizeof(addr)) != -1);
-	assert(listen(recv_s0, 128) != -1);
+	ret = bind(recv_s0, (struct sockaddr*)&addr, sizeof(addr));
+	assert(ret != -1);
+	ret = listen(recv_s0, 128);
+	assert(ret != -1);
 
 
 	p_fd[1] = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP);
 
 	val = 1;
-	assert(setsockopt(p_fd[1], IPPROTO_TCP, TCP_NODELAY, &val, sizeof(val)) != -1);
+	ret = setsockopt(p_fd[1], IPPROTO_TCP, TCP_NODELAY, &val, sizeof(val));
+	assert(ret != -1);
 
 	int32_t flags = fcntl(p_fd[1], F_GETFL, 0);
 	assert(flags != -1);
 
 	flags |= O_NONBLOCK;
-	assert(fcntl(p_fd[1], F_SETFL, flags) != -1);
+	ret = fcntl(p_fd[1], F_SETFL, flags);
+	assert(ret != -1);
 
-	assert(connect(p_fd[1], (struct sockaddr*)&addr, sizeof(addr)) == -1);
+	ret = connect(p_fd[1], (struct sockaddr*)&addr, sizeof(addr));
+	assert(ret == -1);
 
 	flags = fcntl(p_fd[1], F_GETFL, 0);
 	assert(flags != -1);
 
 	flags &= ~O_NONBLOCK;
-	assert(fcntl(p_fd[1], F_SETFL, flags) != -1);
+	ret = fcntl(p_fd[1], F_SETFL, flags);
+	assert(ret != -1);
 
 	p_fd[0] = accept(recv_s0, NULL, NULL);
 	assert(p_fd[0] != -1);
@@ -69,7 +77,8 @@ int main(int argc, char *argv[])
 		int32_t code;
 		socklen_t code_len = sizeof(code);
 
-		assert(getsockopt(p_fd[1], SOL_SOCKET, SO_ERROR, &code, &code_len) != -1);
+		ret = getsockopt(p_fd[1], SOL_SOCKET, SO_ERROR, &code, &code_len);
+		assert(ret != -1);
 
 		if (!code)
 			break;
@@ -77,7 +86,8 @@ int main(int argc, char *argv[])
 
 	struct io_uring m_io_uring;
 
-	assert(io_uring_queue_init(32, &m_io_uring, 0) >= 0);
+	ret = io_uring_queue_init(32, &m_io_uring, 0);
+	assert(ret >= 0);
 
 	char recv_buff[128];
 	char send_buff[128];
@@ -106,7 +116,8 @@ int main(int argc, char *argv[])
 		io_uring_prep_writev(sqe, p_fd[1], iov, 1, 0);
 	}
 
-	assert(io_uring_submit_and_wait(&m_io_uring, 2) != -1);
+	ret = io_uring_submit_and_wait(&m_io_uring, 2);
+	assert(ret != -1);
 
 	struct io_uring_cqe* cqe;
 	uint32_t head;


### PR DESCRIPTION
assert() is redefined as check() in liburing.h to ensure that it
will run if NDEBUG is defined. Without this, certain tests will
fail due to functions being called within an assert(), which are
skipped if NDEBUG is defined.
    
check() is a macro that will use assert() if NDEBUG is not defined.
Otherwise, it uses its own implementation.