### PR TITLE
Add untracked test files to .gitignore and trivial memory leak fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,12 @@
 /test/timeout-overflow
 /test/unlink
 /test/wakeup-hang
+/test/multicqes_drain
+/test/poll-mshot-update
+/test/rsrc_tags
+/test/rw_merge_test
+/test/sqpoll-cancel-hang
+/test/testfile
 /test/*.dmesg
 
 config-host.h

--- a/test/file-update.c
+++ b/test/file-update.c
@@ -128,6 +128,7 @@ static int test_sqe_update(struct io_uring *ring)
 
 	ret = cqe->res;
 	io_uring_cqe_seen(ring, cqe);
+	free(fds);
 	if (ret == -EINVAL) {
 		fprintf(stdout, "IORING_OP_FILES_UPDATE not supported, skipping\n");
 		return 0;

--- a/test/fsync.c
+++ b/test/fsync.c
@@ -69,7 +69,7 @@ static int test_barrier_fsync(struct io_uring *ring)
 		return 1;
 	}
 
-	for (i = 0; i < 4; i++) {
+	for (i = 0; i < ARRAY_SIZE(iovecs); i++) {
 		iovecs[i].iov_base = t_malloc(4096);
 		iovecs[i].iov_len = 4096;
 	}
@@ -129,11 +129,16 @@ static int test_barrier_fsync(struct io_uring *ring)
 		io_uring_cqe_seen(ring, cqe);
 	}
 
-	unlink("testfile");
-	return 0;
+
+	ret = 0;
+	goto out;
 err:
+	ret = 1;
+out:
 	unlink("testfile");
-	return 1;
+	for (i = 0; i < ARRAY_SIZE(iovecs); i++)
+		free(iovecs[i].iov_base);
+	return ret;
 }
 
 #define FILE_SIZE 1024

--- a/test/helpers.h
+++ b/test/helpers.h
@@ -54,6 +54,8 @@ enum t_setup_ret t_create_ring_params(int depth, struct io_uring *ring,
 enum t_setup_ret t_create_ring(int depth, struct io_uring *ring,
 			       unsigned int flags);
 
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
```
Hi Jens,

After running the tests, we have these untracked files that shouldn't be
commited:
    test/multicqes_drain
    test/poll-mshot-update
    test/rsrc_tags
    test/rw_merge_test
    test/sqpoll-cancel-hang
    test/testfile

Add them to .gitignore. The rest commits are trivial memory leak fixes
for test. I also add a new helper macro `ARRAY_SIZE`.

-------
The following changes since commit 0ea4ccd1c0e4bb05cb4471d64e55d2e7d4e8a24c:

  src/queue: don't flush SQ ring for new wait interface (2021-08-08 21:44:48 -0600)

are available in the Git repository at:

  https://github.com/ammarfaizi2/liburing ammarfaizi2-liburing-dev

for you to fetch changes up to f0230dc3fcbd54d9a371553f84f97db8092556ce:

  test/file-update: clean up t_malloc() before return (2021-08-09 18:51:41 +0700)

----------------------------------------------------------------
Ammar Faizi (3):
      .gitignore: add several untracked test files
      test/fsync: clean up t_malloc() before return
      test/file-update: clean up t_malloc() before return

 .gitignore         |  6 ++++++
 test/file-update.c |  1 +
 test/fsync.c       | 13 +++++++++----
 test/helpers.h     |  2 ++
 4 files changed, 18 insertions(+), 4 deletions(-)
```