### PR TITLE
[GIT PULL] Test fixes

### DIFF
--- a/test/35fa71a030ca.c
+++ b/test/35fa71a030ca.c
@@ -238,8 +238,7 @@ static void execute_one(void);
 
 static void loop(void)
 {
-  int iter;
-  for (iter = 0;; iter++) {
+  for (;;) {
     int pid = fork();
     if (pid < 0)
       exit(1);

--- a/test/rw_merge_test.c
+++ b/test/rw_merge_test.c
@@ -35,7 +35,8 @@ int main(int argc, char *argv[])
 	assert(!ret);
 
 	fd = open("testfile", O_RDWR | O_CREAT, 0644);
-	assert(ret >= 0);
+	assert(fd >= 0);
+	unlink("testfile");
 	ret = ftruncate(fd, 4096);
 	assert(!ret);
 

--- a/test/submit-reuse.c
+++ b/test/submit-reuse.c
@@ -26,13 +26,11 @@ struct thread_data {
 static void *flusher(void *__data)
 {
 	struct thread_data *data = __data;
-	int i = 0;
 
 	while (!data->do_exit) {
 		posix_fadvise(data->fd1, 0, FILE_SIZE, POSIX_FADV_DONTNEED);
 		posix_fadvise(data->fd2, 0, FILE_SIZE, POSIX_FADV_DONTNEED);
 		usleep(10);
-		i++;
 	}
 
 	return NULL;


### PR DESCRIPTION
Hi Jens,

  - Two fixes for `-Wunused-but-set-variable` warning from clang-15.

  - Fix the wrong assertion condition and testfile cleanup in
    test/submit_reuse.

Please pull!
```
The following changes since commit 7cea31e742c175b8df2895b57f472b49ff514ee0:

  man/io_uring_setup.2: document recent FEAT flag additions (2022-04-14 11:22:51 -0600)

are available in the Git repository at:

  https://github.com/ammarfaizi2/liburing tags/test-fixes-2022-04-15

for you to fetch changes up to 045b8c5b183859fbc481ec7ab6b818442cc57ab0:

  test/submit-reuse: Fix `-Wunused-but-set-variable` warning from clang-15 (2022-04-15 04:24:24 +0700)

----------------------------------------------------------------
Pull test fixes from Ammar Faizi:

  - Two fixes for `-Wunused-but-set-variable` warning from clang-15.

  - Fix the wrong assertion condition and testfile cleanup in
    test/submit_reuse.

  Link: https://github.com/axboe/liburing/pull/567

----------------------------------------------------------------
Ammar Faizi (3):
      test/rw_merge_test: Fix the wrong assertion condition and unlink testfile
      test/35fa71a030ca: Fix `-Wunused-but-set-variable` warning from clang-15
      test/submit-reuse: Fix `-Wunused-but-set-variable` warning from clang-15

 test/35fa71a030ca.c  | 3 +--
 test/rw_merge_test.c | 3 ++-
 test/submit-reuse.c  | 2 --
 3 files changed, 3 insertions(+), 5 deletions(-)
```