### PR TITLE
Add CMakeLists.txt to project as build method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ config-host.mak
 config.log
 
 liburing.pc
+
+/.ccls-cache/
+/build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,90 @@
+cmake_minimum_required(VERSION 3.14)
+
+project("liburing")
+set(libname "uring")
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+############################
+## Add headers to library ##
+############################
+function(add_headers VAR dir)
+    set(headers ${${VAR}})
+    foreach (header ${ARGN})
+        set(headers ${headers} ${dir}/${header})
+    endforeach()
+    set(${VAR} ${headers} PARENT_SCOPE)
+endfunction()
+
+add_headers(
+    liburing_headers    # Variable name
+    src/include         # Directory to find headers
+    liburing.h
+    liburing/barrier.h
+    liburing/io_uring.h)
+
+file(GLOB liburing_sources src/*.c)
+# string(REPLACE ";" " " liburing_sources "${liburing_sources}")
+
+add_library("${libname}" ${liburing_sources} ${liburing_headers})
+
+target_include_directories(
+    "${libname}"
+    PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/include/>
+    $<INSTALL_INTERFACE:include>)
+
+# If we're building this project directly (rather than as a dependency), we
+# have to build tests
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+
+    # Run configure to generate config-host.h, if configure hasn't been run
+    if(NOT EXISTS "${PROJECT_SOURCE_DIR}/config-host.h")
+        execute_process(
+            COMMAND "${PROJECT_SOURCE_DIR}/configure"
+            WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")
+    endif()
+
+    include(CTest)
+
+    # Tests need to be linked against pthreads
+    set(THREADS_PREFER_PTHREAD_FLAG ON)
+    find_package(Threads REQUIRED)
+
+    set(liburing_test_flags
+        -include "${PROJECT_SOURCE_DIR}/config-host.h"
+        -g
+        -O2
+        -D_GNU_SOURCE
+        -D__SANE_USERSPACE_TYPES__
+        -Wall
+        -Wextra
+        -Wno-unused-parameter
+        -Wno-sign-compare
+        -Wstringop-overflow=0
+        -Warray-bounds=0)
+    file(GLOB liburing_tests "test/*.c")
+    # Remove the helpers.c, which doesn't contain a main
+    list(FILTER liburing_tests EXCLUDE REGEX "helpers.c")
+    foreach(test_file ${liburing_tests})
+
+        # Get the name of the target. This will be the file name, stripped of
+        # ".c" at the end.
+        get_filename_component(target ${test_file} NAME_WLE)
+
+        # Create an executable target for the test; add test/helpers.c as a source
+        add_executable(${target} ${test_file} test/helpers.c)
+
+        # Target liburing and pthreads
+        target_link_libraries(
+            ${target}
+            PRIVATE
+            ${libname}
+            Threads::Threads)
+
+        # Add additional compiler options and definitions
+        target_compile_options(${target} PRIVATE ${liburing_test_flags})
+
+        # Register the test with ctest
+        add_test(NAME "test-${target}" COMMAND "${target}")
+    endforeach()
+endif()


### PR DESCRIPTION
Hi! I created a CMakeLists.txt file for the project. It can build both the library itself and also the tests. This PR also enables running tests with *ctest*. Tests can now be built and run via:
```bash
cmake -B build
cmake --build build
cd build && ctest
```
Aside from support for ctest, including a CMakeLists.txt in the library allows it to be added as a dependency via the [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) interface, so that other projects build and link against *liburing* on supported kernel versions even if no system installation is present:
```cmake
# Example code illustrating how another project could automatically 
# link against liburing
FetchContent_Declare(
  liburing
  GIT_REPOSITORY https://github.com/axboe/liburing.git
  GIT_TAG        master)
FetchContent_MakeAvailable(liburing)
```
Having this can be useful on HPC systems or other shared clusters where getting a library approved for system-wide install is a difficult process. It also makes it easier for users to test and compare more recent versions of the library to an existing system installation.

Other features include:

- Out of source builds (like meson, although it's significantly less complex to support CMake, requiring only one file)
- Automatic generation of `compile_commands.json`, which is used by language servers like clangd, cquery, and ccls to enable automatic linting as well as to provide support for other features of modern IDEs. (This is placed in the build directory when generated, and isn't included in the project)
- The CMakeLists.txt file ***does not*** have to be updated if additional tests are added in `test/`. All .c files in the `test/` directory are added as tests, except for `helper.c`.

Please let me know if you have any questions or feedback, and I'll do my best to address them!