### PR TITLE
[GIT PULL] configure: Allow the configure script to fail with a non-zero exit code

### DIFF
--- a/configure
+++ b/configure
@@ -1,10 +1,12 @@
 #!/bin/sh
 
+set -e
+
 cc=${CC:-gcc}
 cxx=${CXX:-g++}
 
 for opt do
-  optarg=$(expr "x$opt" : 'x[^=]*=\(.*\)')
+  optarg=$(expr "x$opt" : 'x[^=]*=\(.*\)' || true)
   case "$opt" in
   --help|-h) show_help=yes
   ;;


### PR DESCRIPTION
Hi Jens,

One configure script fix for liburing:
  - Allow the configure script to fail with a non-zero exit code.

Please pull!

Cc: @romange 
```
The following changes since commit 3b52ae980c41b420592e3005199041890a56d6dc:

  test/fixed-reuse: test that linked file slot reuse is correct (2022-03-30 11:33:38 -0600)

are available in the Git repository at:

  https://github.com/ammarfaizi2/liburing tags/liburing-2022-05-01

for you to fetch changes up to 30830bddbfbe9503836bdcb3ed90ec3f945d122d:

  configure: Allow the configure script to fail with a non-zero exit code (2022-04-01 23:23:02 +0700)

----------------------------------------------------------------
Pull a configure script fix from Ammar Faizi:
  - Allow the configure script to fail with a non-zero exit code.

  Link: https://github.com/axboe/liburing/pull/553
  Link: https://github.com/axboe/liburing/pull/554

----------------------------------------------------------------
Ammar Faizi (1):
      configure: Allow the configure script to fail with a non-zero exit code

 configure | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)
```