### PR TITLE
Fix a bug due to the unreleased lock before function returns

### DIFF
--- a/test/ring-leak2.c
+++ b/test/ring-leak2.c
@@ -197,6 +197,7 @@ static void *client_thread(void *arg)
 					// connection closed or error
 					shutdown(conn_i.fd, SHUT_RDWR);
 				} else {
+					pthread_mutex_unlock(&lock);
 					break;
 				}
 				add_socket_pollin(&ring, conn_i.fd);


### PR DESCRIPTION
Fix a bug due to the unreleased lock before the function returns by inserting unlock statement before breaking.

Signed-off-by: Anson Lo ycaibb@gmail.com