### PR TITLE
[GIT PULL] fix build error related to statx when using glibc >= 2.28 

### DIFF
--- a/configure
+++ b/configure
@@ -268,7 +268,6 @@ print_config "__kernel_timespec" "$__kernel_timespec"
 open_how="no"
 cat > $TMPC << EOF
 #include <sys/types.h>
-#include <sys/stat.h>
 #include <fcntl.h>
 #include <string.h>
 #include <linux/openat2.h>
@@ -307,6 +306,27 @@ if compile_prog "" "" "statx"; then
   statx="yes"
 fi
 print_config "statx" "$statx"
+
+##########################################
+# check for glibc statx
+glibc_statx="no"
+cat > $TMPC << EOF
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+#include <linux/stat.h>
+int main(int argc, char **argv)
+{
+  struct statx x;
+
+  return memset(&x, 0, sizeof(x)) != NULL;
+}
+EOF
+if compile_prog "" "" "glibc_statx"; then
+  glibc_statx="yes"
+fi
+print_config "glibc_statx" "$glibc_statx"
 
 ##########################################
 # check for C++
@@ -380,6 +400,9 @@ fi
 if test "$statx" = "yes"; then
   output_sym "CONFIG_HAVE_STATX"
 fi
+if test "$glibc_statx" = "yes"; then
+  output_sym "CONFIG_HAVE_GLIBC_STATX"
+fi
 if test "$has_cxx" = "yes"; then
   output_sym "CONFIG_HAVE_CXX"
 fi
@@ -445,6 +468,12 @@ struct open_how {
 EOF
 else cat >> $compat_h << EOF
 #include <linux/openat2.h>
+
+EOF
+fi
+if test "$glibc_statx" = "no" && "$statx" = "yes"; then
+cat >> $compat_h << EOF
+#include <sys/stat.h>
 
 EOF
 fi

--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -8,7 +8,6 @@
 
 #include <sys/socket.h>
 #include <sys/uio.h>
-#include <sys/stat.h>
 #include <errno.h>
 #include <signal.h>
 #include <stdbool.h>

--- a/test/Makefile
+++ b/test/Makefile
@@ -157,6 +157,10 @@ include ../Makefile.quiet
 ifdef CONFIG_HAVE_STATX
 	test_srcs += statx.c
 endif
+
+ifdef CONFIG_HAVE_GLIBC_STATX
+	test_srcs += statx.c
+endif
 all_targets += statx
 
 

--- a/test/file-verify.c
+++ b/test/file-verify.c
@@ -12,6 +12,7 @@
 #include <assert.h>
 #include <string.h>
 #include <sys/ioctl.h>
+#include <sys/stat.h>
 #include <linux/fs.h>
 
 #include "helpers.h"

--- a/test/rename.c
+++ b/test/rename.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 
 #include "liburing.h"
 

--- a/test/unlink.c
+++ b/test/unlink.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 
 #include "liburing.h"
 


### PR DESCRIPTION
fix build error related to statx when using glibc >= 2.28 
## git request-pull output:
```
The following changes since commit a0039bd99910b3a9e28c8c70a52cadbd69e7c0f0:

  Merge branch 'unused-var-man' of https://github.com/yinan1048576/liburing (2021-11-12 09:29:24 -0700)

are available in the Git repository at:

  origin/glibc-statx

for you to fetch changes up to 986ca17139c5dc1678256ae252d3c204881557bb:

  fix 'make' when using glibc >= 2.28 (2021-11-12 17:28:32 +0000)

----------------------------------------------------------------
Bikal Lem (1):
      fix 'make' when using glibc >= 2.28

 configure              | 31 ++++++++++++++++++++++++++++++-
 src/include/liburing.h |  1 -
 test/Makefile          |  6 +++++-
 3 files changed, 35 insertions(+), 3 deletions(-)
```