### PR TITLE
[GIT PULL] Fix memory ordering in sq_ring_needs_enter

### DIFF
--- a/src/include/liburing/barrier.h
+++ b/src/include/liburing/barrier.h
@@ -52,6 +52,11 @@ static inline T io_uring_smp_load_acquire(const T *p)
 		reinterpret_cast<const std::atomic<T> *>(p),
 		std::memory_order_acquire);
 }
+
+static inline void io_uring_smp_mb()
+{
+	std::atomic_thread_fence(std::memory_order_seq_cst);
+}
 #else
 #include <stdatomic.h>
 
@@ -68,6 +73,9 @@ static inline T io_uring_smp_load_acquire(const T *p)
 #define io_uring_smp_load_acquire(p)				\
 	atomic_load_explicit((_Atomic __typeof__(*(p)) *)(p),	\
 			     memory_order_acquire)
+
+#define io_uring_smp_mb()					\
+	atomic_thread_fence(memory_order_seq_cst)
 #endif
 
 #endif /* defined(LIBURING_BARRIER_H) */

--- a/src/queue.c
+++ b/src/queue.c
@@ -17,6 +17,12 @@ static inline bool sq_ring_needs_enter(struct io_uring *ring, unsigned *flags)
 	if (!(ring->flags & IORING_SETUP_SQPOLL))
 		return true;
 
+	/*
+	 * Ensure the kernel can see the store to the SQ tail before we read
+	 * the flags.
+	 */
+	io_uring_smp_mb();
+
 	if (uring_unlikely(IO_URING_READ_ONCE(*ring->sq.kflags) &
 			   IORING_SQ_NEED_WAKEUP)) {
 		*flags |= IORING_ENTER_SQ_WAKEUP;


### PR DESCRIPTION
A full memory barrier is required between the store to the SQ tail in
__io_uring_flush_sq and the load of the flags in sq_ring_needs_enter
to prevent a situation where the kernel thread goes to sleep while
sq_ring_needs_enter returns false

Fixes: https://github.com/axboe/liburing/issues/541
Signed-off-by: Almog Khaikin <almogkh@gmail.com>



----
## git request-pull output:
```
The following changes since commit 2de98320d5b02951936fc0ab677dd01e4fb2a7a7:

  src/Makefile: Don't use stack protector for all builds by default (2022-02-25 07:17:37 -0700)

are available in the Git repository at:

  https://github.com/almogkh/liburing fix-needenter

for you to fetch changes up to 748fd137c7f70d352fdc546535cf52108352e827:

  Fix memory ordering in sq_ring_needs_enter (2022-03-05 19:18:24 +0200)

----------------------------------------------------------------
Almog Khaikin (1):
      Fix memory ordering in sq_ring_needs_enter

 src/include/liburing/barrier.h | 8 ++++++++
 src/queue.c                    | 6 ++++++
 2 files changed, 14 insertions(+)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
