### PR TITLE
[GIT PULL] io_uring.7: atomic_store_explicit() in examples

### DIFF
--- a/man/io_uring.7
+++ b/man/io_uring.7
@@ -299,7 +299,7 @@ describe_io(sqe);
 /* fill the sqe index into the SQ ring array */
 sqring->array[index] = index;
 tail++;
-atomic_store_release(sqring->tail, tail);
+atomic_store_explicit(sqring->tail, tail, memory_order_release);
 .EE
 .in
 .PP
@@ -453,7 +453,7 @@ if (head != atomic_load_acquire(cqring->tail)) {
     /* CQE consumption complete */
     head++;
 }
-atomic_store_release(cqring->head, head);
+atomic_store_explicit(cqring->head, head, memory_order_release);
 .EE
 .in
 .PP

--- a/man/io_uring_queue_init.3
+++ b/man/io_uring_queue_init.3
@@ -33,12 +33,12 @@ memory shared between the application and the kernel.
 By default, the CQ ring will have twice the number of entries as specified by
 .I entries
 for the SQ ring. This is adequate for regular file or storage workloads, but
-may be too small networked workloads. The SQ ring entries do not impose a limit
-on the number of in-flight requests that the ring can support, it merely limits
-the number that can be submitted to the kernel in one go (batch). if the CQ
-ring overflows, e.g. more entries are generated than fits in the ring before the
-application can reap them, then the ring enters a CQ ring overflow state. This
-is indicated by
+may be too small for networked workloads. The SQ ring entries do not impose a
+limit on the number of in-flight requests that the ring can support, it merely
+limits the number that can be submitted to the kernel in one go (batch). if the
+CQ ring overflows, e.g. more entries are generated than fits in the ring before
+the application can reap them, then the ring enters a CQ ring overflow state.
+This is indicated by
 .B IORING_SQ_CQ_OVERFLOW
 being set in the SQ ring flags. Unless the kernel runs out of available memory,
 entries are not dropped, but it is a much slower completion path and will slow

--- a/man/io_uring_setup.2
+++ b/man/io_uring_setup.2
@@ -527,7 +527,7 @@ is the file descriptor returned from
 .BR io_uring_setup (2).
 The addition of
 .I sq_off.array
-to the length of the region accounts for the fact that the ring
+to the length of the region accounts for the fact that the ring is
 located at the end of the data structure.  As an example, the ring
 buffer head pointer can be accessed by adding
 .I sq_off.head


### PR DESCRIPTION
The inline examples currently reference atomic_store_release(),
though io_uring_smp_store_release() in the standalone example
uses C11's atomic_store_explicit(). Use atomic_store_explicit()
in the standalone example together with memory_order_release.

----
## git request-pull output:
```

The following changes since commit 000dd873f4da9b6052792c93d4d0978bb4ea3252:

  test/open-direct-link: add IOSQE_ASYNC (2022-03-29 16:38:27 -0600)

are available in the Git repository at:

  https://github.com/dankamongmen/liburing.git dankamongmen/man-atomics

for you to fetch changes up to 94ed3b286e00fe4fdc1f97633e10934896aa9a77:

  io_uring.7: atomic_store_explicit() in examples (2022-04-02 02:04:52 -0400)

----------------------------------------------------------------
nick black (1):
      io_uring.7: atomic_store_explicit() in examples

 man/io_uring.7 | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
