### PR TITLE
[RFC][GIT PULL] Use GitHub Actions as CI (build only)

### DIFF
--- a/.github/workflows/build_with_clang.yml
+++ b/.github/workflows/build_with_clang.yml
@@ -1,0 +1,32 @@
+name: Build with Clang
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+    
+jobs:
+  main:
+    name: Build with Clang
+    strategy:
+      fail-fast: false
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Toolchains
+      run: |
+        sudo apt install -y man git clang make && \
+        git --version && \
+        clang --version && \
+        clang++ --version && \
+        make --version;
+
+    - name: Build
+      run: |
+        make -j$(nproc) V=1 CFLAGS="-Werror" CPPFLAGS="-Werror" CXXFLAGS="-Werror" CC=clang CXX=clang++;
+
+    - name: Test install command
+      run: sudo make install;

--- a/.github/workflows/build_with_clang.yml
+++ b/.github/workflows/build_with_clang.yml
@@ -26,7 +26,12 @@ jobs:
 
     - name: Build
       run: |
-        make -j$(nproc) V=1 CFLAGS="-Werror" CPPFLAGS="-Werror" CXXFLAGS="-Werror" CC=clang CXX=clang++;
+        make -j$(nproc) V=1 \
+        CFLAGS="-Werror -Wno-unused-command-line-argument" \
+        CPPFLAGS="-Werror -Wno-unused-command-line-argument" \
+        CXXFLAGS="-Werror -Wno-unused-command-line-argument" \
+        CC=clang \
+        CXX=clang++;
 
     - name: Test install command
       run: sudo make install;

--- a/.github/workflows/build_with_gcc.yml
+++ b/.github/workflows/build_with_gcc.yml
@@ -1,0 +1,32 @@
+name: Build with GCC
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+    
+jobs:
+  main:
+    name: Build with GCC
+    strategy:
+      fail-fast: false
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Toolchains
+      run: |
+        sudo apt install -y man git gcc g++ make && \
+        git --version && \
+        gcc --version && \
+        g++ --version && \
+        make --version;
+
+    - name: Build
+      run: |
+        make -j$(nproc) V=1 CFLAGS="-Werror" CPPFLAGS="-Werror" CXXFLAGS="-Werror" CC=gcc CXX=g++;
+
+    - name: Test install command
+      run: sudo make install;


### PR DESCRIPTION
Hi Jens,

Following up about the CI in https://github.com/axboe/liburing/pull/425#issuecomment-914540396

I wired up the GitHub Actions CI. This will build the lib and tests. But it doesn't perform the `make runtests` due to kernel limitation reason.

There are 2 builds:
1) Build with GCC.
2) Build with Clang.

Both uses `CFLAGS="-Werror" CPPFLAGS="-Werror" CXXFLAGS="-Werror"` to make sure the build is totally clean from warnings.

Extra note:
There was very specific warning from clang that caused the build fail. It is fixed in commit 008ccce8858aa620315aba71e6d2b332dff5a39c ("build_with_clang.yml: fix clang build error -Wunused-command-line-argument").

The CI runs well on my fork repo, you can take a look here:
Build with Clang: https://github.com/ammarfaizi2/liburing/runs/3573032633
Build with GCC: https://github.com/ammarfaizi2/liburing/runs/3573032671

Please review. If you love it, please pull and remove the appveyor failing CI.

Adding Guillem to CC list..
Cc: @guillemj

```
----------------------------------------------------------------
The following changes since commit 8b087c441ed5f57e344b2ec1b26fcac42b42896a:

  test/runtests.sh: fix retrieving status (2021-09-10 10:17:31 -0600)

are available in the Git repository at:

  git://github.com/ammarfaizi2/liburing github-actions-ci

for you to fetch changes up to 008ccce8858aa620315aba71e6d2b332dff5a39c:

  build_with_clang.yml: fix clang build error -Wunused-command-line-argument (2021-09-11 09:45:55 +0700)

----------------------------------------------------------------
Ammar Faizi (3):
      .github/workflows: add build_with_gcc.yml
      .github/workflows: add build_with_clang.yml
      build_with_clang.yml: fix clang build error -Wunused-command-line-argument

 .github/workflows/build_with_clang.yml | 37 +++++++++++++++++++++++++++++++++++++
 .github/workflows/build_with_gcc.yml   | 32 ++++++++++++++++++++++++++++++++
 2 files changed, 69 insertions(+)
 create mode 100644 .github/workflows/build_with_clang.yml
 create mode 100644 .github/workflows/build_with_gcc.yml

```