### PR TITLE
liburing.h: Prevent unwanted addr 32bit truncations.

### DIFF
--- a/examples/io_uring-cp.c
+++ b/examples/io_uring-cp.c
@@ -74,7 +74,7 @@ static void queue_prepped(struct io_uring *ring, struct io_data *data)
 	else
 		io_uring_prep_writev(sqe, outfd, &data->iov, 1, data->offset);
 
-	io_uring_sqe_set_data(sqe, data);
+	io_uring_sqe_set_data(sqe, (__u64) (uintptr_t) data);
 }
 
 static int queue_read(struct io_uring *ring, off_t size, off_t offset)
@@ -100,7 +100,7 @@ static int queue_read(struct io_uring *ring, off_t size, off_t offset)
 	data->first_len = size;
 
 	io_uring_prep_readv(sqe, infd, &data->iov, 1, offset);
-	io_uring_sqe_set_data(sqe, data);
+	io_uring_sqe_set_data(sqe, (__u64) (uintptr_t) data);
 	return 0;
 }
 
@@ -185,7 +185,7 @@ static int copy_file(struct io_uring *ring, off_t insize)
 			if (!cqe)
 				break;
 
-			data = io_uring_cqe_get_data(cqe);
+			data = (void *) (uintptr_t) io_uring_cqe_get_data(cqe);
 			if (cqe->res < 0) {
 				if (cqe->res == -EAGAIN) {
 					queue_prepped(ring, data);
@@ -235,7 +235,7 @@ static int copy_file(struct io_uring *ring, off_t insize)
 			fprintf(stderr, "write res=%d\n", cqe->res);
 			return 1;
 		}
-		data = io_uring_cqe_get_data(cqe);
+		data = (void *) (uintptr_t) io_uring_cqe_get_data(cqe);
 		free(data);
 		writes--;
 		io_uring_cqe_seen(ring, cqe);

--- a/examples/link-cp.c
+++ b/examples/link-cp.c
@@ -79,16 +79,16 @@ static void queue_rw_pair(struct io_uring *ring, off_t size, off_t offset)
 	sqe = io_uring_get_sqe(ring);
 	io_uring_prep_readv(sqe, infd, &data->iov, 1, offset);
 	sqe->flags |= IOSQE_IO_LINK;
-	io_uring_sqe_set_data(sqe, data);
+	io_uring_sqe_set_data(sqe, (__u64) (uintptr_t) data);
 
 	sqe = io_uring_get_sqe(ring);
 	io_uring_prep_writev(sqe, outfd, &data->iov, 1, offset);
-	io_uring_sqe_set_data(sqe, data);
+	io_uring_sqe_set_data(sqe, (__u64) (uintptr_t) data);
 }
 
 static int handle_cqe(struct io_uring *ring, struct io_uring_cqe *cqe)
 {
-	struct io_data *data = io_uring_cqe_get_data(cqe);
+	struct io_data *data = (void *) (uintptr_t) io_uring_cqe_get_data(cqe);
 	int ret = 0;
 
 	data->index++;

--- a/test/accept.c
+++ b/test/accept.c
@@ -329,7 +329,7 @@ static int test_accept_cancel(unsigned usecs)
 		usleep(usecs);
 
 	sqe = io_uring_get_sqe(&m_io_uring);
-	io_uring_prep_cancel(sqe, (void *) 1, 0);
+	io_uring_prep_cancel(sqe, 1, 0);
 	sqe->user_data = 2;
 	ret = io_uring_submit(&m_io_uring);
 	assert(ret == 1);

--- a/test/d77a67ed5f27-test.c
+++ b/test/d77a67ed5f27-test.c
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
 	}
 
 	io_uring_prep_nop(sqe);
-	io_uring_sqe_set_data(sqe, (void *) (unsigned long) 42);
+	io_uring_sqe_set_data(sqe, 42);
 	io_uring_submit_and_wait(&ring, 1);
 
 	ret = io_uring_peek_cqe(&ring, &cqe);

--- a/test/fixed-link.c
+++ b/test/fixed-link.c
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
 		io_uring_prep_read_fixed(sqe, fd, iovecs[i].iov_base, strlen(str), 0, i);
 		if (i == 0)
 			io_uring_sqe_set_flags(sqe, IOSQE_IO_LINK);
-		io_uring_sqe_set_data(sqe, (void *)str);
+		io_uring_sqe_set_data(sqe, (__u64) (uintptr_t) str);
 	}
 
 	ret = io_uring_submit_and_wait(&ring, IOVECS_LEN);

--- a/test/io-cancel.c
+++ b/test/io-cancel.c
@@ -128,7 +128,7 @@ static int start_cancel(struct io_uring *ring, int do_partial, int async_cancel)
 			fprintf(stderr, "sqe get failed\n");
 			goto err;
 		}
-		io_uring_prep_cancel(sqe, (void *) (unsigned long) i + 1, 0);
+		io_uring_prep_cancel(sqe, i + 1, 0);
 		if (async_cancel)
 			sqe->flags |= IOSQE_ASYNC;
 		sqe->user_data = 0;
@@ -246,7 +246,7 @@ static int test_dont_cancel_another_ring(void)
 		fprintf(stderr, "%s: failed to get sqe\n", __FUNCTION__);
 		return 1;
 	}
-	io_uring_prep_cancel(sqe, (void *) (unsigned long)1, 0);
+	io_uring_prep_cancel(sqe, 1, 0);
 	sqe->user_data = 2;
 
 	ret = io_uring_submit(&ring2);
@@ -326,7 +326,7 @@ static int test_cancel_req_across_fork(void)
 			fprintf(stderr, "%s: failed to get sqe\n", __FUNCTION__);
 			return 1;
 		}
-		io_uring_prep_cancel(sqe, (void *) (unsigned long)1, 0);
+		io_uring_prep_cancel(sqe, 1, 0);
 		sqe->user_data = 2;
 
 		ret = io_uring_submit(&ring);

--- a/test/io_uring_enter.c
+++ b/test/io_uring_enter.c
@@ -135,7 +135,7 @@ io_prep_read(struct io_uring_sqe *sqe, int fd, off_t offset, size_t len)
 	iov->iov_len = len;
 
 	io_uring_prep_readv(sqe, fd, iov, 1, offset);
-	io_uring_sqe_set_data(sqe, iov); // free on completion
+	io_uring_sqe_set_data(sqe, (__u64) (uintptr_t) iov); // free on completion
 }
 
 void
@@ -158,7 +158,7 @@ reap_events(struct io_uring *ring, unsigned nr)
 		}
 		if (cqe->res != 4096)
 			printf("cqe->res: %d, expected 4096\n", cqe->res);
-		iov = io_uring_cqe_get_data(cqe);
+		iov = (void *) (uintptr_t) io_uring_cqe_get_data(cqe);
 		free(iov->iov_base);
 		free(iov);
 		left--;

--- a/test/multicqes_drain.c
+++ b/test/multicqes_drain.c
@@ -91,7 +91,7 @@ void io_uring_sqe_prep(int op, struct io_uring_sqe *sqe, unsigned sqe_flags, int
 			io_uring_prep_nop(sqe);
 			break;
 		case cancel:
-			io_uring_prep_poll_remove(sqe, (void *)(long)arg);
+			io_uring_prep_poll_remove(sqe, arg);
 			break;
 	}
 	sqe->flags = sqe_flags;

--- a/test/poll-cancel-ton.c
+++ b/test/poll-cancel-ton.c
@@ -51,10 +51,10 @@ static int del_polls(struct io_uring *ring, int fd, int nr)
 			batch = nr;
 
 		for (i = 0; i < batch; i++) {
-			void *data;
+			__u64 data;
 
 			sqe = io_uring_get_sqe(ring);
-			data = sqe_index[lrand48() % nr];
+			data = (__u64) (uintptr_t) sqe_index[lrand48() % nr];
 			io_uring_prep_poll_remove(sqe, data);
 		}
 
@@ -84,7 +84,7 @@ static int add_polls(struct io_uring *ring, int fd, int nr)
 			sqe = io_uring_get_sqe(ring);
 			io_uring_prep_poll_add(sqe, fd, POLLIN);
 			sqe_index[count++] = sqe;
-			sqe->user_data = (unsigned long) sqe;
+			sqe->user_data = (__u64) (uintptr_t) sqe;
 		}
 
 		ret = io_uring_submit(ring);

--- a/test/poll-cancel.c
+++ b/test/poll-cancel.c
@@ -63,7 +63,7 @@ static int test_poll_cancel(void)
 
 	pds[0].is_poll = 1;
 	pds[0].is_cancel = 0;
-	io_uring_sqe_set_data(sqe, &pds[0]);
+	io_uring_sqe_set_data(sqe, (__u64) (uintptr_t) &pds[0]);
 
 	ret = io_uring_submit(&ring);
 	if (ret <= 0) {
@@ -79,8 +79,8 @@ static int test_poll_cancel(void)
 
 	pds[1].is_poll = 0;
 	pds[1].is_cancel = 1;
-	io_uring_prep_poll_remove(sqe, &pds[0]);
-	io_uring_sqe_set_data(sqe, &pds[1]);
+	io_uring_prep_poll_remove(sqe, (__u64) (uintptr_t) &pds[0]);
+	io_uring_sqe_set_data(sqe, (__u64) (uintptr_t) &pds[1]);
 
 	ret = io_uring_submit(&ring);
 	if (ret <= 0) {
@@ -94,7 +94,7 @@ static int test_poll_cancel(void)
 		return 1;
 	}
 
-	pd = io_uring_cqe_get_data(cqe);
+	pd = (void *) (uintptr_t) io_uring_cqe_get_data(cqe);
 	if (pd->is_poll && cqe->res != -ECANCELED) {
 		fprintf(stderr ,"sqe (add=%d/remove=%d) failed with %ld\n",
 					pd->is_poll, pd->is_cancel,
@@ -114,7 +114,7 @@ static int test_poll_cancel(void)
 		return 1;
 	}
 
-	pd = io_uring_cqe_get_data(cqe);
+	pd = (void *) (uintptr_t) io_uring_cqe_get_data(cqe);
 	if (pd->is_poll && cqe->res != -ECANCELED) {
 		fprintf(stderr, "sqe (add=%d/remove=%d) failed with %ld\n",
 					pd->is_poll, pd->is_cancel,

--- a/test/poll-mshot-update.c
+++ b/test/poll-mshot-update.c
@@ -42,7 +42,7 @@ static int has_poll_update(void)
 		return -1;
 
 	sqe = io_uring_get_sqe(&ring);
-	io_uring_prep_poll_update(sqe, NULL, NULL, POLLIN, IORING_TIMEOUT_UPDATE);
+	io_uring_prep_poll_update(sqe, 0, 0, POLLIN, IORING_TIMEOUT_UPDATE);
 
 	ret = io_uring_submit(&ring);
 	if (ret != 1)
@@ -86,8 +86,7 @@ static int reap_polls(struct io_uring *ring)
 
 		sqe = io_uring_get_sqe(ring);
 		/* update event */
-		io_uring_prep_poll_update(sqe, (void *)(unsigned long)i, NULL,
-					  POLLIN, IORING_POLL_UPDATE_EVENTS);
+		io_uring_prep_poll_update(sqe, i, 0, POLLIN, IORING_POLL_UPDATE_EVENTS);
 		sqe->user_data = 0x12345678;
 	}
 

--- a/test/poll-ring.c
+++ b/test/poll-ring.c
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
 	}
 
 	io_uring_prep_poll_add(sqe, ring.ring_fd, POLLIN);
-	io_uring_sqe_set_data(sqe, sqe);
+	io_uring_sqe_set_data(sqe, (__u64) (uintptr_t) sqe);
 
 	ret = io_uring_submit(&ring);
 	if (ret <= 0) {

--- a/test/poll.c
+++ b/test/poll.c
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
 		}
 
 		io_uring_prep_poll_add(sqe, pipe1[0], POLLIN);
-		io_uring_sqe_set_data(sqe, sqe);
+		io_uring_sqe_set_data(sqe, (__u64) (uintptr_t) sqe);
 
 		ret = io_uring_submit(&ring);
 		if (ret <= 0) {

--- a/test/timeout-overflow.c
+++ b/test/timeout-overflow.c
@@ -121,7 +121,7 @@ static int test_timeout_overflow(void)
 	for (i = 0; i < 2; i++) {
 		sqe = io_uring_get_sqe(&ring);
 		io_uring_prep_nop(sqe);
-		io_uring_sqe_set_data(sqe, (void *) 1);
+		io_uring_sqe_set_data(sqe, 1);
 	}
 	ret = io_uring_submit(&ring);
 	if (ret < 0) {
@@ -147,7 +147,7 @@ static int test_timeout_overflow(void)
 		switch (i) {
 		case 0:
 		case 3:
-			if (io_uring_cqe_get_data(cqe) != (void *) 1) {
+			if (io_uring_cqe_get_data(cqe) != 1) {
 				fprintf(stderr, "nop not seen as 1 or 2\n");
 				goto err;
 			}

--- a/test/timeout.c
+++ b/test/timeout.c
@@ -133,10 +133,10 @@ static int test_single_timeout_nr(struct io_uring *ring, int nr)
 
 	sqe = io_uring_get_sqe(ring);
 	io_uring_prep_nop(sqe);
-	io_uring_sqe_set_data(sqe, (void *) 1);
+	io_uring_sqe_set_data(sqe, 1);
 	sqe = io_uring_get_sqe(ring);
 	io_uring_prep_nop(sqe);
-	io_uring_sqe_set_data(sqe, (void *) 1);
+	io_uring_sqe_set_data(sqe, 1);
 
 	ret = io_uring_submit_and_wait(ring, 3);
 	if (ret <= 0) {
@@ -158,7 +158,7 @@ static int test_single_timeout_nr(struct io_uring *ring, int nr)
 		 * NOP commands have user_data as 1. Check that we get the
 		 * at least 'nr' NOPs first, then the successfully removed timout.
 		 */
-		if (io_uring_cqe_get_data(cqe) == NULL) {
+		if (!io_uring_cqe_get_data(cqe)) {
 			if (i < nr) {
 				fprintf(stderr, "%s: timeout received too early\n", __FUNCTION__);
 				goto err;
@@ -193,11 +193,11 @@ static int test_single_timeout_wait(struct io_uring *ring,
 
 	sqe = io_uring_get_sqe(ring);
 	io_uring_prep_nop(sqe);
-	io_uring_sqe_set_data(sqe, (void *) 1);
+	io_uring_sqe_set_data(sqe, 1);
 
 	sqe = io_uring_get_sqe(ring);
 	io_uring_prep_nop(sqe);
-	io_uring_sqe_set_data(sqe, (void *) 1);
+	io_uring_sqe_set_data(sqe, 1);
 
 	/* no implied submit for newer kernels */
 	if (p->features & IORING_FEAT_EXT_ARG) {
@@ -648,7 +648,7 @@ static int test_multi_timeout_nr(struct io_uring *ring)
 		goto err;
 	}
 	io_uring_prep_nop(sqe);
-	io_uring_sqe_set_data(sqe, (void *) 1);
+	io_uring_sqe_set_data(sqe, 1);
 
 	ret = io_uring_submit(ring);
 	if (ret <= 0) {
@@ -670,7 +670,7 @@ static int test_multi_timeout_nr(struct io_uring *ring)
 		switch (i) {
 		case 0:
 			/* Should be nop req */
-			if (io_uring_cqe_get_data(cqe) != (void *) 1) {
+			if (io_uring_cqe_get_data(cqe) != 1) {
 				fprintf(stderr, "%s: nop not seen as 1 or 2\n", __FUNCTION__);
 				goto err;
 			}


### PR DESCRIPTION
The addr field is used by several operations to match against a previous user_data field. Using void * for the io_uring_prep_rw parameter type causes undesired 32bit truncation when building the library for 32bit architecture and may fail to match a previously set 64bit user_data.

I think something like that should be done to fix https://github.com/axboe/liburing/issues/490