### PR TITLE
[GIT PULL] configure script fixes

### DIFF
--- a/configure
+++ b/configure
@@ -369,7 +369,6 @@ print_config "has_ucontext" "$has_ucontext"
 # check for memfd_create(2)
 has_memfd_create="no"
 cat > $TMPC << EOF
-#define _GNU_SOURCE
 #include <sys/mman.h>
 int main(int argc, char **argv)
 {

--- a/configure
+++ b/configure
@@ -81,10 +81,11 @@ fi
 TMP_DIRECTORY="$(mktemp -d)"
 TMPC="$TMP_DIRECTORY/liburing-conf.c"
 TMPC2="$TMP_DIRECTORY/liburing-conf-2.c"
+TMPCXX="$TMP_DIRECTORY/liburing-conf-2.cpp"
 TMPO="$TMP_DIRECTORY/liburing-conf.o"
 TMPE="$TMP_DIRECTORY/liburing-conf.exe"
 
-touch $TMPC $TMPC2 $TMPO $TMPE
+touch $TMPC $TMPC2 $TMPCXX $TMPO $TMPE
 
 # NB: do not call "exit" in the trap handler; this is buggy with some shells;
 # see <1285349658-3122-1-git-send-email-loic.minier@linaro.org>
@@ -171,7 +172,7 @@ compile_prog_cxx() {
   local_cflags="$1"
   local_ldflags="$2 $LIBS"
   echo "Compiling test case $3" >> config.log
-  do_cxx $CFLAGS $local_cflags -o $TMPE $TMPC $LDFLAGS $local_ldflags
+  do_cxx $CFLAGS $local_cflags -o $TMPE $TMPCXX $LDFLAGS $local_ldflags
 }
 
 has() {
@@ -334,7 +335,7 @@ print_config "glibc_statx" "$glibc_statx"
 ##########################################
 # check for C++
 has_cxx="no"
-cat > $TMPC << EOF
+cat > $TMPCXX << EOF
 #include <iostream>
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
Hi Jens,

Two configure script fixes from Alviro:
  - configure: Fix _GNU_SOURCE redefinition warning
  - configure: Fix clang-12 warning `-Wdeprecated`

Please pull!

```
The following changes since commit 93e30695bb0c4e27bd2ab9a7e91a8279225d1264:

  Merge tag 'multiarch-gh-ci-20220222' of https://github.com/ammarfaizi2/liburing (2022-02-22 06:14:09 -0700)

are available in the Git repository at:

  https://github.com/ammarfaizi2/liburing tags/liburing-2022-02-23

for you to fetch changes up to 2cd9452658b6420e0211ed0a0e1440bed50bdbf7:

  configure: Fix clang-12 warning `-Wdeprecated` (2022-02-23 11:46:05 +0700)

----------------------------------------------------------------
liburing-2022-02-23

Two configure script fixes from Alviro Iskandar Setiawan:
  - configure: Fix _GNU_SOURCE redefinition warning
  - configure: Fix clang-12 warning `-Wdeprecated`

----------------------------------------------------------------
Alviro Iskandar Setiawan (2):
      configure: Fix _GNU_SOURCE redefinition warning
      configure: Fix clang-12 warning `-Wdeprecated`

 configure | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)
```