### PR TITLE
Add __builtin_expect(cond, 0) to NEED_WAKEUP for SQPOLL.

### DIFF
--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -15,6 +15,14 @@
 #include "liburing/io_uring.h"
 #include "liburing/barrier.h"
 
+#ifndef uring_unlikely
+#  define uring_unlikely(cond)      __builtin_expect(!!(cond), 0)
+#endif
+
+#ifndef uring_likely
+#  define uring_likely(cond)        __builtin_expect(!!(cond), 1)
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/queue.c
+++ b/src/queue.c
@@ -25,10 +25,11 @@ static inline bool sq_ring_needs_enter(struct io_uring *ring, unsigned *flags)
 {
 	if (!(ring->flags & IORING_SETUP_SQPOLL))
 		return true;
-	if (IO_URING_READ_ONCE(*ring->sq.kflags) & IORING_SQ_NEED_WAKEUP) {
-		*flags |= IORING_ENTER_SQ_WAKEUP;
-		return true;
-	}
+    if (uring_unlikely(IO_URING_READ_ONCE(*ring->sq.kflags) &
+                       IORING_SQ_NEED_WAKEUP)) {
+        *flags |= IORING_ENTER_SQ_WAKEUP;
+        return true;
+    }
 
 	return false;
 }


### PR DESCRIPTION
If heavy IO load then kernel thread will only very rarely need to be woken up. Only case where this condition is common is if timeout expected between IO calls in which case should be using GETEVENTS.

Have seen this condition get optimized for (compiler puts it as the fall through case).

Possible worth considering wrapping some of the error checking with this?