### PR TITLE
man: Fix typo in man io_uring_queue_exit

### DIFF
--- a/man/io_uring_queue_exit.3
+++ b/man/io_uring_queue_exit.3
@@ -10,7 +10,7 @@ io_uring_queue_exit - tear down io_uring submission and completion queues
 .nf
 .BR "#include <liburing.h>"
 .PP
-.BI "int io_uring_queue_exit(struct io_uring *" ring );
+.BI "void io_uring_queue_exit(struct io_uring * ring );"
 .fi
 .PP
 .SH DESCRIPTION


### PR DESCRIPTION
Fixes #337, incorrect return result in the synopsis of man
io_uring_queue_exit, and misplaced quote.

Signed-off-by: Emmanuel Le Trong <emmanuel.le-trong@cnrs-orleans.fr>