### PR TITLE
setup: check whether malloc succ before using it

### DIFF
--- a/src/setup.c
+++ b/src/setup.c
@@ -185,7 +185,10 @@ struct io_uring_probe *io_uring_get_probe_ring(struct io_uring *ring)
 
 	size_t len = sizeof(*probe) + 256 * sizeof(struct io_uring_probe_op);
 	probe = malloc(len);
+	if (!probe)
+		return NULL;
 	memset(probe, 0, len);
+
 	r = io_uring_register_probe(ring, probe, 256);
 	if (r < 0)
 		goto fail;


### PR DESCRIPTION
In io_uring_get_probe_ring func, we will call malloc()
to alloc memory for probe. Considering malloc may return NULL,
we should check whether malloc() succ before using it.

Signed-off-by: Zhiqiang Liu <liuzhiqiang26@huawei.com>