### PR TITLE
[GIT PULL] configure: fix compile-checks for statx

### DIFF
--- a/configure
+++ b/configure
@@ -300,7 +300,6 @@ cat > $TMPC << EOF
 #include <unistd.h>
 #include <fcntl.h>
 #include <string.h>
-#include <linux/stat.h>
 int main(int argc, char **argv)
 {
   struct statx x;
@@ -321,7 +320,7 @@ cat > $TMPC << EOF
 #include <unistd.h>
 #include <fcntl.h>
 #include <string.h>
-#include <linux/stat.h>
+#include <sys/stat.h>
 int main(int argc, char **argv)
 {
   struct statx x;


### PR DESCRIPTION
This is related to the the issue reported here: https://github.com/axboe/liburing/issues/578
A fix for the reported issue changed ``linux/stat.h`` to ``sys/stat.h`` , however, it did not change the compile-check in ``configure``. 

This commit is needed on Alpine Linux / muslc, where 'statx' is detected by ``configure/compile-check`` but ``sys/stat.h`` does not provide what is needed by ``test/statx.c``. Resulting in a build-error.

This changes the compiler-check to match the usage in `tests/statx.c`, thereby fixing the build-error on Alpine Linux / muslc.

----
## git request-pull output:
```
The following changes since commit b2d28aea257d0eee40bcdc5c0613712c9e4e8184:

  io_uring.h: sync with 5.19 io_uring release (2022-05-17 06:04:15 -0600)

are available in the Git repository at:

  https://github.com/safl/liburing.git fix/configure-statx

for you to fetch changes up to 45969ce39dc764e12541681ed3ddbafcf7f0de85:

  configure: fix compile-checks for statx (2022-05-17 17:07:17 +0200)

----------------------------------------------------------------
Simon A. F. Lund (1):
      configure: fix compile-checks for statx

 configure | 3 +--
 1 file changed, 1 insertion(+), 2 deletions(-)
```