### PR TITLE
[GIT PULL] src/Makefile: use VERSION variable consistently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
-NAME=liburing
-SPECFILE=$(NAME).spec
-VERSION=$(shell awk '/Version:/ { print $$2 }' $(SPECFILE))
-TAG = $(NAME)-$(VERSION)
+include Makefile.common
+
 RPMBUILD=$(shell `which rpmbuild >&/dev/null` && echo "rpmbuild" || echo "rpm")
 
 INSTALL=install

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,0 +1,5 @@
+TOP := $(dir $(CURDIR)/$(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST)))
+NAME=liburing
+SPECFILE=$(TOP)/$(NAME).spec
+VERSION=$(shell awk '/Version:/ { print $$2 }' $(SPECFILE))
+TAG = $(NAME)-$(VERSION)

--- a/liburing.spec
+++ b/liburing.spec
@@ -1,5 +1,5 @@
 Name: liburing
-Version: 2.1
+Version: 2.2
 Release: 1%{?dist}
 Summary: Linux-native io_uring I/O access library
 License: (GPLv2 with exceptions and LGPLv2+) or MIT

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,3 +1,5 @@
+include ../Makefile.common
+
 prefix ?= /usr
 includedir ?= $(prefix)/include
 libdir ?= $(prefix)/lib
@@ -14,10 +16,8 @@ LINK_FLAGS=
 LINK_FLAGS+=$(LDFLAGS)
 ENABLE_SHARED ?= 1
 
-soname=liburing.so.2
-minor=1
-micro=0
-libname=$(soname).$(minor).$(micro)
+soname=liburing.so
+libname=$(soname).$(VERSION)
 all_targets += liburing.a
 
 ifeq ($(ENABLE_SHARED),1)


### PR DESCRIPTION
This PR ensures that we use VERSION variable consistently and correctly in Makefiles.

## git request-pull output:
```
The following changes since commit b7159e46bc002c7a174e184d94cfa61552f92e69:

  Merge branch 'fix-make-tests' of https://github.com/bikallem/liburing (2021-11-12 11:51:45 -0700)

are available in the Git repository at:

  origin/version

for you to fetch changes up to c0b43df28a982747e081343f23289357ab4615db:

  src/Makefile: use VERSION variable consistently (2021-11-15 13:09:30 +0000)

----------------------------------------------------------------
Bikal Lem (1):
      src/Makefile: use VERSION variable consistently

 Makefile        | 6 ++----
 Makefile.common | 5 +++++
 liburing.spec   | 2 +-
 src/Makefile    | 8 ++++----
 4 files changed, 12 insertions(+), 9 deletions(-)
 create mode 100644 Makefile.common
```