### PR TITLE
[WIP][GIT PULL] Always use `-fpic -fPIC` flag for nolibc build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -36,9 +36,9 @@ liburing_srcs := setup.c queue.c register.c
 
 ifeq ($(CONFIG_NOLIBC),y)
 	liburing_srcs += nolibc.c
-	override CFLAGS += -nostdlib -nodefaultlibs -ffreestanding -fno-stack-protector
-	override CPPFLAGS += -nostdlib -nodefaultlibs -ffreestanding -fno-stack-protector
-	override LINK_FLAGS += -nostdlib -nodefaultlibs
+	override CFLAGS += -fpic -fPIC -nostdlib -nodefaultlibs -ffreestanding -fno-stack-protector
+	override CPPFLAGS += -fpic -fPIC -nostdlib -nodefaultlibs -ffreestanding -fno-stack-protector
+	override LINK_FLAGS += -fpic -fPIC -nostdlib -nodefaultlibs
 else
 	liburing_srcs += syscall.c
 endif


### PR DESCRIPTION
Hi Jens,

This PR only contains 1 commit from me.

Bob reports linking time error for nolibc build:
```
  relocation R_X86_64_PC32 against symbol `memset' can not be \
  used when making a shared object; recompile with -fPIC
```
When we statically link liburing.a into a shared object, we need to
make sure it's built with `-fpic -fPIC` flag.

Note:
liburing.a can be used to create a new shared object (*.so) or a
non shared object ELF. When we use it to create a shared object,
it needs to be compiled with the above flag.

Always using this flag for nolibc build even if the target is not
a shared object ELF is still fine.

Link: https://github.com/axboe/liburing/issues/443#issuecomment-975493681
Fixes: c7d03dc2c123bc2ee85582d8f922acd268d6ac78 ("configure: Add `CONFIG_NOLIBC` variable and macro")
Fixes: f48ee3168cdc325233825603269f304d348d323c ("Add nolibc build support")
```
Reported-by: Bob Chen <beef9999@qq.com>
Tested-by: Bob Chen <beef9999@qq.com>
Signed-off-by: Ammar Faizi <ammarfaizi2@gmail.com>
```
Cc: @beef9999

----
## git request-pull output:
```
The following changes since commit df9a741895028204b130b6cbe03c5c3dda3cf1a9:

  Rename man page (2021-11-18 07:27:17 -0700)

are available in the Git repository at:

  https://github.com/ammarfaizi2/liburing tags/pic-issue-nolibc

for you to fetch changes up to bfb8975dda09f39d9f947f7b431f3dc01cb74b78:

  src/Makefile: Always use `-fpic -fPIC` flag for nolibc build (2021-11-23 16:23:40 +0700)

----------------------------------------------------------------
pic-issue-nolibc

----------------------------------------------------------------
Ammar Faizi (1):
      src/Makefile: Always use `-fpic -fPIC` flag for nolibc build

 src/Makefile | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```
----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
