### PR TITLE
[GIT PULL] Fix test shmem and extra small CI fix

### DIFF
--- a/.github/workflows/build_with_clang.yml
+++ b/.github/workflows/build_with_clang.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-    
+
 jobs:
   main:
     name: Build with Clang
@@ -18,7 +18,7 @@ jobs:
 
     - name: Install Toolchains
       run: |
-        sudo apt install -y man git clang make && \
+        sudo apt-get install -y man git clang make && \
         git --version && \
         clang --version && \
         clang++ --version && \

--- a/.github/workflows/build_with_gcc.yml
+++ b/.github/workflows/build_with_gcc.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-    
+
 jobs:
   main:
     name: Build with GCC
@@ -18,7 +18,7 @@ jobs:
 
     - name: Install Toolchains
       run: |
-        sudo apt install -y man git gcc g++ make && \
+        sudo apt-get install -y man git gcc g++ make && \
         git --version && \
         gcc --version && \
         g++ --version && \

--- a/configure
+++ b/configure
@@ -338,6 +338,23 @@ if compile_prog "" "" "has_ucontext"; then
 fi
 print_config "has_ucontext" "$has_ucontext"
 
+##########################################
+# check for memfd_create(2)
+has_memfd_create="no"
+cat > $TMPC << EOF
+#define _GNU_SOURCE
+#include <sys/mman.h>
+int main(int argc, char **argv)
+{
+  int memfd = memfd_create("test", 0);
+  return 0;
+}
+EOF
+if compile_prog "-Werror=implicit-function-declaration" "" "has_memfd_create"; then
+  has_memfd_create="yes"
+fi
+print_config "has_memfd_create" "$has_memfd_create"
+
 
 #############################################################################
 
@@ -364,6 +381,9 @@ if test "$stringop_overflow" = "yes"; then
 fi
 if test "$array_bounds" = "yes"; then
   output_sym "CONFIG_HAVE_ARRAY_BOUNDS"
+fi
+if test "$has_memfd_create" = "yes"; then
+  output_sym "CONFIG_HAVE_MEMFD_CREATE"
 fi
 
 echo "CC=$cc" >> $config_host_mak

--- a/test/io_uring_register.c
+++ b/test/io_uring_register.c
@@ -31,6 +31,17 @@ static int pagesize;
 static rlim_t mlock_limit;
 static int devnull;
 
+#if !defined(CONFIG_HAVE_MEMFD_CREATE)
+#include <sys/syscall.h>
+#include <linux/memfd.h>
+
+static int memfd_create(const char *name, unsigned int flags)
+{
+	return (int)syscall(SYS_memfd_create, name, flags);
+}
+#endif
+
+
 int
 expect_fail(int fd, unsigned int opcode, void *arg,
 	    unsigned int nr_args, int error)


### PR DESCRIPTION
Hi Jens,

Louvian reported that on some systems, glibc doesn't provide the wrapper
for `memfd_create(2)`. This pull request contains a fix for that and extra
small CI fix.

Compiler message:
```
  io_uring_register.c: In function 'test_shmem':
  io_uring_register.c:514:10: warning: implicit declaration of function 'memfd_create' [-Wimplicit-function-declaration]
    memfd = memfd_create("uring-shmem-test", 0);
            ^
```

Please pull.

Cc: @louvian
```
----------------------------------------------------------------
The following changes since commit 6401b3149ff49458cf4fd330d74ff22abd90cb07:

  Merge branch 'github-actions-ci' of https://github.com/ammarfaizi2/liburing (2021-09-10 21:25:21 -0600)

are available in the Git repository at:

  https://github.com/ammarfaizi2/liburing fix-test-shmem

for you to fetch changes up to cb57034d2ff203cc5dbfd91ac9f0f6b0c8a511bf:

  .github/workflows: fix apt warning (2021-09-11 14:16:56 +0700)

----------------------------------------------------------------
Ammar Faizi (2):
      test/io_uring_register: fix -Wimplicit-function-declaration of memfd_create
      .github/workflows: fix apt warning

 .github/workflows/build_with_clang.yml |  4 ++--
 .github/workflows/build_with_gcc.yml   |  4 ++--
 configure                              | 20 ++++++++++++++++++++
 test/io_uring_register.c               | 11 +++++++++++
 4 files changed, 35 insertions(+), 4 deletions(-)

```