### PR TITLE
examples: disable ucontext-cp for elbrus (e2k) architecture

### DIFF
--- a/configure
+++ b/configure
@@ -327,6 +327,7 @@ int main(int argc, char **argv)
 {
   ucontext_t ctx;
   getcontext(&ctx);
+  makecontext(&ctx, NULL, 0);
   return 0;
 }
 EOF


### PR DESCRIPTION
Elbrus 2000 (aka e2k) is a 64-bit little-endian architecture. For several reasons it use makecontext_e2k(ctx, ...) with different semantic instead of makecontext(ctx, ...).