### PR TITLE
tests: add helpers.h to harden the tests

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,8 @@
 prefix ?= /usr
 datadir ?= $(prefix)/share
 
+helpers = helpers.c
+
 INSTALL=install
 
 CPPFLAGS ?=
@@ -132,13 +134,13 @@ test_targets += sq-full-cpp
 endif
 all_targets += sq-full-cpp
 
-all: $(test_targets)
+all: $(test_targets) helpers.o
 
 %: %.c
-	$(QUIET_CC)$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ $< -luring $(XCFLAGS)
+	$(QUIET_CC)$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ $< -luring $(XCFLAGS) ${helpers}
 
 %: %.cc
-	$(QUIET_CXX)$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ $< -luring $(XCFLAGS)
+	$(QUIET_CXX)$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ $< -luring $(XCFLAGS) ${helpers}
 
 test_srcs := \
 	232c93d07b74-test.c \
@@ -266,7 +268,7 @@ install: $(test_targets) runtests.sh runtests-loop.sh
 	$(INSTALL) -D -m 755 runtests.sh  $(datadir)/liburing-test/
 	$(INSTALL) -D -m 755 runtests-loop.sh  $(datadir)/liburing-test/
 clean:
-	@rm -f $(all_targets) $(test_objs)
+	@rm -f $(all_targets) $(test_objs) helpers.o
 
 runtests: all
 	@./runtests.sh $(test_targets)

--- a/test/accept.c
+++ b/test/accept.c
@@ -18,6 +18,7 @@
 #include <netinet/tcp.h>
 #include <netinet/in.h>
 
+#include "helpers.h"
 #include "liburing.h"
 
 static int no_accept;
@@ -32,7 +33,7 @@ static void queue_send(struct io_uring *ring, int fd)
 	struct io_uring_sqe *sqe;
 	struct data *d;
 
-	d = malloc(sizeof(*d));
+	d = io_uring_malloc(sizeof(*d));
 	d->iov.iov_base = d->buf;
 	d->iov.iov_len = sizeof(d->buf);
 
@@ -45,7 +46,7 @@ static void queue_recv(struct io_uring *ring, int fd)
 	struct io_uring_sqe *sqe;
 	struct data *d;
 
-	d = malloc(sizeof(*d));
+	d = io_uring_malloc(sizeof(*d));
 	d->iov.iov_base = d->buf;
 	d->iov.iov_len = sizeof(d->buf);
 

--- a/test/cq-overflow.c
+++ b/test/cq-overflow.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <fcntl.h>
 
+#include "helpers.h"
 #include "liburing.h"
 
 #define FILE_SIZE	(256 * 1024)
@@ -22,7 +23,7 @@ static int create_buffers(void)
 {
 	int i;
 
-	vecs = malloc(BUFFERS * sizeof(struct iovec));
+	vecs = io_uring_malloc(BUFFERS * sizeof(struct iovec));
 	for (i = 0; i < BUFFERS; i++) {
 		if (posix_memalign(&vecs[i].iov_base, BS, BS))
 			return 1;
@@ -38,7 +39,7 @@ static int create_file(const char *file)
 	char *buf;
 	int fd;
 
-	buf = malloc(FILE_SIZE);
+	buf = io_uring_malloc(FILE_SIZE);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);

--- a/test/d4ae271dfaae-test.c
+++ b/test/d4ae271dfaae-test.c
@@ -11,6 +11,7 @@
 #include <unistd.h>
 #include <string.h>
 
+#include "helpers.h"
 #include "liburing.h"
 
 #define FILE_SIZE	(128 * 1024)
@@ -21,7 +22,7 @@ static int create_file(const char *file)
 	char *buf;
 	int fd;
 
-	buf = malloc(FILE_SIZE);
+	buf = io_uring_malloc(FILE_SIZE);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);

--- a/test/defer.c
+++ b/test/defer.c
@@ -8,6 +8,7 @@
 #include <sys/uio.h>
 #include <stdbool.h>
 
+#include "helpers.h"
 #include "liburing.h"
 
 struct test_context {
@@ -32,8 +33,8 @@ static int init_context(struct test_context *ctx, struct io_uring *ring, int nr)
 	memset(ctx, 0, sizeof(*ctx));
 	ctx->nr = nr;
 	ctx->ring = ring;
-	ctx->sqes = malloc(nr * sizeof(*ctx->sqes));
-	ctx->cqes = malloc(nr * sizeof(*ctx->cqes));
+	ctx->sqes = io_uring_malloc(nr * sizeof(*ctx->sqes));
+	ctx->cqes = io_uring_malloc(nr * sizeof(*ctx->cqes));
 
 	if (!ctx->sqes || !ctx->cqes)
 		goto err;

--- a/test/eeed8b54e0df-test.c
+++ b/test/eeed8b54e0df-test.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <fcntl.h>
 
+#include "helpers.h"
 #include "liburing.h"
 
 #define BLOCK	4096
@@ -30,7 +31,7 @@ static int get_file_fd(void)
 		return -1;
 	}
 
-	buf = malloc(BLOCK);
+	buf = io_uring_malloc(BLOCK);
 	ret = write(fd, buf, BLOCK);
 	if (ret != BLOCK) {
 		if (ret < 0)
@@ -70,7 +71,7 @@ int main(int argc, char *argv[])
 	if (argc > 1)
 		return 0;
 
-	iov.iov_base = malloc(4096);
+	iov.iov_base = io_uring_malloc(4096);
 	iov.iov_len = 4096;
 
 	ret = io_uring_queue_init(2, &ring, 0);

--- a/test/fadvise.c
+++ b/test/fadvise.c
@@ -11,6 +11,7 @@
 #include <sys/types.h>
 #include <sys/time.h>
 
+#include "helpers.h"
 #include "liburing.h"
 
 #define FILE_SIZE	(128 * 1024)
@@ -47,7 +48,7 @@ static int create_file(const char *file)
 	char *buf;
 	int fd;
 
-	buf = malloc(FILE_SIZE);
+	buf = io_uring_malloc(FILE_SIZE);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);
@@ -138,7 +139,7 @@ static int test_fadvise(struct io_uring *ring, const char *filename)
 		return 1;
 	}
 
-	buf = malloc(FILE_SIZE);
+	buf = io_uring_malloc(FILE_SIZE);
 
 	cached_read = do_read(fd, buf);
 	if (cached_read == -1)

--- a/test/file-register.c
+++ b/test/file-register.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <fcntl.h>
 
+#include "helpers.h"
 #include "liburing.h"
 
 static int no_update = 0;
@@ -156,7 +157,7 @@ static int test_replace_all(struct io_uring *ring)
 		goto err;
 	}
 
-	fds = malloc(100 * sizeof(int));
+	fds = io_uring_malloc(100 * sizeof(int));
 	for (i = 0; i < 100; i++)
 		fds[i] = -1;
 
@@ -423,11 +424,11 @@ static int test_fixed_read_write(struct io_uring *ring, int index)
 	struct iovec iov[2];
 	int ret;
 
-	iov[0].iov_base = malloc(4096);
+	iov[0].iov_base = io_uring_malloc(4096);
 	iov[0].iov_len = 4096;
 	memset(iov[0].iov_base, 0x5a, 4096);
 
-	iov[1].iov_base = malloc(4096);
+	iov[1].iov_base = io_uring_malloc(4096);
 	iov[1].iov_len = 4096;
 
 	sqe = io_uring_get_sqe(ring);
@@ -602,7 +603,7 @@ static int test_sparse_updates(void)
 		return ret;
 	}
 
-	fds = malloc(256 * sizeof(int));
+	fds = io_uring_malloc(256 * sizeof(int));
 	for (i = 0; i < 256; i++)
 		fds[i] = -1;
 

--- a/test/file-update.c
+++ b/test/file-update.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <fcntl.h>
 
+#include "helpers.h"
 #include "liburing.h"
 
 static void close_files(int *files, int nr_files, int add)
@@ -107,7 +108,7 @@ static int test_sqe_update(struct io_uring *ring)
 	struct io_uring_cqe *cqe;
 	int *fds, i, ret;
 
-	fds = malloc(sizeof(int) * 10);
+	fds = io_uring_malloc(sizeof(int) * 10);
 	for (i = 0; i < 10; i++)
 		fds[i] = -1;
 

--- a/test/fixed-link.c
+++ b/test/fixed-link.c
@@ -7,6 +7,7 @@
 #include <fcntl.h>
 #include <sys/types.h>
 
+#include "helpers.h"
 #include "liburing.h"
 
 #define IOVECS_LEN 2
@@ -33,7 +34,7 @@ int main(int argc, char *argv[])
 	}
 
 	for (i = 0; i < IOVECS_LEN; ++i) {
-		iovecs[i].iov_base = malloc(64);
+		iovecs[i].iov_base = io_uring_malloc(64);
 		iovecs[i].iov_len = 64;
 	};
 

--- a/test/fsync.c
+++ b/test/fsync.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <fcntl.h>
 
+#include "helpers.h"
 #include "liburing.h"
 
 static int test_single_fsync(struct io_uring *ring)
@@ -69,7 +70,7 @@ static int test_barrier_fsync(struct io_uring *ring)
 	}
 
 	for (i = 0; i < 4; i++) {
-		iovecs[i].iov_base = malloc(4096);
+		iovecs[i].iov_base = io_uring_malloc(4096);
 		iovecs[i].iov_len = 4096;
 	}
 
@@ -143,7 +144,7 @@ static int create_file(const char *file)
 	char *buf;
 	int fd;
 
-	buf = malloc(FILE_SIZE);
+	buf = io_uring_malloc(FILE_SIZE);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);

--- a/test/helpers.c
+++ b/test/helpers.c
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Description: Helpers for tests.
+ */
+#include <stdlib.h>
+#include <assert.h>
+
+#include "helpers.h"
+
+/*
+ * Helper for allocating memory in tests.
+ */
+void *io_uring_malloc(size_t size)
+{
+	void *ret;
+	ret = malloc(size);
+	assert(ret);
+	return ret;
+}

--- a/test/helpers.h
+++ b/test/helpers.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Description: Helpers for tests.
+ */
+#ifndef LIBURING_HELPERS_H
+#define LIBURING_HELPERS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Helper for allocating memory in tests.
+ */
+void *io_uring_malloc(size_t size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/test/io-cancel.c
+++ b/test/io-cancel.c
@@ -11,6 +11,7 @@
 #include <sys/types.h>
 #include <sys/time.h>
 
+#include "helpers.h"
 #include "liburing.h"
 
 #define FILE_SIZE	(128 * 1024)
@@ -23,7 +24,7 @@ static int create_buffers(void)
 {
 	int i;
 
-	vecs = malloc(BUFFERS * sizeof(struct iovec));
+	vecs = io_uring_malloc(BUFFERS * sizeof(struct iovec));
 	for (i = 0; i < BUFFERS; i++) {
 		if (posix_memalign(&vecs[i].iov_base, BS, BS))
 			return 1;
@@ -39,7 +40,7 @@ static int create_file(const char *file)
 	char *buf;
 	int fd;
 
-	buf = malloc(FILE_SIZE);
+	buf = io_uring_malloc(FILE_SIZE);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);

--- a/test/io_uring_enter.c
+++ b/test/io_uring_enter.c
@@ -23,6 +23,8 @@
 #include <sys/resource.h>
 #include <limits.h>
 #include <sys/time.h>
+
+#include "helpers.h"
 #include "liburing.h"
 #include "liburing/barrier.h"
 #include "../src/syscall.h"
@@ -124,10 +126,10 @@ io_prep_read(struct io_uring_sqe *sqe, int fd, off_t offset, size_t len)
 {
 	struct iovec *iov;
 
-	iov = malloc(sizeof(*iov));
+	iov = io_uring_malloc(sizeof(*iov));
 	assert(iov);
 
-	iov->iov_base = malloc(len);
+	iov->iov_base = io_uring_malloc(len);
 	assert(iov->iov_base);
 	iov->iov_len = len;
 

--- a/test/io_uring_register.c
+++ b/test/io_uring_register.c
@@ -22,6 +22,8 @@
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <limits.h>
+
+#include "helpers.h"
 #include "liburing.h"
 #include "../src/syscall.h"
 
@@ -240,8 +242,7 @@ test_memlock_exceeded(int fd)
 		return 0;
 
 	iov.iov_len = mlock_limit * 2;
-	buf = malloc(iov.iov_len);
-	assert(buf);
+	buf = io_uring_malloc(iov.iov_len);
 	iov.iov_base = buf;
 
 	while (iov.iov_len) {
@@ -283,11 +284,8 @@ test_iovec_nr(int fd)
 	struct iovec *iovs;
 	void *buf;
 
-	buf = malloc(pagesize);
-	assert(buf);
-
-	iovs = malloc(nr * sizeof(struct iovec));
-	assert(iovs);
+	buf = io_uring_malloc(pagesize);
+	iovs = io_uring_malloc(nr * sizeof(struct iovec));
 
 	for (i = 0; i < nr; i++) {
 		iovs[i].iov_base = buf;

--- a/test/iopoll.c
+++ b/test/iopoll.c
@@ -12,6 +12,7 @@
 #include <sys/poll.h>
 #include <sys/eventfd.h>
 #include <sys/resource.h>
+#include "helpers.h"
 #include "liburing.h"
 #include "../src/syscall.h"
 
@@ -27,7 +28,7 @@ static int create_buffers(void)
 {
 	int i;
 
-	vecs = malloc(BUFFERS * sizeof(struct iovec));
+	vecs = io_uring_malloc(BUFFERS * sizeof(struct iovec));
 	for (i = 0; i < BUFFERS; i++) {
 		if (posix_memalign(&vecs[i].iov_base, BS, BS))
 			return 1;
@@ -43,7 +44,7 @@ static int create_file(const char *file)
 	char *buf;
 	int fd;
 
-	buf = malloc(FILE_SIZE);
+	buf = io_uring_malloc(FILE_SIZE);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);

--- a/test/link_drain.c
+++ b/test/link_drain.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <fcntl.h>
 
+#include "helpers.h"
 #include "liburing.h"
 
 static int test_link_drain_one(struct io_uring *ring)
@@ -28,7 +29,7 @@ static int test_link_drain_one(struct io_uring *ring)
 		return 1;
 	}
 
-	iovecs.iov_base = malloc(4096);
+	iovecs.iov_base = io_uring_malloc(4096);
 	iovecs.iov_len = 4096;
 
 	for (i = 0; i < 5; i++) {
@@ -111,7 +112,7 @@ int test_link_drain_multi(struct io_uring *ring)
 		return 1;
 	}
 
-	iovecs.iov_base = malloc(4096);
+	iovecs.iov_base = io_uring_malloc(4096);
 	iovecs.iov_len = 4096;
 
 	for (i = 0; i < 9; i++) {

--- a/test/madvise.c
+++ b/test/madvise.c
@@ -12,6 +12,7 @@
 #include <sys/time.h>
 #include <sys/mman.h>
 
+#include "helpers.h"
 #include "liburing.h"
 
 #define FILE_SIZE	(128 * 1024)
@@ -49,7 +50,7 @@ static int create_file(const char *file)
 	char *buf;
 	int fd;
 
-	buf = malloc(FILE_SIZE);
+	buf = io_uring_malloc(FILE_SIZE);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);
@@ -123,7 +124,7 @@ static int test_madvise(struct io_uring *ring, const char *filename)
 		return 1;
 	}
 
-	buf = malloc(FILE_SIZE);
+	buf = io_uring_malloc(FILE_SIZE);
 
 	ptr = mmap(NULL, FILE_SIZE, PROT_READ, MAP_PRIVATE, fd, 0);
 	if (ptr == MAP_FAILED) {

--- a/test/open-close.c
+++ b/test/open-close.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <fcntl.h>
 
+#include "helpers.h"
 #include "liburing.h"
 
 static int create_file(const char *file, size_t size)
@@ -18,7 +19,7 @@ static int create_file(const char *file, size_t size)
 	char *buf;
 	int fd;
 
-	buf = malloc(size);
+	buf = io_uring_malloc(size);
 	memset(buf, 0xaa, size);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);

--- a/test/openat2.c
+++ b/test/openat2.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <fcntl.h>
 
+#include "helpers.h"
 #include "liburing.h"
 
 static int create_file(const char *file, size_t size)
@@ -18,7 +19,7 @@ static int create_file(const char *file, size_t size)
 	char *buf;
 	int fd;
 
-	buf = malloc(size);
+	buf = io_uring_malloc(size);
 	memset(buf, 0xaa, size);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);

--- a/test/read-write.c
+++ b/test/read-write.c
@@ -12,6 +12,8 @@
 #include <sys/poll.h>
 #include <sys/eventfd.h>
 #include <sys/resource.h>
+
+#include "helpers.h"
 #include "liburing.h"
 
 #define FILE_SIZE	(128 * 1024)
@@ -27,7 +29,7 @@ static int create_buffers(void)
 {
 	int i;
 
-	vecs = malloc(BUFFERS * sizeof(struct iovec));
+	vecs = io_uring_malloc(BUFFERS * sizeof(struct iovec));
 	for (i = 0; i < BUFFERS; i++) {
 		if (posix_memalign(&vecs[i].iov_base, BS, BS))
 			return 1;
@@ -41,9 +43,9 @@ static int create_nonaligned_buffers(void)
 {
 	int i;
 
-	vecs = malloc(BUFFERS * sizeof(struct iovec));
+	vecs = io_uring_malloc(BUFFERS * sizeof(struct iovec));
 	for (i = 0; i < BUFFERS; i++) {
-		char *p = malloc(3 * BS);
+		char *p = io_uring_malloc(3 * BS);
 
 		if (!p)
 			return 1;
@@ -60,7 +62,7 @@ static int create_file(const char *file)
 	char *buf;
 	int fd;
 
-	buf = malloc(FILE_SIZE);
+	buf = io_uring_malloc(FILE_SIZE);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);

--- a/test/short-read.c
+++ b/test/short-read.c
@@ -8,6 +8,8 @@
 #include <sys/types.h>
 #include <sys/poll.h>
 
+
+#include "helpers.h"
 #include "liburing.h"
 
 #define BUF_SIZE 4096
@@ -19,7 +21,7 @@ static int create_file(const char *file)
 	char *buf;
 	int fd;
 
-	buf = malloc(FILE_SIZE);
+	buf = io_uring_malloc(FILE_SIZE);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);
@@ -43,7 +45,7 @@ int main(int argc, char *argv[])
 	if (argc > 1)
 		return 0;
 
-	vec.iov_base = malloc(BUF_SIZE);
+	vec.iov_base = io_uring_malloc(BUF_SIZE);
 	vec.iov_len = BUF_SIZE;
 
 	if (create_file(".short-read")) {

--- a/test/sq-poll-dup.c
+++ b/test/sq-poll-dup.c
@@ -13,6 +13,8 @@
 #include <sys/poll.h>
 #include <sys/eventfd.h>
 #include <sys/resource.h>
+
+#include "helpers.h"
 #include "liburing.h"
 
 #define FILE_SIZE	(128 * 1024 * 1024)
@@ -28,7 +30,7 @@ static int create_buffers(void)
 {
 	int i;
 
-	vecs = malloc(BUFFERS * sizeof(struct iovec));
+	vecs = io_uring_malloc(BUFFERS * sizeof(struct iovec));
 	for (i = 0; i < BUFFERS; i++) {
 		if (posix_memalign(&vecs[i].iov_base, BS, BS))
 			return 1;
@@ -44,7 +46,7 @@ static int create_file(const char *file)
 	char *buf;
 	int fd;
 
-	buf = malloc(FILE_SIZE);
+	buf = io_uring_malloc(FILE_SIZE);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);

--- a/test/sq-poll-share.c
+++ b/test/sq-poll-share.c
@@ -12,6 +12,8 @@
 #include <sys/poll.h>
 #include <sys/eventfd.h>
 #include <sys/resource.h>
+
+#include "helpers.h"
 #include "liburing.h"
 
 #define FILE_SIZE	(128 * 1024 * 1024)
@@ -26,7 +28,7 @@ static int create_buffers(void)
 {
 	int i;
 
-	vecs = malloc(BUFFERS * sizeof(struct iovec));
+	vecs = io_uring_malloc(BUFFERS * sizeof(struct iovec));
 	for (i = 0; i < BUFFERS; i++) {
 		if (posix_memalign(&vecs[i].iov_base, BS, BS))
 			return 1;
@@ -42,7 +44,7 @@ static int create_file(const char *file)
 	char *buf;
 	int fd;
 
-	buf = malloc(FILE_SIZE);
+	buf = io_uring_malloc(FILE_SIZE);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);

--- a/test/statx.c
+++ b/test/statx.c
@@ -13,6 +13,7 @@
 #include <sys/syscall.h>
 #include <linux/stat.h>
 
+#include "helpers.h"
 #include "liburing.h"
 
 #ifdef __NR_statx
@@ -36,7 +37,7 @@ static int create_file(const char *file, size_t size)
 	char *buf;
 	int fd;
 
-	buf = malloc(size);
+	buf = io_uring_malloc(size);
 	memset(buf, 0xaa, size);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);

--- a/test/submit-reuse.c
+++ b/test/submit-reuse.c
@@ -12,6 +12,7 @@
 #include <pthread.h>
 #include <sys/time.h>
 
+#include "helpers.h"
 #include "liburing.h"
 
 #define STR_SIZE	32768
@@ -43,7 +44,7 @@ static int create_file(const char *file)
 	char *buf;
 	int fd;
 
-	buf = malloc(FILE_SIZE);
+	buf = io_uring_malloc(FILE_SIZE);
 	memset(buf, 0xaa, FILE_SIZE);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);

--- a/test/thread-exit.c
+++ b/test/thread-exit.c
@@ -14,6 +14,7 @@
 #include <sys/poll.h>
 #include <pthread.h>
 
+#include "helpers.h"
 #include "liburing.h"
 
 #define NR_IOS	8
@@ -25,7 +26,7 @@ static int create_file(const char *file, size_t size)
 	char *buf;
 	int fd;
 
-	buf = malloc(size);
+	buf = io_uring_malloc(size);
 	memset(buf, 0xaa, size);
 
 	fd = open(file, O_WRONLY | O_CREAT, 0644);
@@ -54,7 +55,7 @@ static void *do_io(void *data)
 	char *buffer;
 	int ret;
 
-	buffer = malloc(WSIZE);
+	buffer = io_uring_malloc(WSIZE);
 	memset(buffer, 0x5a, WSIZE);
 	sqe = io_uring_get_sqe(d->ring);
 	if (!sqe) {


### PR DESCRIPTION
As axboe said, Right now a lot of basic stuff is duplicated,
and it makes the tests bigger than they should be.
Here, we try to add helpers.h which will contains various
utilities that tests could use, then that'd help make tests simpler.

In this patch, we just add one helper io_uring_malloc(), which
will call assert() if allocating memory fails.
We will add more helpers in subsequent patches

Signed-off-by: Zhiqiang Liu <liuzhiqiang26@huawei.com>