### PR TITLE
[GIT PULL] configure: fix statx configure and build on !CONFIG_HAVE_STATX toolchains

### DIFF
--- a/configure
+++ b/configure
@@ -471,7 +471,7 @@ else cat >> $compat_h << EOF
 
 EOF
 fi
-if test "$glibc_statx" = "no" && "$statx" = "yes"; then
+if [ "$glibc_statx" = "no" ] && [ "$statx" = "yes" ]; then
 cat >> $compat_h << EOF
 #include <sys/stat.h>
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -138,7 +138,6 @@ test_srcs := \
 	sq-poll-share.c \
 	sqpoll-sleep.c \
 	sq-space_left.c \
-	statx.c \
 	stdout.c \
 	submit-link-fail.c \
 	submit-reuse.c \


### PR DESCRIPTION
Update configure and test/Makefile, such that if !CONFIG_HAVE_STATX will
not generate statx.c test. Without this patch, liburing fails to compile
on an older toolchain that does not have statx available.

Fixes: #516

Signed-off-by: Jon Kohler <jon@nutanix.com>
