### PR TITLE
[GIT PULL] Fix madvise syscall wrapper

### DIFF
--- a/src/arch/x86/syscall.h
+++ b/src/arch/x86/syscall.h
@@ -154,7 +154,7 @@ static inline int __sys_munmap(void *addr, size_t length)
 
 static inline int __sys_madvise(void *addr, size_t length, int advice)
 {
-	return (int) __do_syscall2(__NR_madvise, addr, length);
+	return (int) __do_syscall3(__NR_madvise, addr, length, advice);
 }
 
 static inline int __sys_getrlimit(int resource, struct rlimit *rlim)


### PR DESCRIPTION
The current wrapper uses `__do_syscall2` (wrong arity, should be 3) and ignores the `advice` parameter.

----
## git request-pull output:
```
The following changes since commit fd1d6cfafb4e9fb4d826175247527c7d1ca4ffc1:

  test/pollfree: use mmap(2) instead of a manual syscall (2022-02-21 05:11:29 -0700)

are available in the Git repository at:

  https://github.com/Spasi/liburing.git fix_madvise_syscall

for you to fetch changes up to e05652f22ee5b5bcc78f69a09ed7a7ba883a928a:

  Fix madvise syscall wrapper (2022-02-21 15:33:09 +0200)

----------------------------------------------------------------
Ioannis Tsakpinis (1):
      Fix madvise syscall wrapper

 src/arch/x86/syscall.h | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
