### PR TITLE
[GIT PULL] remove double casts

### DIFF
--- a/test/recv-msgall-stream.c
+++ b/test/recv-msgall-stream.c
@@ -362,7 +362,7 @@ static int test(int use_recvmsg, int use_sync)
 
 	do_send(&rd);
 	pthread_join(recv_thread, &retval);
-	return (int)(intptr_t)retval;
+	return (intptr_t)retval;
 }
 
 int main(int argc, char *argv[])

--- a/test/recv-msgall.c
+++ b/test/recv-msgall.c
@@ -241,7 +241,7 @@ static int test(int use_recvmsg)
 	pthread_mutex_lock(&rd.mutex);
 	do_send();
 	pthread_join(recv_thread, &retval);
-	return (int)(intptr_t)retval;
+	return (intptr_t)retval;
 }
 
 int main(int argc, char *argv[])

--- a/test/send_recv.c
+++ b/test/send_recv.c
@@ -254,7 +254,7 @@ static int test(int use_sqthread, int regfiles)
 	pthread_mutex_lock(&rd.mutex);
 	do_send();
 	pthread_join(recv_thread, &retval);
-	return (int)(intptr_t)retval;
+	return (intptr_t)retval;
 }
 
 int main(int argc, char *argv[])

--- a/test/send_recvmsg.c
+++ b/test/send_recvmsg.c
@@ -305,7 +305,7 @@ static int test(int buf_select, int no_buf_add, int iov_count)
 	pthread_mutex_lock(&mutex);
 	do_sendmsg();
 	pthread_join(recv_thread, &retval);
-	ret = (int)(intptr_t)retval;
+	ret = (intptr_t)retval;
 
 	return ret;
 }


### PR DESCRIPTION
Remove "obviously useless" double casts.

----
## git request-pull output:
```
The following changes since commit 000dd873f4da9b6052792c93d4d0978bb4ea3252:

  test/open-direct-link: add IOSQE_ASYNC (2022-03-29 16:38:27 -0600)

are available in the Git repository at:

  dankamongmen remove-double-cast

for you to fetch changes up to 662989e4aa2cac1d6f87b3ada5c1fd579d5d75b3:

  remove double casts (2022-04-04 10:57:27 -0400)

----------------------------------------------------------------
nick black (1):
      remove double casts

 test/recv-msgall-stream.c | 2 +-
 test/recv-msgall.c        | 2 +-
 test/send_recv.c          | 2 +-
 test/send_recvmsg.c       | 2 +-
 4 files changed, 4 insertions(+), 4 deletions(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
