### PR TITLE
[GIT PULL] man: clean up spelling

### DIFF
--- a/man/io_uring.7
+++ b/man/io_uring.7
@@ -425,7 +425,7 @@ successful read and update of the head.
 Because of the shared ring buffers between kernel and user space,
 .B io_uring
 can be a zero-copy system.
-Copying buffers to and fro becomes necessary when system calls that
+Copying buffers to and from becomes necessary when system calls that
 transfer data between kernel and user space are involved.
 But since the bulk of the communication in 
 .B io_uring
@@ -435,7 +435,7 @@ this huge performance overhead is completely avoided.
 While system calls may not seem like a significant overhead,
 in high performance applications,
 making a lot of them will begin to matter.
-While workarounds the operating system has in place to deal with Specter
+While workarounds the operating system has in place to deal with Spectre
 and Meltdown are ideally best done away with,
 unfortunately,
 some of these workarounds are around the system call interface,

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -1061,7 +1061,7 @@ Used in conjunction with the
 command, which registers a pool of buffers to be used by commands that read
 or receive data. When buffers are registered for this use case, and this
 flag is set in the command, io_uring will grab a buffer from this pool when
-the request is ready to receive or read data. If succesful, the resulting CQE
+the request is ready to receive or read data. If successful, the resulting CQE
 will have
 .B IORING_CQE_F_BUFFER
 set in the flags part of the struct, and the upper
@@ -1189,7 +1189,7 @@ res
 holding the equivalent of
 .I -errno
 for error cases, or the transferred number of bytes in case the operation
-is succesful. Hence both error and success return can be found in that
+is successful. Hence both error and success return can be found in that
 field in the CQE. For other request types, the return values are documented
 in the matching man page for that type, or in the opcodes section above for
 io_uring-specific opcodes.

--- a/man/io_uring_register.2
+++ b/man/io_uring_register.2
@@ -228,7 +228,7 @@ wait for those to finish before proceeding. See
 for how to update an existing set without that limitation.
 
 Files are automatically unregistered when the io_uring instance is
-torn down. An application need only unregister if it wishes to
+torn down. An application needs only unregister if it wishes to
 register a new set of fds. Available since 5.1.
 
 .TP


### PR DESCRIPTION
Hi Jens,
Trivial man clean up from me before 2.1 release.
Please pull.
```
----------------------------------------------------------------
The following changes since commit bb75e12e9bb628b62c13149478035b37acd518b5:

  man/io_uring_enter.2: add notes about direct open/accept (2021-08-31 15:22:39 -0600)

are available in the Git repository at:

  https://github.com/ammarfaizi2/liburing man-page-fixes

for you to fetch changes up to 4c5987928e8df326e682c85e7deff557c0d0eebd:

  man: clean up spelling (2021-09-01 09:45:27 +0700)

----------------------------------------------------------------
Ammar Faizi (1):
      man: clean up spelling

 man/io_uring.7          | 4 ++--
 man/io_uring_enter.2    | 4 ++--
 man/io_uring_register.2 | 2 +-
 3 files changed, 5 insertions(+), 5 deletions(-)
```