### PR TITLE
fix 'make runtests`

### DIFF
--- a/test/runtests-loop.sh
+++ b/test/runtests-loop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TESTS=("$@")
 ITER=0

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TESTS=("$@")
 RET=0


### PR DESCRIPTION
fixes `make runtests`.

## git request-pull output:
```
The following changes since commit 28e631994a6770072b833e27ec0f2f75b29de305:

  Merge branch 'glibc-statx' of https://github.com/bikallem/liburing (2021-11-12 11:26:54 -0700)

are available in the Git repository at:

  origin/fix-make-tests

for you to fetch changes up to 17c23393b6367e40c04299a9d67e4cab65273e66:

  fix 'make runtests` (2021-11-12 18:37:12 +0000)

----------------------------------------------------------------
Bikal Lem (1):
      fix 'make runtests`

 test/runtests-loop.sh | 2 +-
 test/runtests.sh      | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```