### PR TITLE
tests: call assert() when allocating memory fails

### DIFF
--- a/test/accept.c
+++ b/test/accept.c
@@ -7,7 +7,6 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <assert.h>
-
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -33,6 +32,7 @@ static void queue_send(struct io_uring *ring, int fd)
 	struct data *d;
 
 	d = malloc(sizeof(*d));
+	assert(d);
 	d->iov.iov_base = d->buf;
 	d->iov.iov_len = sizeof(d->buf);
 
@@ -46,6 +46,7 @@ static void queue_recv(struct io_uring *ring, int fd)
 	struct data *d;
 
 	d = malloc(sizeof(*d));
+	assert(d);
 	d->iov.iov_base = d->buf;
 	d->iov.iov_len = sizeof(d->buf);
 

--- a/test/cq-overflow.c
+++ b/test/cq-overflow.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <assert.h>
 
 #include "liburing.h"
 
@@ -18,18 +19,17 @@
 
 static struct iovec *vecs;
 
-static int create_buffers(void)
+static void create_buffers(void)
 {
 	int i;
 
 	vecs = malloc(BUFFERS * sizeof(struct iovec));
+	assert(vecs);
 	for (i = 0; i < BUFFERS; i++) {
 		if (posix_memalign(&vecs[i].iov_base, BS, BS))
-			return 1;
+			assert(0);
 		vecs[i].iov_len = BS;
 	}
-
-	return 0;
 }
 
 static int create_file(const char *file)
@@ -39,6 +39,7 @@ static int create_file(const char *file)
 	int fd;
 
 	buf = malloc(FILE_SIZE);
+	assert(buf);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);
@@ -496,10 +497,8 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "file creation failed\n");
 		goto err;
 	}
-	if (create_buffers()) {
-		fprintf(stderr, "file creation failed\n");
-		goto err;
-	}
+
+	create_buffers();
 
 	iters = 0;
 	usecs = 1000;

--- a/test/d4ae271dfaae-test.c
+++ b/test/d4ae271dfaae-test.c
@@ -10,6 +10,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <string.h>
+#include <assert.h>
 
 #include "liburing.h"
 
@@ -22,6 +23,7 @@ static int create_file(const char *file)
 	int fd;
 
 	buf = malloc(FILE_SIZE);
+	assert(buf);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);

--- a/test/eeed8b54e0df-test.c
+++ b/test/eeed8b54e0df-test.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <assert.h>
 
 #include "liburing.h"
 
@@ -31,6 +32,7 @@ static int get_file_fd(void)
 	}
 
 	buf = malloc(BLOCK);
+	assert(buf);
 	ret = write(fd, buf, BLOCK);
 	if (ret != BLOCK) {
 		if (ret < 0)
@@ -71,6 +73,7 @@ int main(int argc, char *argv[])
 		return 0;
 
 	iov.iov_base = malloc(4096);
+	assert(iov.iov_base);
 	iov.iov_len = 4096;
 
 	ret = io_uring_queue_init(2, &ring, 0);

--- a/test/fadvise.c
+++ b/test/fadvise.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <assert.h>
 #include <sys/types.h>
 #include <sys/time.h>
 
@@ -48,6 +49,7 @@ static int create_file(const char *file)
 	int fd;
 
 	buf = malloc(FILE_SIZE);
+	assert(buf);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);
@@ -139,6 +141,7 @@ static int test_fadvise(struct io_uring *ring, const char *filename)
 	}
 
 	buf = malloc(FILE_SIZE);
+	assert(buf);
 
 	cached_read = do_read(fd, buf);
 	if (cached_read == -1)

--- a/test/file-register.c
+++ b/test/file-register.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <assert.h>
 
 #include "liburing.h"
 
@@ -157,6 +158,7 @@ static int test_replace_all(struct io_uring *ring)
 	}
 
 	fds = malloc(100 * sizeof(int));
+	assert(fds);
 	for (i = 0; i < 100; i++)
 		fds[i] = -1;
 
@@ -424,10 +426,12 @@ static int test_fixed_read_write(struct io_uring *ring, int index)
 	int ret;
 
 	iov[0].iov_base = malloc(4096);
+	assert(iov[0].iov_base);
 	iov[0].iov_len = 4096;
 	memset(iov[0].iov_base, 0x5a, 4096);
 
 	iov[1].iov_base = malloc(4096);
+	assert(iov[1].iov_base);
 	iov[1].iov_len = 4096;
 
 	sqe = io_uring_get_sqe(ring);
@@ -603,6 +607,7 @@ static int test_sparse_updates(void)
 	}
 
 	fds = malloc(256 * sizeof(int));
+	assert(fds);
 	for (i = 0; i < 256; i++)
 		fds[i] = -1;
 

--- a/test/file-update.c
+++ b/test/file-update.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <assert.h>
 
 #include "liburing.h"
 
@@ -108,6 +109,7 @@ static int test_sqe_update(struct io_uring *ring)
 	int *fds, i, ret;
 
 	fds = malloc(sizeof(int) * 10);
+	assert(fds);
 	for (i = 0; i < 10; i++)
 		fds[i] = -1;
 

--- a/test/fixed-link.c
+++ b/test/fixed-link.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <assert.h>
 #include <sys/types.h>
 
 #include "liburing.h"
@@ -34,6 +35,7 @@ int main(int argc, char *argv[])
 
 	for (i = 0; i < IOVECS_LEN; ++i) {
 		iovecs[i].iov_base = malloc(64);
+		assert(iovecs[i].iov_base);
 		iovecs[i].iov_len = 64;
 	};
 

--- a/test/fsync.c
+++ b/test/fsync.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <assert.h>
 
 #include "liburing.h"
 
@@ -70,6 +71,7 @@ static int test_barrier_fsync(struct io_uring *ring)
 
 	for (i = 0; i < 4; i++) {
 		iovecs[i].iov_base = malloc(4096);
+		assert(iovecs[i].iov_base);
 		iovecs[i].iov_len = 4096;
 	}
 
@@ -144,6 +146,7 @@ static int create_file(const char *file)
 	int fd;
 
 	buf = malloc(FILE_SIZE);
+	assert(buf);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);

--- a/test/io-cancel.c
+++ b/test/io-cancel.c
@@ -10,6 +10,7 @@
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/time.h>
+#include <assert.h>
 
 #include "liburing.h"
 
@@ -19,18 +20,17 @@
 
 static struct iovec *vecs;
 
-static int create_buffers(void)
+static void create_buffers(void)
 {
 	int i;
 
 	vecs = malloc(BUFFERS * sizeof(struct iovec));
+	assert(vecs);
 	for (i = 0; i < BUFFERS; i++) {
 		if (posix_memalign(&vecs[i].iov_base, BS, BS))
-			return 1;
+			assert(0);
 		vecs[i].iov_len = BS;
 	}
-
-	return 0;
 }
 
 static int create_file(const char *file)
@@ -40,6 +40,7 @@ static int create_file(const char *file)
 	int fd;
 
 	buf = malloc(FILE_SIZE);
+	assert(buf);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);
@@ -239,10 +240,8 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "file creation failed\n");
 		goto err;
 	}
-	if (create_buffers()) {
-		fprintf(stderr, "file creation failed\n");
-		goto err;
-	}
+
+	create_buffers();
 
 	for (i = 0; i < 4; i++) {
 		int v1 = (i & 1) != 0;

--- a/test/iopoll.c
+++ b/test/iopoll.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <assert.h>
 #include <sys/types.h>
 #include <sys/poll.h>
 #include <sys/eventfd.h>
@@ -28,6 +29,7 @@ static int create_buffers(void)
 	int i;
 
 	vecs = malloc(BUFFERS * sizeof(struct iovec));
+	assert(vecs);
 	for (i = 0; i < BUFFERS; i++) {
 		if (posix_memalign(&vecs[i].iov_base, BS, BS))
 			return 1;
@@ -44,6 +46,7 @@ static int create_file(const char *file)
 	int fd;
 
 	buf = malloc(FILE_SIZE);
+	assert(buf);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);

--- a/test/link_drain.c
+++ b/test/link_drain.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <assert.h>
 
 #include "liburing.h"
 
@@ -29,6 +30,7 @@ static int test_link_drain_one(struct io_uring *ring)
 	}
 
 	iovecs.iov_base = malloc(4096);
+	assert(iovecs.iov_base);
 	iovecs.iov_len = 4096;
 
 	for (i = 0; i < 5; i++) {
@@ -112,6 +114,7 @@ int test_link_drain_multi(struct io_uring *ring)
 	}
 
 	iovecs.iov_base = malloc(4096);
+	assert(iovecs.iov_base);
 	iovecs.iov_len = 4096;
 
 	for (i = 0; i < 9; i++) {

--- a/test/madvise.c
+++ b/test/madvise.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <assert.h>
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/mman.h>
@@ -50,6 +51,7 @@ static int create_file(const char *file)
 	int fd;
 
 	buf = malloc(FILE_SIZE);
+	assert(buf);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);
@@ -124,6 +126,7 @@ static int test_madvise(struct io_uring *ring, const char *filename)
 	}
 
 	buf = malloc(FILE_SIZE);
+	assert(buf);
 
 	ptr = mmap(NULL, FILE_SIZE, PROT_READ, MAP_PRIVATE, fd, 0);
 	if (ptr == MAP_FAILED) {

--- a/test/open-close.c
+++ b/test/open-close.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <assert.h>
 
 #include "liburing.h"
 
@@ -19,6 +20,7 @@ static int create_file(const char *file, size_t size)
 	int fd;
 
 	buf = malloc(size);
+	assert(buf);
 	memset(buf, 0xaa, size);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);

--- a/test/openat2.c
+++ b/test/openat2.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <assert.h>
 
 #include "liburing.h"
 
@@ -19,6 +20,7 @@ static int create_file(const char *file, size_t size)
 	int fd;
 
 	buf = malloc(size);
+	assert(buf);
 	memset(buf, 0xaa, size);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);

--- a/test/short-read.c
+++ b/test/short-read.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <assert.h>
 #include <sys/types.h>
 #include <sys/poll.h>
 
@@ -20,6 +21,7 @@ static int create_file(const char *file)
 	int fd;
 
 	buf = malloc(FILE_SIZE);
+	assert(buf);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);
@@ -44,6 +46,7 @@ int main(int argc, char *argv[])
 		return 0;
 
 	vec.iov_base = malloc(BUF_SIZE);
+	assert(vec.iov_base);
 	vec.iov_len = BUF_SIZE;
 
 	if (create_file(".short-read")) {

--- a/test/sq-poll-dup.c
+++ b/test/sq-poll-dup.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <assert.h>
 #include <sys/types.h>
 #include <sys/poll.h>
 #include <sys/eventfd.h>
@@ -24,18 +25,17 @@
 static struct iovec *vecs;
 static struct io_uring rings[NR_RINGS];
 
-static int create_buffers(void)
+static void create_buffers(void)
 {
 	int i;
 
 	vecs = malloc(BUFFERS * sizeof(struct iovec));
+	assert(vecs);
 	for (i = 0; i < BUFFERS; i++) {
 		if (posix_memalign(&vecs[i].iov_base, BS, BS))
-			return 1;
+			assert(0);
 		vecs[i].iov_len = BS;
 	}
-
-	return 0;
 }
 
 static int create_file(const char *file)
@@ -45,6 +45,7 @@ static int create_file(const char *file)
 	int fd;
 
 	buf = malloc(FILE_SIZE);
+	assert(buf);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);
@@ -198,10 +199,7 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	if (create_buffers()) {
-		fprintf(stderr, "file creation failed\n");
-		goto err;
-	}
+	create_buffers();
 
 	fd = open(fname, O_RDONLY | O_DIRECT);
 	if (fd < 0) {

--- a/test/sq-poll-share.c
+++ b/test/sq-poll-share.c
@@ -7,6 +7,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/poll.h>
@@ -27,6 +28,7 @@ static int create_buffers(void)
 	int i;
 
 	vecs = malloc(BUFFERS * sizeof(struct iovec));
+	assert(vecs);
 	for (i = 0; i < BUFFERS; i++) {
 		if (posix_memalign(&vecs[i].iov_base, BS, BS))
 			return 1;
@@ -43,6 +45,7 @@ static int create_file(const char *file)
 	int fd;
 
 	buf = malloc(FILE_SIZE);
+	assert(buf);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);

--- a/test/statx.c
+++ b/test/statx.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <assert.h>
 #include <sys/types.h>
 #include <sys/syscall.h>
 #include <linux/stat.h>
@@ -37,6 +38,7 @@ static int create_file(const char *file, size_t size)
 	int fd;
 
 	buf = malloc(size);
+	assert(buf);
 	memset(buf, 0xaa, size);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);

--- a/test/submit-reuse.c
+++ b/test/submit-reuse.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <pthread.h>
+#include <assert.h>
 #include <sys/time.h>
 
 #include "liburing.h"
@@ -44,6 +45,7 @@ static int create_file(const char *file)
 	int fd;
 
 	buf = malloc(FILE_SIZE);
+	assert(buf);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);

--- a/test/thread-exit.c
+++ b/test/thread-exit.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <assert.h>
 #include <sys/poll.h>
 #include <pthread.h>
 
@@ -26,6 +27,7 @@ static int create_file(const char *file, size_t size)
 	int fd;
 
 	buf = malloc(size);
+	assert(buf);
 	memset(buf, 0xaa, size);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);
@@ -55,6 +57,7 @@ static void *do_io(void *data)
 	int ret;
 
 	buffer = malloc(WSIZE);
+	assert(buffer);
 	memset(buffer, 0x5a, WSIZE);
 	sqe = io_uring_get_sqe(d->ring);
 	if (!sqe) {


### PR DESCRIPTION
In tests, we can just call assert() when allocating memory fails,
as done in io_uring_regeister.c and io_uring_enter.c.

Signed-off-by: Zhiqiang Liu <liuzhiqiang26@huawei.com>