### PR TITLE
Fix IORING_OP_FALLOCATE args in io_uring_enter(2) man page

### DIFF
--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -453,9 +453,11 @@ Issue the equivalent of a
 system call.
 .I fd
 must be set to the file descriptor,
+.I len
+must contain the mode associated with the operation,
 .I off
 must contain the offset on which to operate, and
-.I len
+.I addr
 must contain the length. See also
 .BR fallocate(2)
 for the general description of the related system call. Available since 5.6.


### PR DESCRIPTION
`addr` must in fact contain the length.
`len` is used for the fallocate mode.

See: https://patchwork.kernel.org/project/linux-fsdevel/patch/20191213183632.19441-2-axboe@kernel.dk/

Signed-off-by: Joran Dirk Greef <joran@coil.com>