### PR TITLE
Changes format string from %lld to %PRIu64 in several tests.

### DIFF
--- a/test/accept-link.c
+++ b/test/accept-link.c
@@ -156,8 +156,8 @@ void *recv_thread(void *arg)
 				data->stop = 1;
 				goto out;
 			}
-			fprintf(stderr, "cqe %llu got %d, wanted %d\n",
-					cqe->user_data, cqe->res,
+			fprintf(stderr, "cqe %" PRIu64 " got %d, wanted %d\n",
+					(uint64_t) cqe->user_data, cqe->res,
 					data->expected[idx]);
 			goto err;
 		}

--- a/test/cq-peek-batch.c
+++ b/test/cq-peek-batch.c
@@ -74,7 +74,8 @@ int main(int argc, char *argv[])
 	CHECK_BATCH(&ring, got, cqes, 4, 4);
 	for (i=0;i<4;i++) {
 		if (i != cqes[i]->user_data) {
-			printf("Got user_data %lld, expected %d\n", cqes[i]->user_data, i);
+			printf("Got user_data %" PRIu64 ", expected %d\n",
+				(uint64_t) cqes[i]->user_data, i);
 			goto err;
 		}
 	}
@@ -86,7 +87,8 @@ int main(int argc, char *argv[])
 	CHECK_BATCH(&ring, got, cqes, 4, 4);
 	for (i=0;i<4;i++) {
 		if (i + 4 != cqes[i]->user_data) {
-			printf("Got user_data %lld, expected %d\n", cqes[i]->user_data, i + 4);
+			printf("Got user_data %" PRIu64 ", expected %d\n",
+				(uint64_t) cqes[i]->user_data, i + 4);
 			goto err;
 		}
 	}

--- a/test/fallocate.c
+++ b/test/fallocate.c
@@ -191,8 +191,8 @@ static int test_fallocate_fsync(struct io_uring *ring)
 			goto err;
 		}
 		if (cqe->res) {
-			fprintf(stderr, "cqe->res=%d,data=%llu\n", cqe->res,
-							cqe->user_data);
+			fprintf(stderr, "cqe->res=%d,data=%" PRIu64 "\n", cqe->res,
+							(uint64_t) cqe->user_data);
 			goto err;
 		}
 		io_uring_cqe_seen(ring, cqe);

--- a/test/link-timeout.c
+++ b/test/link-timeout.c
@@ -592,7 +592,7 @@ static int test_timeout_link_chain1(struct io_uring *ring)
 		switch (cqe->user_data) {
 		case 1:
 			if (cqe->res != -EINTR && cqe->res != -ECANCELED) {
-				fprintf(stderr, "Req %llu got %d\n", cqe->user_data,
+				fprintf(stderr, "Req %" PRIu64 " got %d\n", (uint64_t) cqe->user_data,
 						cqe->res);
 				goto err;
 			}
@@ -600,14 +600,14 @@ static int test_timeout_link_chain1(struct io_uring *ring)
 		case 2:
 			/* FASTPOLL kernels can cancel successfully */
 			if (cqe->res != -EALREADY && cqe->res != -ETIME) {
-				fprintf(stderr, "Req %llu got %d\n", cqe->user_data,
+				fprintf(stderr, "Req %" PRIu64 " got %d\n", (uint64_t) cqe->user_data,
 						cqe->res);
 				goto err;
 			}
 			break;
 		case 3:
 			if (cqe->res != -ECANCELED) {
-				fprintf(stderr, "Req %llu got %d\n", cqe->user_data,
+				fprintf(stderr, "Req %" PRIu64 " got %d\n", (uint64_t) cqe->user_data,
 						cqe->res);
 				goto err;
 			}
@@ -687,14 +687,14 @@ static int test_timeout_link_chain2(struct io_uring *ring)
 		/* poll cancel really should return -ECANCEL... */
 		case 1:
 			if (cqe->res != -ECANCELED) {
-				fprintf(stderr, "Req %llu got %d\n", cqe->user_data,
+				fprintf(stderr, "Req %" PRIu64 " got %d\n", (uint64_t) cqe->user_data,
 						cqe->res);
 				goto err;
 			}
 			break;
 		case 2:
 			if (cqe->res != -ETIME) {
-				fprintf(stderr, "Req %llu got %d\n", cqe->user_data,
+				fprintf(stderr, "Req %" PRIu64 " got %d\n", (uint64_t) cqe->user_data,
 						cqe->res);
 				goto err;
 			}
@@ -702,7 +702,7 @@ static int test_timeout_link_chain2(struct io_uring *ring)
 		case 3:
 		case 4:
 			if (cqe->res != -ECANCELED) {
-				fprintf(stderr, "Req %llu got %d\n", cqe->user_data,
+				fprintf(stderr, "Req %" PRIu64 " got %d\n", (uint64_t) cqe->user_data,
 						cqe->res);
 				goto err;
 			}
@@ -805,7 +805,7 @@ static int test_timeout_link_chain3(struct io_uring *ring)
 		switch (cqe->user_data) {
 		case 2:
 			if (cqe->res != -ETIME) {
-				fprintf(stderr, "Req %llu got %d\n", cqe->user_data,
+				fprintf(stderr, "Req %" PRIu64 " got %d\n", (uint64_t) cqe->user_data,
 						cqe->res);
 				goto err;
 			}
@@ -815,14 +815,14 @@ static int test_timeout_link_chain3(struct io_uring *ring)
 		case 4:
 		case 5:
 			if (cqe->res != -ECANCELED) {
-				fprintf(stderr, "Req %llu got %d\n", cqe->user_data,
+				fprintf(stderr, "Req %" PRIu64 " got %d\n", (uint64_t) cqe->user_data,
 						cqe->res);
 				goto err;
 			}
 			break;
 		case 6:
 			if (cqe->res) {
-				fprintf(stderr, "Req %llu got %d\n", cqe->user_data,
+				fprintf(stderr, "Req %" PRIu64 " got %d\n", (uint64_t) cqe->user_data,
 						cqe->res);
 				goto err;
 			}
@@ -892,21 +892,21 @@ static int test_timeout_link_chain4(struct io_uring *ring)
 		/* poll cancel really should return -ECANCEL... */
 		case 1:
 			if (cqe->res) {
-				fprintf(stderr, "Req %llu got %d\n", cqe->user_data,
+				fprintf(stderr, "Req %" PRIu64 " got %d\n", (uint64_t) cqe->user_data,
 						cqe->res);
 				goto err;
 			}
 			break;
 		case 2:
 			if (cqe->res != -ECANCELED) {
-				fprintf(stderr, "Req %llu got %d\n", cqe->user_data,
+				fprintf(stderr, "Req %" PRIu64 " got %d\n", (uint64_t) cqe->user_data,
 						cqe->res);
 				goto err;
 			}
 			break;
 		case 3:
 			if (cqe->res != -ETIME) {
-				fprintf(stderr, "Req %llu got %d\n", cqe->user_data,
+				fprintf(stderr, "Req %" PRIu64 " got %d\n", (uint64_t) cqe->user_data,
 						cqe->res);
 				goto err;
 			}

--- a/test/poll-link.c
+++ b/test/poll-link.c
@@ -142,13 +142,13 @@ void *recv_thread(void *arg)
 		}
 		idx = cqe->user_data - 1;
 		if (data->is_mask[idx] && !(data->expected[idx] & cqe->res)) {
-			fprintf(stderr, "cqe %llu got %x, wanted mask %x\n",
-					cqe->user_data, cqe->res,
+			fprintf(stderr, "cqe %" PRIu64 " got %x, wanted mask %x\n",
+					(uint64_t) cqe->user_data, cqe->res,
 					data->expected[idx]);
 			goto err;
 		} else if (!data->is_mask[idx] && cqe->res != data->expected[idx]) {
-			fprintf(stderr, "cqe %llu got %d, wanted %d\n",
-					cqe->user_data, cqe->res,
+			fprintf(stderr, "cqe %" PRIu64 " got %d, wanted %d\n",
+					(uint64_t) cqe->user_data, cqe->res,
 					data->expected[idx]);
 			goto err;
 		}

--- a/test/register-restrictions.c
+++ b/test/register-restrictions.c
@@ -406,8 +406,8 @@ static int test_restrictions_flags(void)
 		case 2: /* writev - flags = IOSQE_FIXED_FILE | IOSQE_ASYNC */
 		case 3: /* writev - flags = IOSQE_FIXED_FILE | IOSQE_IO_LINK */
 			if (cqe->res != sizeof(ptr)) {
-				fprintf(stderr, "write res: %d user_data %lld \n",
-					cqe->res, cqe->user_data);
+				fprintf(stderr, "write res: %d user_data %" PRIu64 "\n",
+					cqe->res, (uint64_t) cqe->user_data);
 				return TEST_FAILED;
 			}
 
@@ -417,8 +417,8 @@ static int test_restrictions_flags(void)
 		case 6: /* writev - flags = IOSQE_ASYNC */
 		case 7: /* writev - flags = 0 */
 			if (cqe->res != -EACCES) {
-				fprintf(stderr, "write res: %d user_data %lld \n",
-					cqe->res, cqe->user_data);
+				fprintf(stderr, "write res: %d user_data %" PRIu64 "\n",
+					cqe->res, (uint64_t) cqe->user_data);
 				return TEST_FAILED;
 			}
 			break;


### PR DESCRIPTION
6 liburing tests failed to build on powerpc due to a 'long' versus
'long long' mismatch. Changing the identifer from %lld to %PRIu64
and casting the value to uint64_t fixes this.