### PR TITLE
[GIT PULL] .github/workflows/build.yml: Add nolibc build x86-64 for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,10 +33,12 @@ jobs:
     - name: Build
       run: |
         ./configure --cc=${{matrix.cc}} --cxx=${{matrix.cxx}};
-        make V=1 -j$(nproc) \
-             CPPFLAGS="-Werror" \
-             CFLAGS="$FLAGS" \
-             CXXFLAGS="$FLAGS";
+        make -j$(nproc) V=1 CPPFLAGS="-Werror" CFLAGS="$FLAGS" CXXFLAGS="$FLAGS";
+
+    - name: Build nolibc x86-64
+      run: |
+        ./configure --cc=${{matrix.cc}} --cxx=${{matrix.cxx}} --nolibc;
+        make -j$(nproc) V=1 CPPFLAGS="-Werror" CFLAGS="$FLAGS" CXXFLAGS="$FLAGS";
 
     - name: Build (32 bit)
       run: |


### PR DESCRIPTION
Hi Jens,

Please pull one commit to add x86-64 nolibc build for CI from me.
v2: Rebased based on your master branch.

I didn't think it was wrong history, but I have just pushed a new branch, this should match with the history.
```
----------------------------------------------------------------
The following changes since commit c7d03dc2c123bc2ee85582d8f922acd268d6ac78:

  configure: Add `CONFIG_NOLIBC` variable and macro (2021-10-10 09:09:56 -0600)

are available in the Git repository at:

  https://github.com/ammarfaizi2/liburing add-ci-nolibc-x86-64

for you to fetch changes up to e4b1317c35684cd14cc21b5176ec39d56cbcc329:

  .github/workflows/build.yml: Add nolibc build x86-64 for CI (2021-10-11 08:41:58 +0700)

----------------------------------------------------------------
Ammar Faizi (1):
      .github/workflows/build.yml: Add nolibc build x86-64 for CI

 .github/workflows/build.yml | 10 ++++++----
 1 file changed, 6 insertions(+), 4 deletions(-)
```