### PR TITLE
test: Fix build on 32bit architectures with 6bit time_t

### DIFF
--- a/test/35fa71a030ca-test.c
+++ b/test/35fa71a030ca-test.c
@@ -24,6 +24,10 @@
 
 #include <linux/futex.h>
 
+#if !defined(SYS_futex) && defined(SYS_futex_time64)
+# define SYS_futex SYS_futex_time64
+#endif
+
 static void sleep_ms(uint64_t ms)
 {
   usleep(ms * 1000);


### PR DESCRIPTION
It uses SYS_futex, which it expects from system C library.
in glibc (/usr/include/bits/syscall.h defines it in terms of of NR_futex)
rv32 is using 64bit time_t from get go unlike other 32bit architectures
in glibc, therefore it wont have NR_futex defined but just NR_futex_time64
this aliases it to NR_futex so that SYS_futex is then defined for rv32

Signed-off-by: Khem Raj <raj.khem@gmail.com>