### PR TITLE
Clarify information about error results

### DIFF
--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -944,7 +944,7 @@ They are described in section
 .B CQE ERRORS.
 .PP
 For read and write opcodes, the
-return values match those documented in the
+return values match errno values documented in the
 .BR preadv2 (2)
 and
 .BR pwritev2 (2)


### PR DESCRIPTION
One could (and did) interpret that cqe->res mathes the return *value* of preadv2 and pwritev2.
Clarify that it matches the errno values used by these two.