### PR TITLE
Adding test suite for #310 multishot poll / update, tests basic functionality and some error boundary conditions.

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -78,6 +78,10 @@ test_targets += \
 	poll-cancel-ton \
 	poll-link \
 	poll-many \
+	poll-multiple-update-ping-pong \
+	poll-multiple-update \
+	poll-multiple-nohup \
+	poll-update-failures \
 	poll-ring \
 	poll-v-poll \
 	probe \
@@ -210,6 +214,10 @@ test_srcs := \
 	poll-cancel-ton.c \
 	poll-cancel.c \
 	poll-link.c \
+	poll-multiple-update-ping-pong.c \
+	poll-multiple-update.c \
+	poll-multiple-nohup.c \
+	poll-update-failures.c \
 	poll-ring.c \
 	poll-v-poll.c \
 	poll.c \
@@ -260,6 +268,10 @@ poll-link: XCFLAGS = -lpthread
 accept-link: XCFLAGS = -lpthread
 submit-reuse: XCFLAGS = -lpthread
 poll-v-poll: XCFLAGS = -lpthread
+poll-update-failures: XCFLAGS = -lpthread
+poll-multiple-update-ping-pong: XCFLAGS = -lpthread
+poll-multiple-update: XCFLAGS = -lpthread
+poll-multiple-nohup: XCFLAGS = -lpthread
 across-fork: XCFLAGS = -lpthread
 ce593a6c480a-test: XCFLAGS = -lpthread
 wakeup-hang: XCFLAGS = -lpthread

--- a/test/poll-multiple-nohup.c
+++ b/test/poll-multiple-nohup.c
@@ -116,7 +116,7 @@ void *server_thread(void *arg)
     int flags = fcntl(client_fd, F_GETFL, 0);
     fcntl(client_fd, F_SETFL, flags | O_NONBLOCK);
 
-    prepare_sqe(&ring, client_fd, POLLIN | POLLHUP | POLLERR ); // POLLRDHUP
+    prepare_sqe(&ring, client_fd, POLLIN | POLLHUP | POLLERR);
 
     ret = io_uring_submit(&ring);
     assert(ret == 1);
@@ -166,11 +166,6 @@ void *server_thread(void *arg)
         
         if (POLLERR & cqe->res) {
             fprintf(stderr, "Server POLLERR fd [%d] [%d] [%ld]\n", fd, cqe->res, poll_mask);
-            done = 1;
-        }
-
-        if (POLLRDHUP & cqe->res) {
-            fprintf(stderr, "Server POLLRDHUP fd [%d] [%d] [%ld]\n", fd, cqe->res, poll_mask);
             done = 1;
         }
 

--- a/test/poll-multiple-nohup.c
+++ b/test/poll-multiple-nohup.c
@@ -1,0 +1,253 @@
+/* SPDX-License-Identifier: MIT */
+//
+//  Test for receving HUP/ERR events for socket fd when
+//  other side closes.
+
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <assert.h>
+#include <pthread.h>
+#include <sys/socket.h>
+#include <netinet/tcp.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/eventfd.h>
+
+#include "liburing.h"
+
+#define WRITE_EVENTS 10
+
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+
+static int server_thread_ready = 0;
+static int server_thread_done = 0;
+static int port = 0; // protected by the mutex, will be set before server signals ready
+
+static void signal_var(int *var)
+{
+        pthread_mutex_lock(&mutex);
+        *var = 1;
+        pthread_cond_broadcast(&cond);
+        pthread_mutex_unlock(&mutex);
+}
+
+static void wait_for_var(int *var)
+{
+        pthread_mutex_lock(&mutex);
+
+        while (!*var)
+                pthread_cond_wait(&cond, &mutex);
+
+        pthread_mutex_unlock(&mutex);
+}
+
+static void prepare_sqe(struct io_uring *ring, int fd, uint64_t poll_mask)
+{
+    struct io_uring_sqe *sqe;
+    uint64_t bitpattern;
+    
+    sqe = io_uring_get_sqe(ring);
+    assert(sqe != NULL);
+
+    bitpattern = (poll_mask << 32) + fd;
+    io_uring_prep_poll_add(sqe, fd, poll_mask);
+    io_uring_sqe_set_data(sqe, (void *) bitpattern);
+    sqe->len |= IORING_POLL_ADD_MULTI;
+
+    return;
+}
+
+void *server_thread(void *arg)
+{
+    struct io_uring ring;
+    int i, ret, client_fd, s0;
+    uint64_t user_data;
+    int fd, done = 0;
+    uint64_t poll_mask;
+    struct sockaddr_in addr;
+    unsigned int rand_seed = getpid();
+    char readbuffer[1024];
+    int bytes_read = 0;
+    
+    // set up uring
+    ret = io_uring_queue_init(8, &ring, 0);
+    assert(ret == 0);
+
+    // set up listening
+    s0 = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    assert(s0 != -1);
+
+    int32_t val = 1;
+    ret = setsockopt(s0, SOL_SOCKET, SO_REUSEPORT, &val, sizeof(val));
+    assert(ret != -1);
+    ret = setsockopt(s0, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
+    assert(ret != -1);
+
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = 0x0100007fU;
+
+    i = 0;
+    do {
+        port = 1025 + (rand_r(&rand_seed) % 64510);
+        addr.sin_port = port;
+
+        if (bind(s0, (struct sockaddr*)&addr, sizeof(addr)) != -1)
+            break;
+    } while (++i < 100);
+
+    if (i >= 100) {
+        fprintf(stderr, "Can't find good port, bailing out\n");
+        exit(1);
+    }
+    
+    ret = listen(s0, 128);
+    assert(ret != -1);
+
+    signal_var(&server_thread_ready);
+
+    client_fd = accept(s0, NULL, NULL);
+    assert(client_fd != -1);
+
+    int flags = fcntl(client_fd, F_GETFL, 0);
+    fcntl(client_fd, F_SETFL, flags | O_NONBLOCK);
+
+    prepare_sqe(&ring, client_fd, POLLIN | POLLHUP | POLLERR ); // POLLRDHUP
+
+    ret = io_uring_submit(&ring);
+    assert(ret == 1);
+
+    while (!done) {
+        struct io_uring_cqe *cqe;
+
+        if (bytes_read >= WRITE_EVENTS)
+        {
+            fprintf(stderr, "We have received %d bytes and should be done now, but we have received no POLLHUP, test fail.\n",bytes_read);
+            exit(1);
+        }
+        
+        if (io_uring_wait_cqe(&ring, &cqe)) {
+            fprintf(stderr, "server wait cqe failed\n");
+            exit(1);
+        }
+        
+        user_data = (uint64_t) io_uring_cqe_get_data(cqe);
+        fd = user_data & 0x00000000FFFFFFFF; // mask out the fd
+        poll_mask = user_data >> 32;         // and shift out the fd to get the poll_mask
+
+        if (POLLIN & cqe->res) {
+            while ((ret = read(fd, readbuffer, 1)) > 0)
+            {
+                readbuffer[1]=0;
+                assert (ret == 1);
+                bytes_read++;
+            }
+            
+            if (ret == 0)
+            {
+                fprintf(stderr, "Read zero bytes, should have received HUP now too cqe->res [%d].\n", cqe->res);
+            }
+            
+            if (ret < 0 && errno != EAGAIN)
+            {
+                fprintf(stderr, "Read failed with return code %d, errno %d\n", ret, errno);
+                exit(1);
+            }
+        }
+
+        if (POLLHUP & cqe->res) {
+            fprintf(stderr, "Server POLLHUP on [%d] [%d] [%ld]\n", fd, cqe->res, poll_mask);
+            done = 1;
+        }
+        
+        if (POLLERR & cqe->res) {
+            fprintf(stderr, "Server POLLERR fd [%d] [%d] [%ld]\n", fd, cqe->res, poll_mask);
+            done = 1;
+        }
+
+        if (POLLRDHUP & cqe->res) {
+            fprintf(stderr, "Server POLLRDHUP fd [%d] [%d] [%ld]\n", fd, cqe->res, poll_mask);
+            done = 1;
+        }
+
+        io_uring_cqe_seen(&ring, cqe);
+    }
+
+    signal_var(&server_thread_done);
+    close(s0);
+    close(client_fd);
+    io_uring_queue_exit(&ring);
+    return NULL;
+}
+
+static void *client_thread(void *arg)
+{
+    int ret, i;
+
+    wait_for_var(&server_thread_ready);
+
+    // connect to server thread
+    int s0 = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    assert(s0 != -1);
+
+    struct sockaddr_in addr;
+    addr.sin_family = AF_INET;
+    addr.sin_port = port;
+    addr.sin_addr.s_addr = 0x0100007fU;
+
+    if (connect(s0, (struct sockaddr*)&addr, sizeof(addr)) == -1)
+    {
+        fprintf(stderr, "Failed to connect to 127.0.0.1:%d, aborting test.\n", port);
+        exit(1);
+    }
+
+    int flags = fcntl(s0, F_GETFL, 0);
+    fcntl(s0, F_SETFL, flags | O_NONBLOCK);
+
+    for (i=0; i<WRITE_EVENTS; i++)
+    {
+      usleep(100000);
+      ret = write(s0, "x", 1);
+      assert (ret == 1);
+    }
+    
+    close(s0); // should give server a HUP
+    wait_for_var(&server_thread_done);
+
+    return 0;
+}
+
+static int start_threads()
+{
+    pthread_t t1, t2;
+    void *tret;
+    int ret = 0;
+
+    server_thread_ready = 0;
+    server_thread_done = 0;
+ 
+    pthread_create(&t1, NULL, server_thread, NULL);
+    pthread_create(&t2, NULL, client_thread, NULL);
+
+    pthread_join(t1, &tret);
+    if (tret)
+        ret++;
+
+    pthread_join(t2, &tret);
+    if (tret)
+        ret++;
+
+    return ret;
+}
+
+int main(int argc, char *argv[])
+{
+    if (argc > 1)
+        return 0;
+    
+    return start_threads();
+}

--- a/test/poll-multiple-update-ping-pong.c
+++ b/test/poll-multiple-update-ping-pong.c
@@ -1,0 +1,334 @@
+/* SPDX-License-Identifier: MIT */
+//
+//  Test for multiple polls (ie. not oneshots) and updates
+//  of polling masks to those.
+//
+//  t1 is the 'server' accepting and t2 is the 'client' connecting.
+//
+//  t1 will simply echo any data recieved, t2 will switch between POLLIN/POLLOUT.
+//
+
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <assert.h>
+#include <pthread.h>
+#include <sys/socket.h>
+#include <netinet/tcp.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/eventfd.h>
+
+#include "liburing.h"
+
+#define ECHO_COUNT 1000000 // number of times server echoes before shutting down client connection
+
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+
+static int server_thread_ready = 0;
+static int server_thread_done = 0;
+static int port = 0; // protected by the mutex, will be set before server signals ready
+
+static void signal_var(int *var)
+{
+    pthread_mutex_lock(&mutex);
+    *var = 1;
+    pthread_cond_broadcast(&cond);
+    pthread_mutex_unlock(&mutex);
+}
+
+static void wait_for_var(int *var)
+{
+    pthread_mutex_lock(&mutex);
+    
+    while (!*var)
+        pthread_cond_wait(&cond, &mutex);
+    
+    pthread_mutex_unlock(&mutex);
+}
+
+static void prepare_sqe(struct io_uring *ring, int fd, uint64_t poll_mask)
+{
+    struct io_uring_sqe *sqe;
+    uint64_t bitpattern;
+    
+    sqe = io_uring_get_sqe(ring);
+    assert(sqe != NULL);
+    
+    bitpattern = (poll_mask << 32) + fd;
+    io_uring_prep_poll_add(sqe, fd, poll_mask);
+    io_uring_sqe_set_data(sqe, (void *) bitpattern);
+    sqe->len |= IORING_POLL_ADD_MULTI;
+    
+    return;
+}
+
+static void switch_poll_mask(struct io_uring *ring, int fd, uint64_t old_poll_mask, uint64_t new_poll_mask)
+{
+    struct io_uring_sqe *sqe;
+    uint64_t old_bitpattern, new_bitpattern;
+    
+    sqe = io_uring_get_sqe(ring);
+    assert(sqe != NULL);
+    
+    old_bitpattern = (old_poll_mask << 32) + fd;
+    new_bitpattern = (new_poll_mask << 32) + fd;
+    io_uring_prep_poll_add(sqe, fd, 0);
+    sqe->len |= IORING_POLL_ADD_MULTI;       // ask for multiple updates
+    sqe->len |= IORING_POLL_UPDATE_EVENTS;   // update existing mask
+    sqe->len |= IORING_POLL_UPDATE_USER_DATA;// and update user data
+    io_uring_sqe_set_data(sqe, (void *) old_bitpattern); // old user_data
+    sqe->addr = old_bitpattern; // old user_data
+    sqe->poll_events = new_poll_mask; // new poll mask
+    sqe->off = new_bitpattern; // new user_data
+    
+    while (io_uring_sq_ready(ring) > 0)
+    {
+        (void) io_uring_submit(ring);
+    }
+    
+    return;
+}
+
+void *server_thread(void *arg)
+{
+    struct io_uring ring;
+    int i, ret, client_fd, s0;
+    uint64_t user_data;
+    int fd, done = 0;
+    uint64_t poll_mask;
+    struct sockaddr_in addr;
+    unsigned int rand_seed = getpid();
+    char readbuffer[1024];
+    
+    // set up uring
+    ret = io_uring_queue_init(64, &ring, 0);
+    assert(ret == 0);
+    
+    // set up listening
+    s0 = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    assert(s0 != -1);
+    
+    int32_t val = 1;
+    ret = setsockopt(s0, SOL_SOCKET, SO_REUSEPORT, &val, sizeof(val));
+    assert(ret != -1);
+    ret = setsockopt(s0, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
+    assert(ret != -1);
+    
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = 0x0100007fU;
+    
+    i = 0;
+    do {
+        port = 1025 + (rand_r(&rand_seed) % 64510);
+        addr.sin_port = port;
+        
+        if (bind(s0, (struct sockaddr*)&addr, sizeof(addr)) != -1)
+            break;
+    } while (++i < 100);
+    
+    if (i >= 100) {
+        fprintf(stderr, "Can't find good port, bailing out\n");
+        exit(1);
+    }
+
+    ret = listen(s0, 128);
+    assert(ret != -1);
+    
+    signal_var(&server_thread_ready);
+    
+    client_fd = accept(s0, NULL, NULL);
+    assert(client_fd != -1);
+    
+    int flags = fcntl(client_fd, F_GETFL, 0);
+    fcntl(client_fd, F_SETFL, flags | O_NONBLOCK);
+    
+    prepare_sqe(&ring, client_fd, POLLIN | POLLHUP | POLLERR);
+    
+    ret = io_uring_submit(&ring);
+    assert(ret == 1);
+    
+    while (done < ECHO_COUNT) {
+        struct io_uring_cqe *cqe;
+        
+        if (io_uring_wait_cqe(&ring, &cqe)) {
+            fprintf(stderr, "server wait cqe failed\n");
+            exit(1);
+        }
+        
+        user_data = (uint64_t) io_uring_cqe_get_data(cqe);
+        fd = user_data & 0x00000000FFFFFFFF; // mask out the fd
+        poll_mask = user_data >> 32;         // and shift out the fd to get the poll_mask
+        
+        if (POLLIN & cqe->res) {
+            while ((ret = read(fd, readbuffer, 1)) > 0)
+            {
+                readbuffer[1]=0;
+                assert (ret == 1);
+                ret = write(fd, "S", 1);
+                assert(ret == 1);
+                done++;
+            }
+        }
+        
+        if (POLLHUP & cqe->res) {
+            printf("Server POLLHUP on [%d] [%d] [%ld]\n", fd, cqe->res, poll_mask);
+            exit(1);
+        }
+        if (POLLERR & cqe->res) {
+            printf("Server POLLERR fd [%d] [%d] [%ld]\n", fd, cqe->res, poll_mask);
+            exit(1);
+        }
+        
+        io_uring_cqe_seen(&ring, cqe);
+    }
+    
+    close(s0);
+    close(client_fd);
+    signal_var(&server_thread_done);
+    io_uring_queue_exit(&ring);
+    return NULL;
+}
+
+static void *client_thread(void *arg)
+{
+    struct io_uring ring;
+    struct io_uring_cqe *cqe;
+    int ret, done = 0;
+    int expecting_data = 0;
+    uint64_t user_data;
+    int fd;
+    uint64_t poll_mask;
+    char readbuffer[1024];
+    
+    wait_for_var(&server_thread_ready);
+    
+        // connect to server thread
+    int s0 = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    assert(s0 != -1);
+    
+    struct sockaddr_in addr;
+    addr.sin_family = AF_INET;
+    addr.sin_port = port;
+    addr.sin_addr.s_addr = 0x0100007fU;
+    
+    if (connect(s0, (struct sockaddr*)&addr, sizeof(addr)) == -1)
+    {
+        fprintf(stderr, "Failed to connect to 127.0.0.1:%d, aborting test.\n", port);
+        exit(1);
+    }
+        
+    // set up uring
+    ret = io_uring_queue_init(8, &ring, 0);
+    assert(ret == 0);
+    
+    prepare_sqe(&ring, s0, POLLOUT | POLLHUP | POLLERR); // POLLRDHUP
+    
+    ret = io_uring_submit(&ring);
+    assert(ret == 1);
+    
+    int flags = fcntl(s0, F_GETFL, 0);
+    fcntl(s0, F_SETFL, flags | O_NONBLOCK);
+    
+    while (!done)
+    {
+        if (io_uring_wait_cqe(&ring, &cqe)) {
+            fprintf(stderr, "wait cqe failed\n");
+        }
+        
+        user_data = (uint64_t) io_uring_cqe_get_data(cqe);
+        assert(user_data != 0);
+        fd = user_data & 0x00000000FFFFFFFF; // mask out the fd
+        poll_mask = user_data >> 32;         // and shift out the fd to get the poll_mask
+
+        if (cqe->res < 0)
+        {
+            printf("Client failed to change poll mask for fd [%d] [%d] [%ld]\n", fd, cqe->res, poll_mask);
+            exit(1);
+        }
+        assert(cqe->res >= 0);
+
+        if (POLLIN & cqe->res) {
+            while ((ret = read(fd, readbuffer, 1)) > 0)
+            {
+                readbuffer[1]=0;
+                assert (ret == 1);
+                if (!expecting_data) {
+                    printf("Client recevied unexpected POLLIN with data available\n");
+                    expecting_data++;
+                }
+            }
+
+            if (!expecting_data)
+            {
+                printf("Client recevied unexpected POLLIN with no data available\n");
+                exit(1);
+            }
+            expecting_data = 0; // we emptied the incoming data, so should have no more coming
+            switch_poll_mask(&ring, fd, poll_mask, (POLLOUT | POLLHUP | POLLERR));
+        }
+        
+        if (POLLOUT & cqe->res) {
+            if (expecting_data)
+            {
+                printf("Client recevied unexpected POLLOUT while expecting data\n");
+                exit(1);
+            }
+            ret = write(fd, "X", 1);
+            assert(ret == 1);
+            expecting_data = 1; // we emptied the incoming data, so should have no more coming
+            switch_poll_mask(&ring, fd, poll_mask, (POLLIN | POLLHUP | POLLERR));
+        }
+        
+        if (POLLHUP & cqe->res) {
+            done = 1;
+        }
+        
+        if (POLLERR & cqe->res) {
+            done = 1;
+        }
+        
+        io_uring_cqe_seen(&ring, cqe);
+    }
+    
+    close(s0);
+    io_uring_queue_exit(&ring);
+    wait_for_var(&server_thread_done);
+    
+    return 0;
+}
+
+static int start_threads()
+{
+    pthread_t t1, t2;
+    void *tret;
+    int ret = 0;
+    
+    server_thread_ready = 0;
+    server_thread_done = 0;
+    
+    pthread_create(&t1, NULL, server_thread, NULL);
+    pthread_create(&t2, NULL, client_thread, NULL);
+    
+    pthread_join(t1, &tret);
+    if (tret)
+        ret++;
+    
+    pthread_join(t2, &tret);
+    if (tret)
+        ret++;
+    
+    return ret;
+}
+
+int main(int argc, char *argv[])
+{
+    if (argc > 1)
+        return 0;
+    
+    return start_threads();
+}

--- a/test/poll-multiple-update.c
+++ b/test/poll-multiple-update.c
@@ -1,0 +1,156 @@
+/* SPDX-License-Identifier: MIT */
+//
+//  Test for multiple polls (ie. not oneshots).
+//
+//  Tests runs two threads and uses an eventfd to trigger uring.
+//
+//  t1 creates a ring and reaps events, t2 generates random wakeups with the eventfd.
+//
+
+
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <assert.h>
+#include <pthread.h>
+#include <sys/socket.h>
+#include <netinet/tcp.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/eventfd.h>
+
+#include "liburing.h"
+
+#define CLIENT_WAKEUPS 100
+
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+
+static int client_thread_ready = 0;
+static int client_thread_done = 0;
+static int event_fd = 0;
+
+static void signal_var(int *var)
+{
+        pthread_mutex_lock(&mutex);
+        *var = 1;
+        pthread_cond_signal(&cond);
+        pthread_mutex_unlock(&mutex);
+}
+
+static void wait_for_var(int *var)
+{
+        pthread_mutex_lock(&mutex);
+
+        while (!*var)
+                pthread_cond_wait(&cond, &mutex);
+
+        pthread_mutex_unlock(&mutex);
+}
+
+static void *client_thread(void *arg)
+{
+    struct io_uring_sqe *sqe;
+    struct io_uring ring;
+    struct io_uring_cqe *cqe;
+    int ret, done = 0;
+    uint64_t u;
+
+    ret = io_uring_queue_init(8, &ring, 0);
+    assert(ret == 0);
+
+    sqe = io_uring_get_sqe(&ring);
+    assert(sqe != NULL);
+
+    io_uring_prep_poll_add(sqe, event_fd, POLLIN);
+    sqe->len |= IORING_POLL_ADD_MULTI;
+
+    ret = io_uring_submit(&ring);
+    assert(ret == 1);
+
+    signal_var(&client_thread_ready);
+
+    while (!done)
+    {
+        if (io_uring_wait_cqe(&ring, &cqe)) {
+            fprintf(stderr, "wait cqe failed\n");
+        }
+        ret = read(event_fd, &u, sizeof(uint64_t));
+        if (ret == sizeof(uint64_t))
+        {
+            if (u == CLIENT_WAKEUPS)
+                done = 1;
+        }
+        else
+        {
+            assert (errno == EAGAIN);
+        }
+        io_uring_cqe_seen(&ring, cqe);
+    }
+    
+    io_uring_queue_exit(&ring);
+    signal_var(&client_thread_done);
+
+    return 0;
+}
+
+static void *wakeup_thread(void *arg)
+{
+    int res;
+    unsigned int rand_seed = getpid();
+    uint64_t u;
+
+    wait_for_var(&client_thread_ready);
+    
+    usleep((rand_r(&rand_seed) % 10000) * 100); // sleep up to 1s before starting
+    
+    for (u=1; u <= CLIENT_WAKEUPS; u++)
+    {
+        res = usleep((rand_r(&rand_seed) % 100) * 1000); // sleep up to 0.1s
+        assert(res != -1);
+        res = write(event_fd, &u, sizeof(uint64_t));
+        assert(res == sizeof(uint64_t));
+    }
+    
+    wait_for_var(&client_thread_done);
+
+    return 0;
+}
+
+static int start_threads()
+{
+    pthread_t t1, t2;
+    void *tret;
+    int ret = 0;
+
+    client_thread_ready = 0;
+    client_thread_done = 0;
+ 
+    pthread_create(&t1, NULL, client_thread, NULL);
+    pthread_create(&t2, NULL, wakeup_thread, NULL);
+    
+    pthread_join(t1, &tret);
+    if (tret)
+        ret++;
+
+    pthread_join(t2, &tret);
+    if (tret)
+        ret++;
+        
+    return ret;
+}
+
+int main(int argc, char *argv[])
+{
+    if (argc > 1)
+        return 0;
+    
+    event_fd = eventfd(0, O_CLOEXEC | EFD_NONBLOCK);
+
+    assert(event_fd != -1);
+
+    return start_threads();
+}

--- a/test/poll-update-failures.c
+++ b/test/poll-update-failures.c
@@ -1,0 +1,428 @@
+/* SPDX-License-Identifier: MIT */
+//
+//  Test for multiple polls (ie. not oneshots) and updates
+//  of polling masks to those.
+//
+//  t1 is the 'server' accepting and t2 is the 'client' connecting.
+//
+//  t1 will simply echo any data recieved, t2 will switch between POLLIN/POLLOUT.
+//
+//  This test explores failure conditions of modifications of pollmasks.
+//
+// First we run NUMBER_OF_EVENTS successfull modifications
+// followed by as many referencing invalid user data
+// followed by as many with a bad fd
+
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <assert.h>
+#include <pthread.h>
+#include <sys/socket.h>
+#include <netinet/tcp.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/eventfd.h>
+
+#include "liburing.h"
+
+#define NUMBER_OF_EVENTS 20 // number of events tested before next step
+
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+
+static int server_thread_ready = 0;
+static int server_thread_done = 0;
+static int port = 0; // protected by the mutex, will be set before server signals ready
+
+enum edge_states // error state we trigger
+{
+    NORMAL, // first run a handful successful modifications
+    TRIGGER_ENOENT,
+    TRIGGER_EBADF,
+    TRIGGER_EINVAL
+};
+
+static void signal_var(int *var)
+{
+    pthread_mutex_lock(&mutex);
+    *var = 1;
+    pthread_cond_broadcast(&cond);
+    pthread_mutex_unlock(&mutex);
+}
+
+static void wait_for_var(int *var)
+{
+    pthread_mutex_lock(&mutex);
+    
+    while (!*var)
+        pthread_cond_wait(&cond, &mutex);
+    
+    pthread_mutex_unlock(&mutex);
+}
+
+static void submit(struct io_uring *ring)
+{
+    int ret;
+    
+    while (io_uring_sq_ready(ring) > 0)
+    {
+        ret = io_uring_submit(ring);
+        assert ( ret >= 0);
+    }
+    
+    return;
+}
+
+static void add_poll_mask(struct io_uring *ring, int fd, uint64_t poll_mask)
+{
+    struct io_uring_sqe *sqe;
+    uint64_t bitpattern;
+    
+    sqe = io_uring_get_sqe(ring);
+    assert(sqe != NULL);
+    
+    bitpattern = (poll_mask << 32) + fd;
+    io_uring_prep_poll_add(sqe, fd, poll_mask);
+    io_uring_sqe_set_data(sqe, (void *) bitpattern);
+    sqe->len |= IORING_POLL_ADD_MULTI;
+
+    submit(ring);
+
+    return;
+}
+
+static struct io_uring_sqe *switch_poll_mask(struct io_uring *ring, int fd, uint64_t old_poll_mask, uint64_t new_poll_mask)
+{
+    struct io_uring_sqe *sqe;
+    uint64_t old_bitpattern, new_bitpattern;
+    
+    sqe = io_uring_get_sqe(ring);
+    assert(sqe != NULL);
+    
+    old_bitpattern = (old_poll_mask << 32) + fd;
+    new_bitpattern = (new_poll_mask << 32) + fd;
+    io_uring_prep_poll_add(sqe, fd, 0);
+    sqe->len |= IORING_POLL_ADD_MULTI;       // ask for multiple updates
+    sqe->len |= IORING_POLL_UPDATE_EVENTS;   // update existing mask
+    sqe->len |= IORING_POLL_UPDATE_USER_DATA;// and update user data
+    io_uring_sqe_set_data(sqe, (void *) old_bitpattern); // old user_data
+    sqe->addr = old_bitpattern; // old user_data
+    sqe->poll_events = new_poll_mask; // new poll mask
+    sqe->off = new_bitpattern; // new user_data
+    
+    return sqe;
+}
+
+static void invalid_switch_poll_mask(struct io_uring *ring, int fd)
+{
+    struct io_uring_sqe *sqe;
+    uint64_t pollmask = (POLLIN | POLLHUP | POLLERR);
+    
+    sqe = switch_poll_mask(ring, fd, pollmask, pollmask);
+    
+    // set some invalid stuff
+    sqe->ioprio = 1;
+    sqe->buf_index = 3;
+    return;
+}
+
+void *server_thread(void *arg)
+{
+    struct io_uring ring;
+    int i, ret, client_fd, s0, done = 0;
+    struct sockaddr_in addr;
+    unsigned int rand_seed = getpid();
+    char readbuffer[1024];
+    
+        // set up uring
+    ret = io_uring_queue_init(64, &ring, 0);
+    assert(ret == 0);
+    
+        // set up listening
+    s0 = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    assert(s0 != -1);
+    
+    int32_t val = 1;
+    ret = setsockopt(s0, SOL_SOCKET, SO_REUSEPORT, &val, sizeof(val));
+    assert(ret != -1);
+    ret = setsockopt(s0, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
+    assert(ret != -1);
+    
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = 0x0100007fU;
+    
+    i = 0;
+    do {
+        port = 1025 + (rand_r(&rand_seed) % 64510);
+        addr.sin_port = port;
+        
+        if (bind(s0, (struct sockaddr*)&addr, sizeof(addr)) != -1)
+            break;
+    } while (++i < 100);
+    
+    if (i >= 100) {
+        fprintf(stderr, "Can't find good port, bailing out\n");
+        exit(1);
+    }
+    
+    ret = listen(s0, 128);
+    assert(ret != -1);
+    
+    signal_var(&server_thread_ready);
+    
+    client_fd = accept(s0, NULL, NULL);
+    assert(client_fd != -1);
+    
+    int flags = fcntl(client_fd, F_GETFL, 0);
+    fcntl(client_fd, F_SETFL, flags | O_NONBLOCK);
+    
+    add_poll_mask(&ring, client_fd, POLLIN | POLLHUP | POLLERR);
+    
+    while (!done) {
+        struct io_uring_cqe *cqe;
+        
+        if (io_uring_wait_cqe(&ring, &cqe)) {
+            fprintf(stderr, "server wait cqe failed\n");
+            exit(1);
+        }
+        
+        if (POLLIN & cqe->res) {
+            while ((ret = read(client_fd, readbuffer, 1)) > 0)
+            {
+                readbuffer[1]=0;
+                assert (ret == 1);
+                ret = write(client_fd, "S", 1);
+                assert(ret == 1);
+            }
+        }
+        
+        if ((POLLERR | POLLHUP) & cqe->res) {
+            done = 1;
+        }
+                
+        io_uring_cqe_seen(&ring, cqe);
+    }
+    
+    close(s0);
+    close(client_fd);
+    signal_var(&server_thread_done);
+    io_uring_queue_exit(&ring);
+    return NULL;
+}
+
+static void *client_thread(void *arg)
+{
+    struct io_uring ring;
+    struct io_uring_cqe *cqe;
+    enum edge_states state = NORMAL;
+    int fd, ret, done = 0, expecting_data = 0, successful_events = 0;
+    uint64_t user_data, poll_mask;
+    char readbuffer[1024];
+    
+    wait_for_var(&server_thread_ready);
+    
+        // connect to server thread
+    int s0 = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    assert(s0 != -1);
+    
+    struct sockaddr_in addr;
+    addr.sin_family = AF_INET;
+    addr.sin_port = port;
+    addr.sin_addr.s_addr = 0x0100007fU;
+    
+    if (connect(s0, (struct sockaddr*)&addr, sizeof(addr)) == -1)
+    {
+        fprintf(stderr, "Failed to connect to 127.0.0.1:%d, aborting test.\n", port);
+        exit(1);
+    }
+    
+        // set up uring
+    ret = io_uring_queue_init(16, &ring, 0);
+    assert(ret == 0);
+    
+    add_poll_mask(&ring, s0, POLLOUT | POLLHUP | POLLERR); // POLLRDHUP
+    
+    int flags = fcntl(s0, F_GETFL, 0);
+    fcntl(s0, F_SETFL, flags | O_NONBLOCK);
+    
+    while (!done)
+    {
+        if (io_uring_wait_cqe(&ring, &cqe)) {
+            fprintf(stderr, "wait cqe failed\n");
+        }
+        
+        user_data = (uint64_t) io_uring_cqe_get_data(cqe);
+        assert(user_data != 0);
+        fd = user_data & 0x00000000FFFFFFFF; // mask out the fd
+        poll_mask = user_data >> 32;         // and shift out the fd to get the poll_mask
+        
+        if (cqe->res > 0) { // handle normal poll events, running some ping-pong
+            if (state == NORMAL)
+            {
+                if (POLLIN & cqe->res) {
+                    while ((ret = read(fd, readbuffer, 1)) > 0)
+                    {
+                        readbuffer[1]=0;
+                        assert (ret == 1);
+                        if (!expecting_data) {
+                            printf("Client recevied unexpected POLLIN with data available\n");
+                            expecting_data++;
+                        }
+                    }
+                    
+                    if (!expecting_data)
+                    {
+                        printf("Client recevied unexpected POLLIN with no data available\n");
+                        exit(1);
+                    }
+                    expecting_data = 0; // we emptied the incoming data, so should have no more coming
+                    (void) switch_poll_mask(&ring, fd, poll_mask, (POLLOUT | POLLHUP | POLLERR));
+                }
+                
+                if (POLLOUT & cqe->res) {
+                    if (expecting_data)
+                    {
+                        printf("Client recevied unexpected POLLOUT while expecting data\n");
+                        exit(1);
+                    }
+                    ret = write(fd, "X", 1);
+                    assert(ret == 1);
+                    expecting_data = 1; // we emptied the incoming data, so should have no more coming
+                    (void) switch_poll_mask(&ring, fd, poll_mask, (POLLIN | POLLHUP | POLLERR));
+                }
+                
+                if (POLLHUP & cqe->res) {
+                    done = 1;
+                }
+                
+                if (POLLERR & cqe->res) {
+                    done = 1;
+                }
+            }
+        } else { // handle failure modes (and success of modifications)
+            switch (cqe->res) {
+                case 0:
+                    if (state == NORMAL) {
+                        successful_events++;
+                        if (successful_events >= NUMBER_OF_EVENTS)
+                        {
+                            (void) switch_poll_mask(&ring, fd, 0x123456, 0x8910);
+                        }
+                    }
+                    break;
+                case -ENOENT:
+                    if (state == NORMAL) { // first
+                        successful_events = 0;
+                        state = TRIGGER_ENOENT;
+                    } else if (state != TRIGGER_ENOENT) {
+                        fprintf(stderr, "Unexpected state transition to ENOENT [%d], test failed.\n", state);
+                        exit(1);
+                    }
+                    if (state == TRIGGER_ENOENT) {
+                        successful_events++;
+                        if (successful_events >= NUMBER_OF_EVENTS)
+                        {
+                            (void) switch_poll_mask(&ring, -1, (POLLOUT | POLLHUP | POLLERR), (POLLIN | POLLHUP | POLLERR));
+                        } else {
+                            (void) switch_poll_mask(&ring, fd, 0x123456, 0x8910);
+                        }
+                    } else {
+                        fprintf(stderr, "Received -ENOENT unexpectedly, test failed.\n");
+                        exit(1);
+                    }
+                    break;
+                case -EBADF:
+                    if (state == TRIGGER_ENOENT)
+                    {
+                        successful_events = 0;
+                        state = TRIGGER_EBADF;
+                    } else if (state != TRIGGER_EBADF) {
+                        fprintf(stderr, "Unexpected state transition to EBADF [%d], test failed.\n", state);
+                        exit(1);
+                    }
+                    if (state == TRIGGER_EBADF) {
+                        successful_events++;
+                        if (successful_events >= NUMBER_OF_EVENTS)
+                        {
+                            invalid_switch_poll_mask(&ring, s0);
+                        } else {
+                            (void) switch_poll_mask(&ring, -1, (POLLOUT | POLLHUP | POLLERR), (POLLIN | POLLHUP | POLLERR));
+                        }
+                    } else {
+                        fprintf(stderr, "Received -EBADF unexpectedly, test failed. [%d] [%d] [%ld]\n", fd, cqe->res, poll_mask);
+                        exit(1);
+                    }
+                    break;
+                case -EINVAL:
+                    if (state == TRIGGER_EBADF) {
+                        state = TRIGGER_EINVAL;
+                        successful_events = 0;
+                    } else if (state != TRIGGER_EINVAL) {
+                        fprintf(stderr, "Unexpected state transition to EINVAL [%d], test failed.\n", state);
+                        exit(1);
+                    }
+                    if (state == TRIGGER_EINVAL) {
+                        successful_events++;
+                        if (successful_events >= NUMBER_OF_EVENTS)
+                        {
+                            done = 1;
+                        } else {
+                            invalid_switch_poll_mask(&ring, s0);
+                        }
+                    } else {
+                        fprintf(stderr, "Received -EINVAL unexpectedly, test failed.\n");
+                        exit(1);
+                    }
+                    break;
+                default:
+                    printf("Received unexpected failure for modifying poll mask fd [%d] cqe->res [%d] poll_mask [%ld], test failed.\n", fd, cqe->res, poll_mask);
+                    exit(1);
+                    break;
+            }
+        }
+        
+        io_uring_cqe_seen(&ring, cqe);
+        submit(&ring);
+    }
+    
+    close(s0);
+    io_uring_queue_exit(&ring);
+    wait_for_var(&server_thread_done);
+    
+    return 0;
+}
+
+static int start_threads()
+{
+    pthread_t t1, t2;
+    void *tret;
+    int ret = 0;
+    
+    server_thread_ready = 0;
+    server_thread_done = 0;
+    
+    pthread_create(&t1, NULL, server_thread, NULL);
+    pthread_create(&t2, NULL, client_thread, NULL);
+    
+    pthread_join(t1, &tret);
+    if (tret)
+        ret++;
+    
+    pthread_join(t2, &tret);
+    if (tret)
+        ret++;
+    
+    return ret;
+}
+
+int main(int argc, char *argv[])
+{
+    if (argc > 1)
+        return 0;
+    
+    return start_threads();
+}


### PR DESCRIPTION
The small set of tests for #310 merged to one package for easier integration.

One test with an eventfd and multishot poll usage (poll-multiple-update)
One test expecting a HUP after other side closes socket (poll-multiple-nohup)
One test with ping-pong updates of an existing multishot poll (poll-multiple-update-ping-pong)
One test which explores expected failures (ENOENT, EBADF and EINVAL).

These tests needs a new io_uring.h with
IORING_POLL_ADD_MULTI, IORING_POLL_UPDATE_EVENTS and IORING_POLL_UPDATE_USER_DATA.

Signed-off-by: Joakim Hassila <joj@mac.com>