### PR TITLE
[GIT PULL] .github/workflows/build.yml: add 32-bit build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,17 +27,26 @@ jobs:
 
     - name: Display compiler versions
       run: |
-        ${{matrix.cc}} --version
-        ${{matrix.cxx}} --version
+        ${{matrix.cc}} --version;
+        ${{matrix.cxx}} --version;
 
     - name: Build
       run: |
-        ./configure --cc=${{matrix.cc}} --cxx=${{matrix.cxx}}
+        ./configure --cc=${{matrix.cc}} --cxx=${{matrix.cxx}};
         make V=1 -j$(nproc) \
              CPPFLAGS="-Werror" \
              CFLAGS="$FLAGS" \
-             CXXFLAGS="$FLAGS"
+             CXXFLAGS="$FLAGS";
+
+    - name: Build (32 bit)
+      run: |
+        sudo apt-get install libc6-dev-i386 gcc-multilib g++-multilib -y;
+        make clean;
+        make V=1 -j$(nproc) \
+             CPPFLAGS="-Werror" \
+             CFLAGS="$FLAGS -m32" \
+             CXXFLAGS="$FLAGS -m32";
 
     - name: Test install command
       run: |
-        sudo make install
+        sudo make install;


### PR DESCRIPTION
Hi Jens,

Please pull 32-bit build for CI.
```
----------------------------------------------------------------
The following changes since commit d859ae0dd023dd37a12be30bfe0a7bca6dd4140a:

  test/file-verify: add provide buffers support for main test too (2021-09-16 12:04:29 -0600)

are available in the Git repository at:

  https://github.com/ammarfaizi2/liburing ci-add-32-bit-build

for you to fetch changes up to dd5b44c509c9833da8bd283c3857b41bfe8bafe8:

  .github/workflows/build.yml: add 32-bit build (2021-09-18 05:14:47 +0700)

----------------------------------------------------------------
Ammar Faizi (1):
      .github/workflows/build.yml: add 32-bit build

 .github/workflows/build.yml | 19 ++++++++++++++-----
 1 file changed, 14 insertions(+), 5 deletions(-)
```