### PR TITLE
Adding support for skipping files in kernel patch. This will add tests / documentation for said patch.

### DIFF
--- a/man/io_uring_register.2
+++ b/man/io_uring_register.2
@@ -144,6 +144,7 @@ This operation replaces existing files in the registered file set with new
 ones, either turning a sparse entry (one where fd is equal to -1) into a
 real one, removing an existing entry (new one is set to -1), or replacing
 an existing entry with a new existing entry.
+
 .I arg
 must contain a pointer to a struct io_uring_files_update, which contains
 an offset on which to start the update, and an array of file descriptors to
@@ -151,6 +152,12 @@ use for the update.
 .I nr_args
 must contain the number of descriptors in the passed in array. Available
 since 5.5.
+
+File descriptors can be skipped if they are set to
+.B IORING_REGISTER_FILES_SKIP.
+Skipping an fd will not touch the file assosiated with the previous
+fd at that index. Available since 5.12.
+
 
 .TP
 .B IORING_UNREGISTER_FILES


### PR DESCRIPTION
This is to add testing / documentation for patch: ```0001-io_uring-Add-skip-option-for-__io_sqe_files_update.patch``` if it is applied.

Should not be accepted unless the patch is as well.