### PR TITLE
[GIT PULL] ci: run tests as part of GitHub actions matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,3 +83,7 @@ jobs:
     - name: Test install command
       run: |
         sudo make install;
+
+    - name: Run unit tests
+      run: |
+        make runtests;


### PR DESCRIPTION
Added support for github to run liburing unit tests as part of
CI actions matrix.

Signed-off-by: Jon Kohler <jon@nutanix.com>