### PR TITLE
build: add -D_GNU_SOURCE to all CPPFLAGS/CFLAGS.

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -2,7 +2,7 @@ CPPFLAGS ?=
 override CPPFLAGS += -D_GNU_SOURCE -I../src/include/
 CFLAGS ?= -g -O2
 XCFLAGS =
-override CFLAGS += -Wall -L../src/
+override CFLAGS += -D_GNU_SOURCE -Wall -L../src/
 
 include ../Makefile.quiet
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,9 +4,11 @@ libdir ?= $(prefix)/lib
 libdevdir ?= $(prefix)/lib
 
 CPPFLAGS ?=
-override CPPFLAGS += -Iinclude/ -include ../config-host.h
+override CPPFLAGS += -D_GNU_SOURCE \
+	-Iinclude/ -include ../config-host.h
 CFLAGS ?= -g -fomit-frame-pointer -O2
-override CFLAGS += -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare
+override CFLAGS += -D_GNU_SOURCE \
+	-Wall -Wextra -Wno-unused-parameter -Wno-sign-compare
 SO_CFLAGS=-fPIC $(CFLAGS)
 L_CFLAGS=$(CFLAGS)
 LINK_FLAGS=

--- a/test/Makefile
+++ b/test/Makefile
@@ -12,7 +12,8 @@ override CPPFLAGS += -D_GNU_SOURCE -D__SANE_USERSPACE_TYPES__ \
 	-I../src/include/ -include ../config-host.h
 CFLAGS ?= -g -O2
 XCFLAGS =
-override CFLAGS += -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare \
+override CFLAGS += -D_GNU_SOURCE \
+	-Wall -Wextra -Wno-unused-parameter -Wno-sign-compare \
 	-L../src/
 
 ifdef CONFIG_HAVE_STRINGOP_OVERFLOW


### PR DESCRIPTION
Closes #422 

Needed for e.g. musl libc which only includes entities like `cpu_set_t` if this is defined.