### PR TITLE
debian/rules: add missing slash for relativelibdir

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -51,7 +51,7 @@ install-arch: check-arch
 	  DESTDIR=$(CURDIR)/debian/tmp \
 	  libdir=/lib/$(DEB_HOST_MULTIARCH) \
 	  libdevdir=/usr/lib/$(DEB_HOST_MULTIARCH) \
-	  relativelibdir=/lib/$(DEB_HOST_MULTIARCH)
+	  relativelibdir=/lib/$(DEB_HOST_MULTIARCH)/
 
 binary: binary-indep binary-arch
 


### PR DESCRIPTION
Otherwise the link created by
    ln -sf $(relativelibdir)$(libname) $(libdevdir)/liburing.so
during make install will be invalid.