### PR TITLE
[GIT PULL] Add multiarch GitHub CI build support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,40 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - cc: gcc
-            cxx: g++
-          - cc: clang
+          # x86-64 gcc
+          - arch: x86_64
+            cc_pkg: gcc-x86-64-linux-gnu
+            cxx_pkg: g++-x86-64-linux-gnu
+            cc: x86_64-linux-gnu-gcc
+            cxx: x86_64-linux-gnu-g++
+
+          # x86-64 clang
+          - arch: x86_64
+            cc_pkg: clang
+            cxx_pkg: clang
+            cc: clang
             cxx: clang++
+
+          # x86 (32-bit) gcc
+          - arch: i686
+            cc_pkg: gcc-i686-linux-gnu
+            cxx_pkg: g++-i686-linux-gnu
+            cc: i686-linux-gnu-gcc
+            cxx: i686-linux-gnu-g++
+
+          # aarch64 gcc
+          - arch: aarch64
+            cc_pkg: gcc-aarch64-linux-gnu
+            cxx_pkg: g++-aarch64-linux-gnu
+            cc: aarch64-linux-gnu-gcc
+            cxx: aarch64-linux-gnu-g++
+
+          # arm (32-bit) gcc
+          - arch: arm
+            cc_pkg: gcc-arm-linux-gnueabi
+            cxx_pkg: g++-arm-linux-gnueabi
+            cc: arm-linux-gnueabi-gcc
+            cxx: arm-linux-gnueabi-g++
 
     env:
       FLAGS: -g -O2 -Wall -Wextra -Werror
@@ -24,6 +54,11 @@ jobs:
     steps:
     - name: Checkout source
       uses: actions/checkout@v2
+
+    - name: Install Compilers
+      run: |
+        sudo apt-get update -y;
+        sudo apt-get install -y ${{matrix.cc_pkg}} ${{matrix.cxx_pkg}};
 
     - name: Display compiler versions
       run: |
@@ -35,19 +70,15 @@ jobs:
         ./configure --cc=${{matrix.cc}} --cxx=${{matrix.cxx}};
         make -j$(nproc) V=1 CPPFLAGS="-Werror" CFLAGS="$FLAGS" CXXFLAGS="$FLAGS";
 
-    - name: Build nolibc x86-64
+    - name: Build nolibc
       run: |
-        ./configure --cc=${{matrix.cc}} --cxx=${{matrix.cxx}} --nolibc;
-        make -j$(nproc) V=1 CPPFLAGS="-Werror" CFLAGS="$FLAGS" CXXFLAGS="$FLAGS";
-
-    - name: Build (32 bit)
-      run: |
-        sudo apt-get install libc6-dev-i386 gcc-multilib g++-multilib -y;
-        make clean;
-        make V=1 -j$(nproc) \
-             CPPFLAGS="-Werror" \
-             CFLAGS="$FLAGS -m32" \
-             CXXFLAGS="$FLAGS -m32";
+        if [[ "${{matrix.arch}}" == "x86_64" ]]; then \
+            make clean; \
+            ./configure --cc=${{matrix.cc}} --cxx=${{matrix.cxx}} --nolibc; \
+            make -j$(nproc) V=1 CPPFLAGS="-Werror" CFLAGS="$FLAGS" CXXFLAGS="$FLAGS"; \
+        else \
+            echo "Skipping nolibc build, this arch doesn't support building liburing without libc"; \
+        fi;
 
     - name: Test install command
       run: |


### PR DESCRIPTION
Hi Jens,

Please pull 1 commit for the GitHub bot.

```
The following changes since commit 63dc2177ed42fd0ae45cb66e169a28305e0fe622:

  test/pollfree: fix compile on 32-bit x86 (2022-02-21 10:24:17 -0700)

are available in the Git repository at:

  git://github.com/ammarfaizi2/liburing.git tags/multiarch-gh-ci-20220222

for you to fetch changes up to f1e75bed0a508177225e3c0fad037a6f1154f53f:

  .github/workflows: Add multiarch GitHub CI build support (2022-02-22 18:09:57 +0700)

----------------------------------------------------------------
multiarch-gh-ci-20220222

This adds multiarch build for GitHub bot. Currently, only GCC that
supports multiarch build. I couldn't find the clang cross compiler
package from the Ubuntu apt, so let's skip it at the moment.

New arch(s) build support:
  - aarch64
  - arm (32-bit)

----------------------------------------------------------------
Ammar Faizi (1):
      .github/workflows: Add multiarch GitHub CI build support

 .github/workflows/build.yml | 61 ++++++++++++++++++++++++++++++----------
 1 file changed, 46 insertions(+), 15 deletions(-)
```