### PR TITLE
man/io_uring_setup.2: add missing `wq_fd` field

### DIFF
--- a/man/io_uring_setup.2
+++ b/man/io_uring_setup.2
@@ -37,7 +37,8 @@ struct io_uring_params {
     __u32 sq_thread_cpu;
     __u32 sq_thread_idle;
     __u32 features;
-    __u32 resv[4];
+    __u32 wq_fd;
+    __u32 resv[3];
     struct io_sqring_offsets sq_off;
     struct io_cqring_offsets cq_off;
 };


### PR DESCRIPTION
Add missing `wq_fd` field for `struct io_uring_params`.

Fixes: https://github.com/axboe/liburing/issues/473
Signed-off-by: Luchen Yang <ylc991@163.com>


<!-- Explain your changes here... -->

----
## git request-pull output:
```
The following changes since commit bceaacc35f9e75469f6179d63436d67dc5bd47d0:

  test/Makefile: Refactor the Makefile (2021-10-31 16:30:00 -0600)

are available in the Git repository at:

  https://github.com/GalaxySnail/liburing pr1

for you to fetch changes up to b0f1f96823ae33648c267115989ea61f29d25e2c:

  man/io_uring_setup.2: add missing `wq_fd` field (2021-11-05 23:30:39 +0800)

----------------------------------------------------------------
GalaxySnail (1):
      man/io_uring_setup.2: add missing `wq_fd` field

 man/io_uring_setup.2 | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

Description should be word-wrapped at 72 chars. Some things should not
be word-wrapped. They may be some kind of quoted text - long compiler
error messages, oops reports, Link, etc. (things that have a certain
specific format).

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
