### PR TITLE
[GIT PULL] Various small changes and simplifications to the manpages

### DIFF
--- a/man/io_uring_buf_ring_add.3
+++ b/man/io_uring_buf_ring_add.3
@@ -7,7 +7,7 @@
 io_uring_buf_ring_add \- add buffers to a shared buffer ring
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_buf_ring_add(struct io_uring_buf_ring *" br ",
 .BI "                          void *" addr ",

--- a/man/io_uring_buf_ring_add.3
+++ b/man/io_uring_buf_ring_add.3
@@ -14,7 +14,7 @@ io_uring_buf_ring_add \- add buffers to a shared buffer ring
 .BI "                          unsigned int " len ",
 .BI "                          unsigned short " bid ",
 .BI "                          int " buf_offset ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_buf_ring_add.3
+++ b/man/io_uring_buf_ring_add.3
@@ -20,7 +20,7 @@ io_uring_buf_ring_add \- add buffers to a shared buffer ring
 The
 .BR io_uring_buf_ring_add (3)
 adds a new buffer to the shared buffer ring
-.I br.
+.IR br .
 The buffer address is indicated by
 .I addr
 and is of

--- a/man/io_uring_buf_ring_add.3
+++ b/man/io_uring_buf_ring_add.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_buf_ring_add 3 "May 18, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_buf_ring_add - add buffers to a shared buffer ring
-.fi
+io_uring_buf_ring_add \- add buffers to a shared buffer ring
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_buf_ring_add.3
+++ b/man/io_uring_buf_ring_add.3
@@ -43,4 +43,6 @@ must be incremented by one for each buffer added.
 .SH RETURN VALUE
 None
 .SH SEE ALSO
-.BR io_uring_register_buf_ring (3), io_uring_buf_ring_advance (3), io_uring_buf_ring_cq_advance (3)
+.BR io_uring_register_buf_ring (3),
+.BR io_uring_buf_ring_advance (3),
+.BR io_uring_buf_ring_cq_advance (3)

--- a/man/io_uring_buf_ring_advance.3
+++ b/man/io_uring_buf_ring_advance.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_buf_ring_advance 3 "May 18, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_buf_ring_advance - advance index of provided buffer in buffer ring
-.fi
+io_uring_buf_ring_advance \- advance index of provided buffer in buffer ring
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_buf_ring_advance.3
+++ b/man/io_uring_buf_ring_advance.3
@@ -19,7 +19,7 @@ The
 commits
 .I count
 previously added buffers to the shared buffer ring
-.I br,
+.IR br ,
 making them visible to the kernel and hence consumable. This passes ownership
 of the buffer to the ring.
 

--- a/man/io_uring_buf_ring_advance.3
+++ b/man/io_uring_buf_ring_advance.3
@@ -11,7 +11,7 @@ io_uring_buf_ring_advance \- advance index of provided buffer in buffer ring
 .PP
 .BI "int io_uring_buf_ring_advance(struct io_uring_buf_ring *" br ",
 .BI "                              int " count ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_buf_ring_advance.3
+++ b/man/io_uring_buf_ring_advance.3
@@ -26,4 +26,6 @@ of the buffer to the ring.
 .SH RETURN VALUE
 None
 .SH SEE ALSO
-.BR io_uring_register_buf_ring (3), io_uring_buf_ring_add (3), io_uring_buf_ring_cq_advance (3)
+.BR io_uring_register_buf_ring (3),
+.BR io_uring_buf_ring_add (3),
+.BR io_uring_buf_ring_cq_advance (3)

--- a/man/io_uring_buf_ring_advance.3
+++ b/man/io_uring_buf_ring_advance.3
@@ -7,7 +7,7 @@
 io_uring_buf_ring_advance \- advance index of provided buffer in buffer ring
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_buf_ring_advance(struct io_uring_buf_ring *" br ",
 .BI "                              int " count ");"

--- a/man/io_uring_buf_ring_cq_advance.3
+++ b/man/io_uring_buf_ring_cq_advance.3
@@ -7,7 +7,7 @@
 io_uring_buf_ring_cq_advance \- advance index of provided buffer and CQ ring
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_buf_ring_cq_advance(struct io_uring *" ring ",
 .BI "                                 struct io_uring_buf_ring *" br ",

--- a/man/io_uring_buf_ring_cq_advance.3
+++ b/man/io_uring_buf_ring_cq_advance.3
@@ -36,4 +36,6 @@ barrier, doing both at once is more efficient.
 .SH RETURN VALUE
 None
 .SH SEE ALSO
-.BR io_uring_register_buf_ring (3), io_uring_buf_ring_add (3), io_uring_buf_ring_advance (3)
+.BR io_uring_register_buf_ring (3),
+.BR io_uring_buf_ring_add (3),
+.BR io_uring_buf_ring_advance (3)

--- a/man/io_uring_buf_ring_cq_advance.3
+++ b/man/io_uring_buf_ring_cq_advance.3
@@ -20,7 +20,7 @@ The
 commits
 .I count
 previously added buffers to the shared buffer ring
-.I br,
+.IR br ,
 making them visible to the kernel and hence consumable. This passes ownership
 of the buffer to the ring. At the same time, it advances the CQ ring of
 .I ring

--- a/man/io_uring_buf_ring_cq_advance.3
+++ b/man/io_uring_buf_ring_cq_advance.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_buf_ring_cq_advance 3 "May 18, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_buf_ring_cq_advance - advance index of provided buffer and CQ ring
-.fi
+io_uring_buf_ring_cq_advance \- advance index of provided buffer and CQ ring
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_buf_ring_cq_advance.3
+++ b/man/io_uring_buf_ring_cq_advance.3
@@ -12,7 +12,7 @@ io_uring_buf_ring_cq_advance \- advance index of provided buffer and CQ ring
 .BI "int io_uring_buf_ring_cq_advance(struct io_uring *" ring ",
 .BI "                                 struct io_uring_buf_ring *" br ",
 .BI "                                 int " count ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_cq_advance.3
+++ b/man/io_uring_cq_advance.3
@@ -12,7 +12,6 @@ io_uring_cq_advance \- mark one or more io_uring completion events as consumed
 .BI "void io_uring_cq_advance(struct io_uring *" ring ","
 .BI "                          unsigned " nr ");"
 .fi
-.PP
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_cq_advance.3
+++ b/man/io_uring_cq_advance.3
@@ -4,7 +4,7 @@
 .\"
 .TH io_uring_cq_advance 3 "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_cq_advance - Mark one or more io_uring completion events as consumed
+io_uring_cq_advance \- mark one or more io_uring completion events as consumed
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_cq_advance.3
+++ b/man/io_uring_cq_advance.3
@@ -7,7 +7,7 @@
 io_uring_cq_advance \- mark one or more io_uring completion events as consumed
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_cq_advance(struct io_uring *" ring ","
 .BI "                          unsigned " nr ");"

--- a/man/io_uring_cq_advance.3
+++ b/man/io_uring_cq_advance.3
@@ -42,4 +42,9 @@ so will result in the same completion being returned on the next invocation.
 .SH RETURN VALUE
 None
 .SH SEE ALSO
-.BR io_uring_submit (3), io_uring_wait_cqe (3), io_uring_peek_cqe (3), io_uring_wait_cqes (3), io_uring_wait_cqe_timeout (3), io_uring_cqe_seen (3)
+.BR io_uring_submit (3),
+.BR io_uring_wait_cqe (3),
+.BR io_uring_peek_cqe (3),
+.BR io_uring_wait_cqes (3),
+.BR io_uring_wait_cqe_timeout (3),
+.BR io_uring_cqe_seen (3)

--- a/man/io_uring_cq_ready.3
+++ b/man/io_uring_cq_ready.3
@@ -23,4 +23,5 @@ param.
 .SH RETURN VALUE
 Returns the number of unconsumed ready entries in the CQ ring.
 .SH SEE ALSO
-.BR io_uring_submit (3),  io_uring_wait_cqe (3)
+.BR io_uring_submit (3),
+.BR io_uring_wait_cqe (3)

--- a/man/io_uring_cq_ready.3
+++ b/man/io_uring_cq_ready.3
@@ -7,7 +7,7 @@
 io_uring_cq_ready \- returns number of unconsumed ready entries in the CQ ring
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "unsigned io_uring_cq_ready(const struct io_uring *" ring ");"
 .fi

--- a/man/io_uring_cq_ready.3
+++ b/man/io_uring_cq_ready.3
@@ -11,7 +11,6 @@ io_uring_cq_ready \- returns number of unconsumed ready entries in the CQ ring
 .PP
 .BI "unsigned io_uring_cq_ready(const struct io_uring *" ring ");"
 .fi
-.PP
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_cq_ready.3
+++ b/man/io_uring_cq_ready.3
@@ -4,7 +4,7 @@
 .\"
 .TH io_uring_cq_ready "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_cq_ready - returns number of unconsumed ready entries in the CQ ring
+io_uring_cq_ready \- returns number of unconsumed ready entries in the CQ ring
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_cqe_get_data.3
+++ b/man/io_uring_cqe_get_data.3
@@ -15,8 +15,8 @@ io_uring_cqe_get_data - get user data for completion event
 .SH DESCRIPTION
 .PP
 The
-.BR io_uring_cqe_get_data (3) function returns the user_data with the completion
-queue entry
+.BR io_uring_cqe_get_data (3)
+function returns the user_data with the completion queue entry
 .I cqe.
 
 After the caller has received a completion queue entry (CQE) with

--- a/man/io_uring_cqe_get_data.3
+++ b/man/io_uring_cqe_get_data.3
@@ -7,7 +7,7 @@
 io_uring_cqe_get_data \- get user data for completion event
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void *io_uring_cqe_get_data(struct io_uring_cqe *" cqe ");"
 .fi
@@ -37,4 +37,4 @@ the functions returns NULL.
 .SH SEE ALSO
 .BR io_uring_get_sqe (3),
 .BR io_uring_sqe_set_data (3),
-.BR io_uring_sqe_submit(3)
+.BR io_uring_sqe_submit (3)

--- a/man/io_uring_cqe_get_data.3
+++ b/man/io_uring_cqe_get_data.3
@@ -36,4 +36,6 @@ If the
 value has been set before submitting the request, it will be returned. Otherwise
 the functions returns NULL.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_sqe_set_data (3),  io_uring_sqe_submit(3)
+.BR io_uring_get_sqe (3),
+.BR io_uring_sqe_set_data (3),
+.BR io_uring_sqe_submit(3)

--- a/man/io_uring_cqe_get_data.3
+++ b/man/io_uring_cqe_get_data.3
@@ -11,7 +11,6 @@ io_uring_cqe_get_data \- get user data for completion event
 .PP
 .BI "void *io_uring_cqe_get_data(struct io_uring_cqe *" cqe ");"
 .fi
-.PP
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_cqe_get_data.3
+++ b/man/io_uring_cqe_get_data.3
@@ -4,7 +4,7 @@
 .\"
 .TH io_uring_cqe_get_data 3 "November 15, 2021" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_cqe_get_data - get user data for completion event
+io_uring_cqe_get_data \- get user data for completion event
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_cqe_get_data.3
+++ b/man/io_uring_cqe_get_data.3
@@ -17,7 +17,7 @@ io_uring_cqe_get_data \- get user data for completion event
 The
 .BR io_uring_cqe_get_data (3)
 function returns the user_data with the completion queue entry
-.I cqe.
+.IR cqe .
 
 After the caller has received a completion queue entry (CQE) with
 .BR io_uring_wait_cqe (3),

--- a/man/io_uring_cqe_seen.3
+++ b/man/io_uring_cqe_seen.3
@@ -12,7 +12,6 @@ io_uring_cqe_seen \- mark io_uring completion event as consumed
 .BI "void io_uring_cqe_seen(struct io_uring *" ring ","
 .BI "                       struct io_uring_cqe *" cqe ");"
 .fi
-.PP
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_cqe_seen.3
+++ b/man/io_uring_cqe_seen.3
@@ -7,7 +7,7 @@
 io_uring_cqe_seen \- mark io_uring completion event as consumed
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_cqe_seen(struct io_uring *" ring ","
 .BI "                       struct io_uring_cqe *" cqe ");"

--- a/man/io_uring_cqe_seen.3
+++ b/man/io_uring_cqe_seen.3
@@ -4,7 +4,7 @@
 .\"
 .TH io_uring_cqe_seen 3 "November 15, 2021" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_cqe_seen - Mark io_uring completion event as consumed
+io_uring_cqe_seen \- mark io_uring completion event as consumed
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_cqe_seen.3
+++ b/man/io_uring_cqe_seen.3
@@ -35,4 +35,9 @@ Completions must be marked as completed so their slot can get reused.
 .SH RETURN VALUE
 None
 .SH SEE ALSO
-.BR io_uring_submit (3), io_uring_wait_cqe (3), io_uring_peek_cqe (3), io_uring_wait_cqes (3), io_uring_wait_cqe_timeout (3), io_uring_cqe_seen (3)
+.BR io_uring_submit (3),
+.BR io_uring_wait_cqe (3),
+.BR io_uring_peek_cqe (3),
+.BR io_uring_wait_cqes (3),
+.BR io_uring_wait_cqe_timeout (3),
+.BR io_uring_cqe_seen (3)

--- a/man/io_uring_free_probe.3
+++ b/man/io_uring_free_probe.3
@@ -11,7 +11,6 @@ io_uring_free_probe \- free probe instance
 .PP
 .BI "void io_uring_free_probe(struct io_uring_probe *" probe ");"
 .fi
-.PP
 .SH DESCRIPTION
 .PP
 The function

--- a/man/io_uring_free_probe.3
+++ b/man/io_uring_free_probe.3
@@ -7,7 +7,7 @@
 io_uring_free_probe \- free probe instance
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_free_probe(struct io_uring_probe *" probe ");"
 .fi

--- a/man/io_uring_free_probe.3
+++ b/man/io_uring_free_probe.3
@@ -4,7 +4,7 @@
 .\"
 .TH io_uring_free_probe "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_free_probe - free probe instance
+io_uring_free_probe \- free probe instance
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_get_probe.3
+++ b/man/io_uring_get_probe.3
@@ -11,7 +11,6 @@ io_uring_get_probe \- get probe instance
 .PP
 .BI "io_uring_probe *io_uring_get_probe(void);"
 .fi
-.PP
 .SH DESCRIPTION
 .PP
 The function

--- a/man/io_uring_get_probe.3
+++ b/man/io_uring_get_probe.3
@@ -7,7 +7,7 @@
 io_uring_get_probe \- get probe instance
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "io_uring_probe *io_uring_get_probe(void);"
 .fi

--- a/man/io_uring_get_probe.3
+++ b/man/io_uring_get_probe.3
@@ -4,7 +4,7 @@
 .\"
 .TH io_uring_get_probe "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_get_probe - get probe instance
+io_uring_get_probe \- get probe instance
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_get_sqe.3
+++ b/man/io_uring_get_sqe.3
@@ -13,7 +13,6 @@ submission queue
 .PP
 .BI "struct io_uring_sqe *io_uring_get_sqe(struct io_uring *" ring ");"
 .fi
-.PP
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_get_sqe.3
+++ b/man/io_uring_get_sqe.3
@@ -9,7 +9,7 @@ io_uring_get_sqe \- get the next available submission queue entry from the
 submission queue
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "struct io_uring_sqe *io_uring_get_sqe(struct io_uring *" ring ");"
 .fi
@@ -22,8 +22,9 @@ queue belonging to the
 .I ring
 param.
 
-On success io_uring_get_sqe() returns a pointer to the submission queue entry.
-On failure NULL is returned.
+On success
+.BR io_uring_get_sqe (3)
+returns a pointer to the submission queue entry. On failure NULL is returned.
 
 If a submission queue entry is returned, it should be filled out via one of the
 prep functions such as

--- a/man/io_uring_get_sqe.3
+++ b/man/io_uring_get_sqe.3
@@ -5,7 +5,7 @@
 .\"
 .TH io_uring_get_sqe 3 "July 10, 2020" "liburing-0.7" "liburing Manual"
 .SH NAME
-io_uring_get_sqe - get the next available submission queue entry from the
+io_uring_get_sqe \- get the next available submission queue entry from the
 submission queue
 .SH SYNOPSIS
 .nf

--- a/man/io_uring_opcode_supported.3
+++ b/man/io_uring_opcode_supported.3
@@ -4,7 +4,7 @@
 .\"
 .TH io_uring_opcode_supported "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_opcode_supported - is op code supported?
+io_uring_opcode_supported \- is op code supported?
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_opcode_supported.3
+++ b/man/io_uring_opcode_supported.3
@@ -12,7 +12,6 @@ io_uring_opcode_supported \- is op code supported?
 .BI "int io_uring_opcode_supported(struct io_uring_probe *" probe ","
 .BI "                              int " opcode ");"
 .fi
-.PP
 .SH DESCRIPTION
 .PP
 The function

--- a/man/io_uring_opcode_supported.3
+++ b/man/io_uring_opcode_supported.3
@@ -7,7 +7,7 @@
 io_uring_opcode_supported \- is op code supported?
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_opcode_supported(struct io_uring_probe *" probe ","
 .BI "                              int " opcode ");"

--- a/man/io_uring_peek_cqe.3
+++ b/man/io_uring_peek_cqe.3
@@ -7,7 +7,7 @@
 io_uring_peek_cqe \- check if an io_uring completion event is available
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_peek_cqe(struct io_uring *" ring ","
 .BI "                      struct io_uring_cqe **" cqe_ptr ");"

--- a/man/io_uring_peek_cqe.3
+++ b/man/io_uring_peek_cqe.3
@@ -32,6 +32,6 @@ On success
 returns
 .B 0
 and the cqe_ptr parameter is filled in. On failure it returns
-.B -EAGAIN.
+.BR -EAGAIN .
 .SH SEE ALSO
 .BR io_uring_submit (3),  io_uring_wait_cqes (3), io_uring_wait_cqe (3)

--- a/man/io_uring_peek_cqe.3
+++ b/man/io_uring_peek_cqe.3
@@ -4,7 +4,7 @@
 .\"
 .TH io_uring_peek_cqe 3 "March 12, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_peek_cqe - check if an io_uring completion event is available
+io_uring_peek_cqe \- check if an io_uring completion event is available
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_peek_cqe.3
+++ b/man/io_uring_peek_cqe.3
@@ -34,4 +34,6 @@ returns
 and the cqe_ptr parameter is filled in. On failure it returns
 .BR -EAGAIN .
 .SH SEE ALSO
-.BR io_uring_submit (3),  io_uring_wait_cqes (3), io_uring_wait_cqe (3)
+.BR io_uring_submit (3),
+.BR io_uring_wait_cqes (3),
+.BR io_uring_wait_cqe (3)

--- a/man/io_uring_peek_cqe.3
+++ b/man/io_uring_peek_cqe.3
@@ -12,7 +12,6 @@ io_uring_peek_cqe \- check if an io_uring completion event is available
 .BI "int io_uring_peek_cqe(struct io_uring *" ring ","
 .BI "                      struct io_uring_cqe **" cqe_ptr ");"
 .fi
-.PP
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_accept.3
+++ b/man/io_uring_prep_accept.3
@@ -153,4 +153,7 @@ behavior by inspecting the
 flag passed back from
 .BR io_uring_queue_init_params (3).
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), io_uring_register (2), accept4 (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR io_uring_register (2),
+.BR accept4 (2)

--- a/man/io_uring_prep_accept.3
+++ b/man/io_uring_prep_accept.3
@@ -15,20 +15,20 @@ io_uring_prep_accept \- prepare an accept request
 .BI "                          struct sockaddr *" addr ","
 .BI "                          socklen_t " addrlen ","
 .BI "                          int " flags ");"
-.BI "
+.PP
 .BI "void io_uring_prep_accept_direct(struct io_uring_sqe *" sqe ","
 .BI "                                 int " sockfd ","
 .BI "                                 struct sockaddr *" addr ","
 .BI "                                 socklen_t " addrlen ","
 .BI "                                 int " flags ","
 .BI "                                 unsigned int " file_index ");"
-.BI "
+.PP
 .BI "void io_uring_prep_multishot_accept(struct io_uring_sqe *" sqe ","
 .BI "                                    int " sockfd ","
 .BI "                                    struct sockaddr *" addr ","
 .BI "                                    socklen_t " addrlen ","
 .BI "                                    int " flags ");"
-.BI "
+.PP
 .BI "void io_uring_prep_multishot_accept_direct(struct io_uring_sqe *" sqe ","
 .BI "                                           int " sockfd ","
 .BI "                                           struct sockaddr *" addr ","

--- a/man/io_uring_prep_accept.3
+++ b/man/io_uring_prep_accept.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_accept 3 "March 13, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_accept  - prepare an accept request
-.fi
+io_uring_prep_accept \- prepare an accept request
 .SH SYNOPSIS
 .nf
 .BR "#include <sys/socket.h>"

--- a/man/io_uring_prep_accept.3
+++ b/man/io_uring_prep_accept.3
@@ -34,7 +34,7 @@ io_uring_prep_accept \- prepare an accept request
 .BI "                                           struct sockaddr *" addr ","
 .BI "                                           socklen_t " addrlen ","
 .BI "                                           int " flags ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_accept.3
+++ b/man/io_uring_prep_accept.3
@@ -39,8 +39,8 @@ io_uring_prep_accept  - prepare an accept request
 .SH DESCRIPTION
 .PP
 The
-.BR io_uring_prep_accept (3) function prepares an accept request. The submission
-queue entry
+.BR io_uring_prep_accept (3)
+function prepares an accept request. The submission queue entry
 .I sqe
 is setup to use the file descriptor
 .I sockfd

--- a/man/io_uring_prep_accept.3
+++ b/man/io_uring_prep_accept.3
@@ -7,8 +7,8 @@
 io_uring_prep_accept \- prepare an accept request
 .SH SYNOPSIS
 .nf
-.BR "#include <sys/socket.h>"
-.BR "#include <liburing.h>"
+.B #include <sys/socket.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_accept(struct io_uring_sqe *" sqe ","
 .BI "                          int " sockfd ","

--- a/man/io_uring_prep_accept.3
+++ b/man/io_uring_prep_accept.3
@@ -48,7 +48,7 @@ to start accepting a connection request described by the socket address at
 and of structure length
 .I addrlen
 and using modifier flags in
-.I flags.
+.IR flags .
 
 For a direct descriptor accept request, the offset is specified by the
 .I file_index
@@ -87,10 +87,10 @@ return.
 For a direct descriptor accept request, the
 .I file_index
 argument can be set to
-.B IORING_FILE_INDEX_ALLOC,
+.BR IORING_FILE_INDEX_ALLOC ,
 In this case a free entry in io_uring file table will
 be used automatically and the file index will be returned as CQE
-.I res.
+.IR res .
 .B -ENFILE
 is otherwise returned if there is no free entries in the io_uring file table.
 
@@ -109,7 +109,7 @@ For multishot with direct descriptors,
 must be used as the file descriptor. This tells io_uring to allocate a free
 direct descriptor from our table, rather than the application passing one in.
 Failure to do so will result in the accept request being terminated with
-.B -EINVAL.
+.BR -EINVAL .
 The allocated descriptor will be returned in the CQE
 .I res
 field, like a non-direct accept request.
@@ -136,7 +136,7 @@ non-direct accept. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_cancel.3
+++ b/man/io_uring_prep_cancel.3
@@ -7,7 +7,7 @@
 io_uring_prep_cancel \- prepare a cancelation request
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_cancel(struct io_uring_sqe *" sqe ","
 .BI "                          __u64 " user_data ","
@@ -38,7 +38,7 @@ their
 field in the SQE.
 
 The
-.BR io_uring_prep_cancel_fd()
+.BR io_uring_prep_cancel_fd (3)
 function prepares a cancelation request. The submission queue entry
 .I sqe
 is prepared to cancel an existing request that used the file descriptor

--- a/man/io_uring_prep_cancel.3
+++ b/man/io_uring_prep_cancel.3
@@ -24,7 +24,7 @@ The
 function prepares a cancelation request. The submission queue entry
 .I sqe
 is prepared to cancel an existing request identified by
-.I user_data.
+.IR user_data .
 For the
 .I flags
 argument, see below.
@@ -42,7 +42,7 @@ The
 function prepares a cancelation request. The submission queue entry
 .I sqe
 is prepared to cancel an existing request that used the file descriptor
-.I fd.
+.IR fd .
 For the
 .I flags
 argument, see below.

--- a/man/io_uring_prep_cancel.3
+++ b/man/io_uring_prep_cancel.3
@@ -96,4 +96,6 @@ is no longer possible. This should normally mean that it will complete shortly,
 either successfully, or interrupted due to the cancelation.
 
 .SH SEE ALSO
-.BR io_uring_prep_poll_remove (3), io_uring_get_sqe (3), io_uring_submit (3)
+.BR io_uring_prep_poll_remove (3),
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3)

--- a/man/io_uring_prep_cancel.3
+++ b/man/io_uring_prep_cancel.3
@@ -12,7 +12,7 @@ io_uring_prep_cancel \- prepare a cancelation request
 .BI "void io_uring_prep_cancel(struct io_uring_sqe *" sqe ","
 .BI "                          __u64 " user_data ","
 .BI "                          int " flags ");"
-.BI "
+.PP
 .BI "void io_uring_prep_cancel_fd(struct io_uring_sqe *" sqe ","
 .BI "                          int " fd ","
 .BI "                          int " flags ");"

--- a/man/io_uring_prep_cancel.3
+++ b/man/io_uring_prep_cancel.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_cancel 3 "March 12, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_cancel  - prepare a cancelation request
-.fi
+io_uring_prep_cancel \- prepare a cancelation request
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_prep_cancel.3
+++ b/man/io_uring_prep_cancel.3
@@ -16,7 +16,7 @@ io_uring_prep_cancel \- prepare a cancelation request
 .BI "void io_uring_prep_cancel_fd(struct io_uring_sqe *" sqe ","
 .BI "                          int " fd ","
 .BI "                          int " flags ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_close.3
+++ b/man/io_uring_prep_close.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_close 3 "March 13, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_close  - prepare a file descriptor close request
-.fi
+io_uring_prep_close \- prepare a file descriptor close request
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_prep_close.3
+++ b/man/io_uring_prep_close.3
@@ -65,4 +65,6 @@ directly in the CQE
 .I res
 field.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), close (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR close (2)

--- a/man/io_uring_prep_close.3
+++ b/man/io_uring_prep_close.3
@@ -26,12 +26,12 @@ The
 function prepares a close request. The submission queue entry
 .I sqe
 is setup to close the file descriptor indicated by
-.I fd.
+.IR fd .
 
 For a direct descriptor close request, the offset is specified by the
 .I file_index
 argument instead of the
-.I fd.
+.IR fd .
 This is identical to unregistering the direct descriptor, and is provided as
 a convenience.
 
@@ -41,7 +41,7 @@ to unregister it,
 function is identical to closing a file descriptor indicated by
 .I fd
 and unregistering the direct descriptor specified by the
-.I file_index.
+.IR file_index .
 
 This function prepares an async
 .BR close (2)
@@ -58,7 +58,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_close.3
+++ b/man/io_uring_prep_close.3
@@ -18,7 +18,7 @@ io_uring_prep_close \- prepare a file descriptor close request
 .BI "void io_uring_prep_close_direct_unregister(struct io_uring_sqe *" sqe ","
 .BI "                                           int " fd ",
 .BI "                                           unsigned " file_index ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_close.3
+++ b/man/io_uring_prep_close.3
@@ -11,10 +11,10 @@ io_uring_prep_close \- prepare a file descriptor close request
 .PP
 .BI "void io_uring_prep_close(struct io_uring_sqe *" sqe ","
 .BI "                          int " fd ");"
-.BI "
+.PP
 .BI "void io_uring_prep_close_direct(struct io_uring_sqe *" sqe ","
 .BI "                                unsigned " file_index ");"
-.BI "
+.PP
 .BI "void io_uring_prep_close_direct_unregister(struct io_uring_sqe *" sqe ","
 .BI "                                           int " fd ",
 .BI "                                           unsigned " file_index ");"

--- a/man/io_uring_prep_close.3
+++ b/man/io_uring_prep_close.3
@@ -7,7 +7,7 @@
 io_uring_prep_close \- prepare a file descriptor close request
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_close(struct io_uring_sqe *" sqe ","
 .BI "                          int " fd ");"

--- a/man/io_uring_prep_connect.3
+++ b/man/io_uring_prep_connect.3
@@ -61,4 +61,6 @@ behavior by inspecting the
 flag passed back from
 .BR io_uring_queue_init_params (3).
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), connect (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR connect (2)

--- a/man/io_uring_prep_connect.3
+++ b/man/io_uring_prep_connect.3
@@ -7,9 +7,9 @@
 io_uring_prep_connect \- prepare a connect request
 .SH SYNOPSIS
 .nf
-.BR "#include <sys/types.h>"
-.BR "#include <sys/socket.h>"
-.BR "#include <liburing.h>"
+.B #include <sys/types.h>
+.B #include <sys/socket.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_connect(struct io_uring_sqe *" sqe ","
 .BI "                           int " sockfd ","

--- a/man/io_uring_prep_connect.3
+++ b/man/io_uring_prep_connect.3
@@ -15,7 +15,7 @@ io_uring_prep_connect \- prepare a connect request
 .BI "                           int " sockfd ","
 .BI "                           const struct sockaddr *" addr ","
 .BI "                           socklen_t " addrlen ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_connect.3
+++ b/man/io_uring_prep_connect.3
@@ -27,7 +27,7 @@ is setup to use the file descriptor
 to start connecting to the destination described by the socket address at
 .I addr
 and of structure length
-.I addrlen.
+.IR addrlen .
 
 This function prepares an async
 .BR connect (2)
@@ -44,7 +44,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_connect.3
+++ b/man/io_uring_prep_connect.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_connect 3 "March 13, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_connect  - prepare a connect request
-.fi
+io_uring_prep_connect \- prepare a connect request
 .SH SYNOPSIS
 .nf
 .BR "#include <sys/types.h>"

--- a/man/io_uring_prep_fadvise.3
+++ b/man/io_uring_prep_fadvise.3
@@ -29,7 +29,7 @@ to start an fadvise operation at
 and of
 .I len
 length in bytes, giving it the advise located in
-.I advice.
+.IR advice .
 
 This function prepares an async
 .BR posix_fadvise (2)
@@ -46,7 +46,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_fadvise.3
+++ b/man/io_uring_prep_fadvise.3
@@ -15,7 +15,7 @@ io_uring_prep_fadvise \- prepare a fadvise request
 .BI "                           __u64 " offset ","
 .BI "                           off_t " len ","
 .BI "                           int " advice ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_fadvise.3
+++ b/man/io_uring_prep_fadvise.3
@@ -53,4 +53,7 @@ directly in the CQE
 .I res
 field.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), io_uring_register (2), posix_fadvise (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR io_uring_register (2),
+.BR posix_fadvise (2)

--- a/man/io_uring_prep_fadvise.3
+++ b/man/io_uring_prep_fadvise.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_fadvise 3 "March 13, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_fadvise  - prepare a fadvise request
-.fi
+io_uring_prep_fadvise \- prepare a fadvise request
 .SH SYNOPSIS
 .nf
 .BR "#include <fcntl.h>"

--- a/man/io_uring_prep_fadvise.3
+++ b/man/io_uring_prep_fadvise.3
@@ -7,8 +7,8 @@
 io_uring_prep_fadvise \- prepare a fadvise request
 .SH SYNOPSIS
 .nf
-.BR "#include <fcntl.h>"
-.BR "#include <liburing.h>"
+.B #include <fcntl.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_fadvise(struct io_uring_sqe *" sqe ","
 .BI "                           int " fd ","

--- a/man/io_uring_prep_fallocate.3
+++ b/man/io_uring_prep_fallocate.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_fallocate 3 "March 13, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_fallocate  - prepare a fallocate request
-.fi
+io_uring_prep_fallocate \- prepare a fallocate request
 .SH SYNOPSIS
 .nf
 .BR "#include <fcntl.h>"

--- a/man/io_uring_prep_fallocate.3
+++ b/man/io_uring_prep_fallocate.3
@@ -54,4 +54,6 @@ directly in the CQE
 .I res
 field.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), fallocate (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR fallocate (2)

--- a/man/io_uring_prep_fallocate.3
+++ b/man/io_uring_prep_fallocate.3
@@ -47,7 +47,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_fallocate.3
+++ b/man/io_uring_prep_fallocate.3
@@ -15,7 +15,7 @@ io_uring_prep_fallocate \- prepare a fallocate request
 .BI "                             int " mode ","
 .BI "                             off_t " offset ","
 .BI "                             off_t " len ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_fallocate.3
+++ b/man/io_uring_prep_fallocate.3
@@ -7,8 +7,8 @@
 io_uring_prep_fallocate \- prepare a fallocate request
 .SH SYNOPSIS
 .nf
-.BR "#include <fcntl.h>"
-.BR "#include <liburing.h>"
+.B #include <fcntl.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_fallocate(struct io_uring_sqe *" sqe ","
 .BI "                             int " fd ","

--- a/man/io_uring_prep_files_update.3
+++ b/man/io_uring_prep_files_update.3
@@ -87,4 +87,6 @@ behavior by inspecting the
 flag passed back from
 .BR io_uring_queue_init_params (3).
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), io_uring_register (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR io_uring_register (2)

--- a/man/io_uring_prep_files_update.3
+++ b/man/io_uring_prep_files_update.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_files_update 3 "March 13, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_files_update  - prepare a registered file update request
-.fi
+io_uring_prep_files_update \- prepare a registered file update request
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_prep_files_update.3
+++ b/man/io_uring_prep_files_update.3
@@ -7,7 +7,7 @@
 io_uring_prep_files_update \- prepare a registered file update request
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_files_update(struct io_uring_sqe *" sqe ","
 .BI "                                int *" fds ","

--- a/man/io_uring_prep_files_update.3
+++ b/man/io_uring_prep_files_update.3
@@ -13,7 +13,7 @@ io_uring_prep_files_update \- prepare a registered file update request
 .BI "                                int *" fds ","
 .BI "                                unsigned " nr_fds ","
 .BI "                                int " offset ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_files_update.3
+++ b/man/io_uring_prep_files_update.3
@@ -27,7 +27,7 @@ and of
 .I nr_fds
 in length to update that amount of previously registered files starting at
 offset
-.I offset.
+.IR offset .
 
 Once a previously registered file is updated with a new one, the existing
 entry is updated and then removed from the table. This operation is equivalent to
@@ -62,7 +62,7 @@ One of the fields set in the SQE was invalid.
 .TP
 .B -EFAULT
 The kernel was unable to copy in the memory pointed to by
-.I fds.
+.IR fds .
 .TP
 .B -EBADF
 On of the descriptors located in

--- a/man/io_uring_prep_fsync.3
+++ b/man/io_uring_prep_fsync.3
@@ -12,7 +12,7 @@ io_uring_prep_fsync \- prepare an fsync request
 .BI "void io_uring_prep_fsync(struct io_uring_sqe *" sqe ","
 .BI "                         int " fd ","
 .BI "                         unsigned " flags ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_fsync.3
+++ b/man/io_uring_prep_fsync.3
@@ -57,7 +57,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_fsync.3
+++ b/man/io_uring_prep_fsync.3
@@ -7,7 +7,7 @@
 io_uring_prep_fsync \- prepare an fsync request
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_fsync(struct io_uring_sqe *" sqe ","
 .BI "                         int " fd ","

--- a/man/io_uring_prep_fsync.3
+++ b/man/io_uring_prep_fsync.3
@@ -64,4 +64,7 @@ directly in the CQE
 .I res
 field.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), fsync (2), fdatasync (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR fsync (2),
+.BR fdatasync (2)

--- a/man/io_uring_prep_fsync.3
+++ b/man/io_uring_prep_fsync.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_fsync 3 "March 12, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_fsync  - prepare an fsync request
-.fi
+io_uring_prep_fsync \- prepare an fsync request
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_prep_linkat.3
+++ b/man/io_uring_prep_linkat.3
@@ -33,7 +33,7 @@ with the new directory file descriptor pointed to by
 and the new path pointed to by
 .I newpath
 and using the specified flags in
-.I flags.
+.IR flags .
 
 This function prepares an async
 .BR linkat (2)
@@ -50,7 +50,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_linkat.3
+++ b/man/io_uring_prep_linkat.3
@@ -7,9 +7,9 @@
 io_uring_prep_linkat \- prepare a linkat request
 .SH SYNOPSIS
 .nf
-.BR "#include <fcntl.h>"
-.BR "#include <unistd.h>"
-.BR "#include <liburing.h>"
+.B #include <fcntl.h>
+.B #include <unistd.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_linkat(struct io_uring_sqe *" sqe ","
 .BI "                          int " olddirfd ","

--- a/man/io_uring_prep_linkat.3
+++ b/man/io_uring_prep_linkat.3
@@ -17,7 +17,7 @@ io_uring_prep_linkat \- prepare a linkat request
 .BI "                          int " newdirfd ","
 .BI "                          const char *" newpath ","
 .BI "                          int " flags ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_linkat.3
+++ b/man/io_uring_prep_linkat.3
@@ -67,4 +67,6 @@ behavior by inspecting the
 flag passed back from
 .BR io_uring_queue_init_params (3).
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), linkat (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR linkat (2)

--- a/man/io_uring_prep_linkat.3
+++ b/man/io_uring_prep_linkat.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_linkat 3 "March 13, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_linkat  - prepare a linkat request
-.fi
+io_uring_prep_linkat \- prepare a linkat request
 .SH SYNOPSIS
 .nf
 .BR "#include <fcntl.h>"

--- a/man/io_uring_prep_madvise.3
+++ b/man/io_uring_prep_madvise.3
@@ -15,7 +15,7 @@ io_uring_prep_madvise \- prepare a madvise request
 .BI "                           void *" addr ","
 .BI "                           off_t " len ","
 .BI "                           int " advice ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_madvise.3
+++ b/man/io_uring_prep_madvise.3
@@ -29,7 +29,7 @@ to start an madvise operation at the virtual address of
 and of
 .I len
 length in bytes, giving it the advise located in
-.I advice.
+.IR advice .
 
 This function prepares an async
 .BR posix_madvise (2)
@@ -46,7 +46,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_madvise.3
+++ b/man/io_uring_prep_madvise.3
@@ -53,4 +53,7 @@ directly in the CQE
 .I res
 field.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), io_uring_register (2), posix_madvise (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR io_uring_register (2),
+.BR posix_madvise (2)

--- a/man/io_uring_prep_madvise.3
+++ b/man/io_uring_prep_madvise.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_madvise 3 "March 13, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_madvise  - prepare a madvise request
-.fi
+io_uring_prep_madvise \- prepare a madvise request
 .SH SYNOPSIS
 .nf
 .BR "#include <sys/mman.h>"

--- a/man/io_uring_prep_madvise.3
+++ b/man/io_uring_prep_madvise.3
@@ -7,8 +7,8 @@
 io_uring_prep_madvise \- prepare a madvise request
 .SH SYNOPSIS
 .nf
-.BR "#include <sys/mman.h>"
-.BR "#include <liburing.h>"
+.B #include <sys/mman.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_madvise(struct io_uring_sqe *" sqe ","
 .BI "                           int " fd ","

--- a/man/io_uring_prep_mkdirat.3
+++ b/man/io_uring_prep_mkdirat.3
@@ -7,9 +7,9 @@
 io_uring_prep_mkdirat \- prepare an mkdirat request
 .SH SYNOPSIS
 .nf
-.BR "#include <fcntl.h>"
-.BR "#include <sys/stat.h>"
-.BR "#include <liburing.h>"
+.B #include <fcntl.h>
+.B #include <sys/stat.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_mkdirat(struct io_uring_sqe *" sqe ","
 .BI "                           int " dirfd ","

--- a/man/io_uring_prep_mkdirat.3
+++ b/man/io_uring_prep_mkdirat.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_mkdirat 3 "March 13, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_mkdirat  - prepare an mkdirat request
-.fi
+io_uring_prep_mkdirat \- prepare an mkdirat request
 .SH SYNOPSIS
 .nf
 .BR "#include <fcntl.h>"

--- a/man/io_uring_prep_mkdirat.3
+++ b/man/io_uring_prep_mkdirat.3
@@ -27,7 +27,7 @@ is setup to use the directory file descriptor pointed to by
 to start an mkdirat operation on the path identified by
 .I path
 with the mode given in
-.I mode.
+.IR mode .
 
 This function prepares an async
 .BR mkdirat (2)
@@ -44,7 +44,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_mkdirat.3
+++ b/man/io_uring_prep_mkdirat.3
@@ -15,7 +15,7 @@ io_uring_prep_mkdirat \- prepare an mkdirat request
 .BI "                           int " dirfd ","
 .BI "                           const char *" path ","
 .BI "                           mode_t " mode ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_mkdirat.3
+++ b/man/io_uring_prep_mkdirat.3
@@ -61,4 +61,6 @@ behavior by inspecting the
 flag passed back from
 .BR io_uring_queue_init_params (3).
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), mkdirat (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR mkdirat (2)

--- a/man/io_uring_prep_msg_ring.3
+++ b/man/io_uring_prep_msg_ring.3
@@ -14,7 +14,7 @@ io_uring_prep_msg_ring \- send a message to another ring
 .BI "                        unsigned int " len ","
 .BI "                        __u64 " data ","
 .BI "                        unsigned int " flags ");"
-
+.fi
 .SH DESCRIPTION
 .PP
 .BR io_uring_prep_msg_ring (3)

--- a/man/io_uring_prep_msg_ring.3
+++ b/man/io_uring_prep_msg_ring.3
@@ -7,7 +7,7 @@
 io_uring_prep_msg_ring \- send a message to another ring
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_msg_ring(struct io_uring_sqe *" sqe ","
 .BI "                        int " fd ","
@@ -22,14 +22,14 @@ prepares a to send a CQE to an io_uring file descriptor. The submission queue
 entry
 .I sqe
 is setup to use the file descriptor
-.I fd
-, which must identify a io_uring context, to post a CQE on that ring where
-the target CQE
-.BR res
+.IR fd ,
+which must identify a io_uring context, to post a CQE on that ring where the
+target CQE
+.B res
 field will contain the content of
 .I len
 and the
-.BR user_data
+.B user_data
 of
 .I data
 with the request modifier flags set by

--- a/man/io_uring_prep_msg_ring.3
+++ b/man/io_uring_prep_msg_ring.3
@@ -33,9 +33,9 @@ and the
 of
 .I data
 with the request modifier flags set by
-.I flags.
+.IR flags .
 Currently there are no valid flag modifiers, this field must contain
-.B 0.
+.BR 0 .
 
 The targeted ring may be any ring that the user has access to, even the ring
 itself. This request can be used for simple message passing to another ring,

--- a/man/io_uring_prep_msg_ring.3
+++ b/man/io_uring_prep_msg_ring.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_msg_ring 3 "March 10, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_msg_ring   - send a message to another ring
-
+io_uring_prep_msg_ring \- send a message to another ring
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_prep_openat.3
+++ b/man/io_uring_prep_openat.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_openat 3 "March 13, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_openat  - prepare an openat request
-.fi
+io_uring_prep_openat \- prepare an openat request
 .SH SYNOPSIS
 .nf
 .BR "#include <sys/types.h>"

--- a/man/io_uring_prep_openat.3
+++ b/man/io_uring_prep_openat.3
@@ -7,10 +7,10 @@
 io_uring_prep_openat \- prepare an openat request
 .SH SYNOPSIS
 .nf
-.BR "#include <sys/types.h>"
-.BR "#include <sys/stat.h>"
-.BR "#include <fcntl.h>"
-.BR "#include <liburing.h>"
+.B #include <sys/types.h>
+.B #include <sys/stat.h>
+.B #include <fcntl.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_openat(struct io_uring_sqe *" sqe ","
 .BI "                          int " dfd ","

--- a/man/io_uring_prep_openat.3
+++ b/man/io_uring_prep_openat.3
@@ -38,7 +38,7 @@ to start opening a file described by
 and using the open flags in
 .I flags
 and using the file mode bits specified in
-.I mode.
+.IR mode .
 
 For a direct descriptor open request, the offset is specified by the
 .I file_index
@@ -94,7 +94,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_openat.3
+++ b/man/io_uring_prep_openat.3
@@ -17,7 +17,7 @@ io_uring_prep_openat \- prepare an openat request
 .BI "                          const char *" path ","
 .BI "                          int " flags ","
 .BI "                          mode_t " mode ");"
-.BI "
+.PP
 .BI "void io_uring_prep_openat_direct(struct io_uring_sqe *" sqe ","
 .BI "                                 int " dfd ","
 .BI "                                 const char *" path ","

--- a/man/io_uring_prep_openat.3
+++ b/man/io_uring_prep_openat.3
@@ -111,4 +111,7 @@ behavior by inspecting the
 flag passed back from
 .BR io_uring_queue_init_params (3).
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), io_uring_register (2), openat (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR io_uring_register (2),
+.BR openat (2)

--- a/man/io_uring_prep_openat.3
+++ b/man/io_uring_prep_openat.3
@@ -24,7 +24,7 @@ io_uring_prep_openat \- prepare an openat request
 .BI "                                 int " flags ","
 .BI "                                 mode_t " mode ","
 .BI "                                 unsigned " file_index ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_openat2.3
+++ b/man/io_uring_prep_openat2.3
@@ -25,7 +25,7 @@ io_uring_prep_openat2 \- prepare an openat2 request
 .BI "                                  int " flags ","
 .BI "                                  struct open_how *" how ","
 .BI "                                  unsigned " file_index ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_openat2.3
+++ b/man/io_uring_prep_openat2.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_openat2 3 "March 13, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_openat2  - prepare an openat2 request
-.fi
+io_uring_prep_openat2 \- prepare an openat2 request
 .SH SYNOPSIS
 .nf
 .BR "#include <sys/types.h>"

--- a/man/io_uring_prep_openat2.3
+++ b/man/io_uring_prep_openat2.3
@@ -18,7 +18,7 @@ io_uring_prep_openat2 \- prepare an openat2 request
 .BI "                           const char *" path ","
 .BI "                           int " flags ","
 .BI "                           struct open_how *" how ");"
-.BI "
+.PP
 .BI "void io_uring_prep_openat2_direct(struct io_uring_sqe *" sqe ","
 .BI "                                  int " dfd ","
 .BI "                                  const char *" path ","

--- a/man/io_uring_prep_openat2.3
+++ b/man/io_uring_prep_openat2.3
@@ -7,11 +7,11 @@
 io_uring_prep_openat2 \- prepare an openat2 request
 .SH SYNOPSIS
 .nf
-.BR "#include <sys/types.h>"
-.BR "#include <sys/stat.h>"
-.BR "#include <fcntl.h>"
-.BR "#include <linux/openat2.h>"
-.BR "#include <liburing.h>"
+.B #include <sys/types.h>
+.B #include <sys/stat.h>
+.B #include <fcntl.h>
+.B #include <linux/openat2.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_openat2(struct io_uring_sqe *" sqe ","
 .BI "                           int " dfd ","

--- a/man/io_uring_prep_openat2.3
+++ b/man/io_uring_prep_openat2.3
@@ -111,4 +111,7 @@ behavior by inspecting the
 flag passed back from
 .BR io_uring_queue_init_params (3).
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), io_uring_register (2), openat2 (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR io_uring_register (2),
+.BR openat2 (2)

--- a/man/io_uring_prep_openat2.3
+++ b/man/io_uring_prep_openat2.3
@@ -39,7 +39,7 @@ to start opening a file described by
 and using the open flags in
 .I flags
 and using the instructions on how to open the file given in
-.I how.
+.IR how .
 
 For a direct descriptor open request, the offset is specified by the
 .I file_index
@@ -94,7 +94,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_poll_add.3
+++ b/man/io_uring_prep_poll_add.3
@@ -59,7 +59,7 @@ man page for details. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_poll_add.3
+++ b/man/io_uring_prep_poll_add.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_poll_add 3 "March 12, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_poll_add  - prepare a poll request
-.fi
+io_uring_prep_poll_add \- prepare a poll request
 .SH SYNOPSIS
 .nf
 .BR "#include <poll.h>"

--- a/man/io_uring_prep_poll_add.3
+++ b/man/io_uring_prep_poll_add.3
@@ -7,8 +7,8 @@
 io_uring_prep_poll_add \- prepare a poll request
 .SH SYNOPSIS
 .nf
-.BR "#include <poll.h>"
-.BR "#include <liburing.h>"
+.B #include <poll.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_poll_add(struct io_uring_sqe *" sqe ","
 .BI "                            int " fd ","

--- a/man/io_uring_prep_poll_add.3
+++ b/man/io_uring_prep_poll_add.3
@@ -13,7 +13,7 @@ io_uring_prep_poll_add \- prepare a poll request
 .BI "void io_uring_prep_poll_add(struct io_uring_sqe *" sqe ","
 .BI "                            int " fd ","
 .BI "                            unsigned " poll_mask ");"
-.BI "
+.PP
 .BI "void io_uring_prep_poll_multishot(struct io_uring_sqe *" sqe ","
 .BI "                                  int " fd ","
 .BI "                                  unsigned " poll_mask ");"

--- a/man/io_uring_prep_poll_add.3
+++ b/man/io_uring_prep_poll_add.3
@@ -17,7 +17,7 @@ io_uring_prep_poll_add \- prepare a poll request
 .BI "void io_uring_prep_poll_multishot(struct io_uring_sqe *" sqe ","
 .BI "                                  int " fd ","
 .BI "                                  unsigned " poll_mask ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_poll_add.3
+++ b/man/io_uring_prep_poll_add.3
@@ -66,4 +66,7 @@ directly in the CQE
 .I res
 field.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), poll (2), epoll_ctl (3)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR poll (2),
+.BR epoll_ctl (3)

--- a/man/io_uring_prep_poll_remove.3
+++ b/man/io_uring_prep_poll_remove.3
@@ -12,7 +12,7 @@ io_uring_prep_poll_remove \- prepare a poll deletion request
 .BI "void io_uring_prep_poll_remove(struct io_uring_sqe *" sqe ","
 .BI "                               __u64 " user_data ");"
 .BI "
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_poll_remove.3
+++ b/man/io_uring_prep_poll_remove.3
@@ -50,4 +50,6 @@ The execution state of the request has progressed far enough that cancelation
 is no longer possible. This should normally mean that it will complete shortly,
 either successfully, or interrupted due to the cancelation.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), io_uring_prep_cancel (3)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR io_uring_prep_cancel (3)

--- a/man/io_uring_prep_poll_remove.3
+++ b/man/io_uring_prep_poll_remove.3
@@ -7,7 +7,7 @@
 io_uring_prep_poll_remove \- prepare a poll deletion request
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_poll_remove(struct io_uring_sqe *" sqe ","
 .BI "                               __u64 " user_data ");"

--- a/man/io_uring_prep_poll_remove.3
+++ b/man/io_uring_prep_poll_remove.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_poll_remove 3 "March 12, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_poll_remove  - prepare a poll deletion request
-.fi
+io_uring_prep_poll_remove \- prepare a poll deletion request
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_prep_poll_update.3
+++ b/man/io_uring_prep_poll_update.3
@@ -15,7 +15,7 @@ io_uring_prep_poll_update \- update an existing poll request
 .BI "                               __u64 " new_user_data ","
 .BI "                               unsigned " poll_mask ","
 .BI "                               unsigned " flags ");"
-
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_poll_update.3
+++ b/man/io_uring_prep_poll_update.3
@@ -83,4 +83,7 @@ was set and an error occurred re-arming the poll request with the new mask.
 The original poll request is terminated if this happens, and that termination
 CQE will contain the reason for the error re-arming.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), io_uring_prep_poll_add (3), io_uring_prep_poll_multishot (3)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR io_uring_prep_poll_add (3),
+.BR io_uring_prep_poll_multishot (3)

--- a/man/io_uring_prep_poll_update.3
+++ b/man/io_uring_prep_poll_update.3
@@ -7,8 +7,8 @@
 io_uring_prep_poll_update \- update an existing poll request
 .SH SYNOPSIS
 .nf
-.BR "#include <poll.h>"
-.BR "#include <liburing.h>"
+.B #include <poll.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_poll_update(struct io_uring_sqe *" sqe ","
 .BI "                               __u64 " old_user_data ","

--- a/man/io_uring_prep_poll_update.3
+++ b/man/io_uring_prep_poll_update.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_poll_update 3 "March 12, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_poll_update  - update an existing poll request
-.fi
+io_uring_prep_poll_update \- update an existing poll request
 .SH SYNOPSIS
 .nf
 .BR "#include <poll.h>"

--- a/man/io_uring_prep_poll_update.3
+++ b/man/io_uring_prep_poll_update.3
@@ -23,7 +23,7 @@ The
 function prepares a poll update request. The submission queue entry
 .I sqe
 is setup to update a poll request identified by
-.I old_user_data,
+.IR old_user_data ,
 replacing it with the
 .I new_user_data
 information. The

--- a/man/io_uring_prep_provide_buffers.3
+++ b/man/io_uring_prep_provide_buffers.3
@@ -125,4 +125,7 @@ and the length of buffers overflowed.
 .B -EBUSY
 Attempt to update a slot that is already used.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), io_uring_register (2), io_uring_prep_remove_buffers (3)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR io_uring_register (2),
+.BR io_uring_prep_remove_buffers (3)

--- a/man/io_uring_prep_provide_buffers.3
+++ b/man/io_uring_prep_provide_buffers.3
@@ -15,7 +15,7 @@ io_uring_prep_provide_buffers \- prepare a provide buffers request
 .BI "                                   int " nr ","
 .BI "                                   int " bgid ","
 .BI "                                   int " bid ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_provide_buffers.3
+++ b/man/io_uring_prep_provide_buffers.3
@@ -30,7 +30,7 @@ number of buffers starting at
 and identified by the buffer group ID of
 .I bgid
 and numbered sequentially starting at
-.I bid.
+.IR bid .
 
 This function sets up a request to provide buffers to the io_uring context
 that can be used by read or receive operations. This is done by filling in
@@ -64,7 +64,7 @@ and sequentially ascending from that value. If
 buffers are provided and start with an initial
 .I bid
 of 0, then the buffer IDs will range from
-.B 0..15.
+.BR 0..15 .
 The application must be aware of this to make sense of the buffer ID passed
 back in the CQE.
 
@@ -76,7 +76,7 @@ receive request. Attempting to use
 with a command that doesn't support it will result in a CQE
 .I res
 error of
-.B -EINVAL.
+.BR -EINVAL .
 Buffer selection will work with operations that take a
 .BR struct iovec
 as its data destination, but only if 1 iovec is provided.

--- a/man/io_uring_prep_provide_buffers.3
+++ b/man/io_uring_prep_provide_buffers.3
@@ -7,7 +7,7 @@
 io_uring_prep_provide_buffers \- prepare a provide buffers request
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_provide_buffers(struct io_uring_sqe *" sqe ","
 .BI "                                   void *" addr ","
@@ -78,7 +78,7 @@ with a command that doesn't support it will result in a CQE
 error of
 .BR -EINVAL .
 Buffer selection will work with operations that take a
-.BR struct iovec
+.B struct iovec
 as its data destination, but only if 1 iovec is provided.
 .
 .SH RETURN VALUE

--- a/man/io_uring_prep_provide_buffers.3
+++ b/man/io_uring_prep_provide_buffers.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_provide_buffers 3 "March 13, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_provide_buffers  - prepare a provide buffers request
-.fi
+io_uring_prep_provide_buffers \- prepare a provide buffers request
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_prep_read.3
+++ b/man/io_uring_prep_read.3
@@ -28,10 +28,10 @@ to start reading
 into the buffer
 .I buf
 at the specified
-.I offset.
+.IR offset .
 
 On files that support seeking, if the offset is set to
-.B -1,
+.BR -1 ,
 the read operation commences at the file offset, and the file offset is
 incremented by the number of bytes read. See
 .BR read (2)
@@ -56,7 +56,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_read.3
+++ b/man/io_uring_prep_read.3
@@ -14,7 +14,7 @@ io_uring_prep_read \- prepare I/O read request
 .BI "                        void *" buf ","
 .BI "                        unsigned " nbytes ","
 .BI "                        __u64 " offset ");"
-
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_read.3
+++ b/man/io_uring_prep_read.3
@@ -63,4 +63,7 @@ directly in the CQE
 .I res
 field.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_prep_readv (3), io_uring_prep_readv2 (3), io_uring_submit(3)
+.BR io_uring_get_sqe (3),
+.BR io_uring_prep_readv (3),
+.BR io_uring_prep_readv2 (3),
+.BR io_uring_submit(3)

--- a/man/io_uring_prep_read.3
+++ b/man/io_uring_prep_read.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_read 3 "November 15, 2021" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_prep_read   - prepare I/O read request
-
+io_uring_prep_read \- prepare I/O read request
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_prep_read.3
+++ b/man/io_uring_prep_read.3
@@ -7,7 +7,7 @@
 io_uring_prep_read \- prepare I/O read request
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_read(struct io_uring_sqe *" sqe ","
 .BI "                        int " fd ","
@@ -66,4 +66,4 @@ field.
 .BR io_uring_get_sqe (3),
 .BR io_uring_prep_readv (3),
 .BR io_uring_prep_readv2 (3),
-.BR io_uring_submit(3)
+.BR io_uring_submit (3)

--- a/man/io_uring_prep_read_fixed.3
+++ b/man/io_uring_prep_read_fixed.3
@@ -15,7 +15,7 @@ io_uring_prep_read_fixed \- prepare I/O read request with registered buffer
 .BI "                        unsigned " nbytes ","
 .BI "                        __u64 " offset ","
 .BI "                        int " buf_index ");"
-
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_read_fixed.3
+++ b/man/io_uring_prep_read_fixed.3
@@ -7,7 +7,7 @@
 io_uring_prep_read_fixed \- prepare I/O read request with registered buffer
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_read_fixed(struct io_uring_sqe *" sqe ","
 .BI "                        int " fd ","

--- a/man/io_uring_prep_read_fixed.3
+++ b/man/io_uring_prep_read_fixed.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_read 3 "February 13, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_prep_read_fixed   - prepare I/O read request with registered buffer
-
+io_uring_prep_read_fixed \- prepare I/O read request with registered buffer
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_prep_read_fixed.3
+++ b/man/io_uring_prep_read_fixed.3
@@ -68,4 +68,5 @@ directly in the CQE
 .I res
 field.
 .SH SEE ALSO
-.BR io_uring_prep_read (3), io_uring_register_buffers (3)
+.BR io_uring_prep_read (3),
+.BR io_uring_register_buffers (3)

--- a/man/io_uring_prep_read_fixed.3
+++ b/man/io_uring_prep_read_fixed.3
@@ -30,14 +30,14 @@ to start reading
 into the buffer
 .I buf
 at the specified
-.I offset,
+.IR offset ,
 and with the buffer matching the registered index of
-.I buf_index.
+.IR buf_index .
 
 This works just like
-.B io_uring_prep_read(3)
+.BR io_uring_prep_read (3)
 except it requires the use of buffers that have been registered with
-.B io_uring_register_buffers(3).
+.BR io_uring_register_buffers (3).
 The
 .I buf
 and
@@ -61,7 +61,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_readv.3
+++ b/man/io_uring_prep_readv.3
@@ -15,7 +15,7 @@ io_uring_prep_readv \- prepare vector I/O read request
 .BI "                         const struct iovec *" iovecs ","
 .BI "                         unsigned " nr_vecs ","
 .BI "                         __u64 " offset ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_readv.3
+++ b/man/io_uring_prep_readv.3
@@ -7,8 +7,8 @@
 io_uring_prep_readv \- prepare vector I/O read request
 .SH SYNOPSIS
 .nf
-.BR "#include <sys/uio.h>"
-.BR "#include <liburing.h>"
+.B #include <sys/uio.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_readv(struct io_uring_sqe *" sqe ","
 .BI "                         int " fd ","

--- a/man/io_uring_prep_readv.3
+++ b/man/io_uring_prep_readv.3
@@ -79,4 +79,7 @@ behavior by inspecting the
 flag passed back from
 .BR io_uring_queue_init_params (3).
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_prep_read (3), io_uring_prep_readv2 (3), io_uring_submit (3)
+.BR io_uring_get_sqe (3),
+.BR io_uring_prep_read (3),
+.BR io_uring_prep_readv2 (3),
+.BR io_uring_submit (3)

--- a/man/io_uring_prep_readv.3
+++ b/man/io_uring_prep_readv.3
@@ -29,10 +29,10 @@ to start reading
 into the
 .I iovecs
 array at the specified
-.I offset.
+.IR offset .
 
 On files that support seeking, if the offset is set to
-.B -1,
+.BR -1 ,
 the read operation commences at the file offset, and the file offset is
 incremented by the number of bytes read. See
 .BR read (2)
@@ -57,7 +57,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_readv.3
+++ b/man/io_uring_prep_readv.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_readv 3 "November 15, 2021" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_prep_readv  - prepare vector I/O read request
-.fi
+io_uring_prep_readv \- prepare vector I/O read request
 .SH SYNOPSIS
 .nf
 .BR "#include <sys/uio.h>"

--- a/man/io_uring_prep_readv2.3
+++ b/man/io_uring_prep_readv2.3
@@ -7,8 +7,8 @@
 io_uring_prep_readv2 \- prepare vector I/O read request with flags
 .SH SYNOPSIS
 .nf
-.BR "#include <sys/uio.h>"
-.BR "#include <liburing.h>"
+.B #include <sys/uio.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_readv2(struct io_uring_sqe *" sqe ","
 .BI "                          int " fd ","

--- a/man/io_uring_prep_readv2.3
+++ b/man/io_uring_prep_readv2.3
@@ -106,4 +106,7 @@ behavior by inspecting the
 flag passed back from
 .BR io_uring_queue_init_params (3).
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_prep_read (3), io_uring_prep_readv (3), io_uring_submit (3)
+.BR io_uring_get_sqe (3),
+.BR io_uring_prep_read (3),
+.BR io_uring_prep_readv (3),
+.BR io_uring_submit (3)

--- a/man/io_uring_prep_readv2.3
+++ b/man/io_uring_prep_readv2.3
@@ -17,7 +17,6 @@ io_uring_prep_readv2 \- prepare vector I/O read request with flags
 .BI "                          __u64 " offset ","
 .BI "                          int " flags ");"
 .fi
-.PP
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_readv2.3
+++ b/man/io_uring_prep_readv2.3
@@ -4,9 +4,7 @@
 .\"
 .TH io_uring_prep_readv2 3 "November 15, 2021" "liburing-2.1" "liburing Manual"
 .SH NAME
-.fi
-io_uring_prep_readv2 - prepare vector I/O read request with flags
-
+io_uring_prep_readv2 \- prepare vector I/O read request with flags
 .SH SYNOPSIS
 .nf
 .BR "#include <sys/uio.h>"

--- a/man/io_uring_prep_readv2.3
+++ b/man/io_uring_prep_readv2.3
@@ -31,7 +31,7 @@ to start reading
 into the
 .I iovecs
 array at the specified
-.I offset.
+.IR offset .
 The behavior of the function can be controlled with the
 .I flags
 parameter.
@@ -59,7 +59,7 @@ per-IO O_APPEND
 
 .P
 On files that support seeking, if the offset is set to
-.B -1,
+.BR -1 ,
 the read operation commences at the file offset, and the file offset is
 incremented by the number of bytes read. See
 .BR read (2)
@@ -84,7 +84,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_recv.3
+++ b/man/io_uring_prep_recv.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_recv 3 "March 12, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_recv  - prepare a recv request
-.fi
+io_uring_prep_recv \- prepare a recv request
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_prep_recv.3
+++ b/man/io_uring_prep_recv.3
@@ -7,7 +7,7 @@
 io_uring_prep_recv \- prepare a recv request
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_recv(struct io_uring_sqe *" sqe ","
 .BI "                        int " sockfd ","

--- a/man/io_uring_prep_recv.3
+++ b/man/io_uring_prep_recv.3
@@ -14,7 +14,7 @@ io_uring_prep_recv \- prepare a recv request
 .BI "                        void *" buf ","
 .BI "                        size_t " len ","
 .BI "                        int " flags ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_recv.3
+++ b/man/io_uring_prep_recv.3
@@ -78,4 +78,6 @@ directly in the CQE
 .I res
 field.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), recv (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR recv (2)

--- a/man/io_uring_prep_recv.3
+++ b/man/io_uring_prep_recv.3
@@ -29,7 +29,7 @@ to start receiving the data into the buffer destination
 of size
 .I size
 and with modifier flags
-.I flags.
+.IR flags .
 
 This function prepares an async
 .BR recv (2)
@@ -71,7 +71,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_recvmsg.3
+++ b/man/io_uring_prep_recvmsg.3
@@ -89,4 +89,6 @@ behavior by inspecting the
 flag passed back from
 .BR io_uring_queue_init_params (3).
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), recvmsg (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR recvmsg (2)

--- a/man/io_uring_prep_recvmsg.3
+++ b/man/io_uring_prep_recvmsg.3
@@ -72,7 +72,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_recvmsg.3
+++ b/man/io_uring_prep_recvmsg.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_recvmsg 3 "March 12, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_recvmsg  - prepare a recvmsg request
-.fi
+io_uring_prep_recvmsg \- prepare a recvmsg request
 .SH SYNOPSIS
 .nf
 .BR "#include <sys/types.h>"

--- a/man/io_uring_prep_recvmsg.3
+++ b/man/io_uring_prep_recvmsg.3
@@ -7,9 +7,9 @@
 io_uring_prep_recvmsg \- prepare a recvmsg request
 .SH SYNOPSIS
 .nf
-.BR "#include <sys/types.h>"
-.BR "#include <sys/socket.h>"
-.BR "#include <liburing.h>"
+.B #include <sys/types.h>
+.B #include <sys/socket.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_recvmsg(struct io_uring_sqe *" sqe ","
 .BI "                           int " fd ","

--- a/man/io_uring_prep_recvmsg.3
+++ b/man/io_uring_prep_recvmsg.3
@@ -15,7 +15,7 @@ io_uring_prep_recvmsg \- prepare a recvmsg request
 .BI "                           int " fd ","
 .BI "                           struct msghdr *" msg ","
 .BI "                           unsigned " flags ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_remove_buffers.3
+++ b/man/io_uring_prep_remove_buffers.3
@@ -12,7 +12,7 @@ io_uring_prep_remove_buffers \- prepare a remove buffers request
 .BI "void io_uring_prep_remove_buffers(struct io_uring_sqe *" sqe ","
 .BI "                                   int " nr ","
 .BI "                                   int " bgid ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_remove_buffers.3
+++ b/man/io_uring_prep_remove_buffers.3
@@ -46,4 +46,7 @@ No buffers exist at the specified
 .I bgid
 buffer group ID.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), io_uring_register (2), io_uring_prep_provide_buffers (3)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR io_uring_register (2),
+.BR io_uring_prep_provide_buffers (3)

--- a/man/io_uring_prep_remove_buffers.3
+++ b/man/io_uring_prep_remove_buffers.3
@@ -23,7 +23,7 @@ submission queue entry
 is setup to remove
 .I nr
 number of buffers from the buffer group ID indicated by
-.I bgid.
+.IR bgid .
 
 .SH RETURN VALUE
 None

--- a/man/io_uring_prep_remove_buffers.3
+++ b/man/io_uring_prep_remove_buffers.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_remove_buffers 3 "March 13, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_remove_buffers  - prepare a remove buffers request
-.fi
+io_uring_prep_remove_buffers \- prepare a remove buffers request
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_prep_remove_buffers.3
+++ b/man/io_uring_prep_remove_buffers.3
@@ -7,7 +7,7 @@
 io_uring_prep_remove_buffers \- prepare a remove buffers request
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_remove_buffers(struct io_uring_sqe *" sqe ","
 .BI "                                   int " nr ","

--- a/man/io_uring_prep_renameat.3
+++ b/man/io_uring_prep_renameat.3
@@ -71,4 +71,7 @@ behavior by inspecting the
 flag passed back from
 .BR io_uring_queue_init_params (3).
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), renameat (2), renameat2 (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR renameat (2),
+.BR renameat2 (2)

--- a/man/io_uring_prep_renameat.3
+++ b/man/io_uring_prep_renameat.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_renameat 3 "March 13, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_renameat  - prepare a renameat request
-.fi
+io_uring_prep_renameat \- prepare a renameat request
 .SH SYNOPSIS
 .nf
 .BR "#include <fcntl.h>"

--- a/man/io_uring_prep_renameat.3
+++ b/man/io_uring_prep_renameat.3
@@ -17,7 +17,7 @@ io_uring_prep_renameat \- prepare a renameat request
 .BI "                            int " newdirfd ","
 .BI "                            const char *" newpath ","
 .BI "                            int " flags ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_renameat.3
+++ b/man/io_uring_prep_renameat.3
@@ -7,9 +7,9 @@
 io_uring_prep_renameat \- prepare a renameat request
 .SH SYNOPSIS
 .nf
-.BR "#include <fcntl.h>"
-.BR "#include <stdio.h>"
-.BR "#include <liburing.h>"
+.B #include <fcntl.h>
+.B #include <stdio.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_renameat(struct io_uring_sqe *" sqe ","
 .BI "                            int " olddirfd ","

--- a/man/io_uring_prep_renameat.3
+++ b/man/io_uring_prep_renameat.3
@@ -33,7 +33,7 @@ with the new directory file descriptor pointed to by
 and the new path pointed to by
 .I newpath
 and using the specified flags in
-.I flags.
+.IR flags .
 
 This function prepares an async
 .BR renameat2 (2)
@@ -54,7 +54,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_send.3
+++ b/man/io_uring_prep_send.3
@@ -14,7 +14,7 @@ io_uring_prep_send \- prepare a send request
 .BI "                        const void *" buf ","
 .BI "                        size_t " len ","
 .BI "                        int " flags ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_send.3
+++ b/man/io_uring_prep_send.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_send 3 "March 12, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_send  - prepare a send request
-.fi
+io_uring_prep_send \- prepare a send request
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_prep_send.3
+++ b/man/io_uring_prep_send.3
@@ -7,7 +7,7 @@
 io_uring_prep_send \- prepare a send request
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_send(struct io_uring_sqe *" sqe ","
 .BI "                        int " sockfd ","

--- a/man/io_uring_prep_send.3
+++ b/man/io_uring_prep_send.3
@@ -52,4 +52,6 @@ directly in the CQE
 .I res
 field.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), send (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR send (2)

--- a/man/io_uring_prep_send.3
+++ b/man/io_uring_prep_send.3
@@ -28,7 +28,7 @@ to start sending the data from
 of size
 .I size
 and with modifier flags
-.I flags.
+.IR flags .
 
 This function prepares an async
 .BR send (2)
@@ -45,7 +45,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_sendmsg.3
+++ b/man/io_uring_prep_sendmsg.3
@@ -64,4 +64,6 @@ behavior by inspecting the
 flag passed back from
 .BR io_uring_queue_init_params (3).
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), sendmsg (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR sendmsg (2)

--- a/man/io_uring_prep_sendmsg.3
+++ b/man/io_uring_prep_sendmsg.3
@@ -7,9 +7,9 @@
 io_uring_prep_sendmsg \- prepare a sendmsg request
 .SH SYNOPSIS
 .nf
-.BR "#include <sys/types.h>"
-.BR "#include <sys/socket.h>"
-.BR "#include <liburing.h>"
+.B #include <sys/types.h>
+.B #include <sys/socket.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_sendmsg(struct io_uring_sqe *" sqe ","
 .BI "                           int " fd ","

--- a/man/io_uring_prep_sendmsg.3
+++ b/man/io_uring_prep_sendmsg.3
@@ -47,7 +47,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_sendmsg.3
+++ b/man/io_uring_prep_sendmsg.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_sendmsg 3 "March 12, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_sendmsg  - prepare a sendmsg request
-.fi
+io_uring_prep_sendmsg \- prepare a sendmsg request
 .SH SYNOPSIS
 .nf
 .BR "#include <sys/types.h>"

--- a/man/io_uring_prep_sendmsg.3
+++ b/man/io_uring_prep_sendmsg.3
@@ -15,7 +15,7 @@ io_uring_prep_sendmsg \- prepare a sendmsg request
 .BI "                           int " fd ","
 .BI "                           const struct msghdr *" msg ","
 .BI "                           unsigned " flags ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_shutdown.3
+++ b/man/io_uring_prep_shutdown.3
@@ -7,8 +7,8 @@
 io_uring_prep_shutdown \- prepare a shutdown request
 .SH SYNOPSIS
 .nf
-.BR "#include <sys/socket.h>"
-.BR "#include <liburing.h>"
+.B #include <sys/socket.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_shutdown(struct io_uring_sqe *" sqe ","
 .BI "                            int " sockfd ","

--- a/man/io_uring_prep_shutdown.3
+++ b/man/io_uring_prep_shutdown.3
@@ -41,7 +41,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_shutdown.3
+++ b/man/io_uring_prep_shutdown.3
@@ -13,7 +13,7 @@ io_uring_prep_shutdown \- prepare a shutdown request
 .BI "void io_uring_prep_shutdown(struct io_uring_sqe *" sqe ","
 .BI "                            int " sockfd ","
 .BI "                            int " how ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_shutdown.3
+++ b/man/io_uring_prep_shutdown.3
@@ -48,4 +48,6 @@ directly in the CQE
 .I res
 field.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), shutdown (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR shutdown (2)

--- a/man/io_uring_prep_shutdown.3
+++ b/man/io_uring_prep_shutdown.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_shutdown 3 "March 12, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_shutdown  - prepare a shutdown request
-.fi
+io_uring_prep_shutdown \- prepare a shutdown request
 .SH SYNOPSIS
 .nf
 .BR "#include <sys/socket.h>"

--- a/man/io_uring_prep_socket.3
+++ b/man/io_uring_prep_socket.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_socket 3 "May 27, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_socket  - prepare a socket creation request
-.fi
+io_uring_prep_socket \- prepare a socket creation request
 .SH SYNOPSIS
 .nf
 .BR "#include <sys/socket.h>"

--- a/man/io_uring_prep_socket.3
+++ b/man/io_uring_prep_socket.3
@@ -22,7 +22,7 @@ io_uring_prep_socket \- prepare a socket creation request
 .BI "                                 int " protocol ","
 .BI "                                 unsigned int " file_index ","
 .BI "                                 unsigned int " flags ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_socket.3
+++ b/man/io_uring_prep_socket.3
@@ -92,4 +92,6 @@ directly in the CQE
 .I res
 field.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), socket (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR socket (2)

--- a/man/io_uring_prep_socket.3
+++ b/man/io_uring_prep_socket.3
@@ -15,7 +15,7 @@ io_uring_prep_socket \- prepare a socket creation request
 .BI "                          int " type ","
 .BI "                          int " protocol ","
 .BI "                          unsigned int " flags ");"
-.BI "
+.PP
 .BI "void io_uring_prep_socket_direct(struct io_uring_sqe *" sqe ","
 .BI "                                 int " domain ","
 .BI "                                 int " type ","

--- a/man/io_uring_prep_socket.3
+++ b/man/io_uring_prep_socket.3
@@ -7,8 +7,8 @@
 io_uring_prep_socket \- prepare a socket creation request
 .SH SYNOPSIS
 .nf
-.BR "#include <sys/socket.h>"
-.BR "#include <liburing.h>"
+.B #include <sys/socket.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_socket(struct io_uring_sqe *" sqe ","
 .BI "                          int " domain ","

--- a/man/io_uring_prep_socket.3
+++ b/man/io_uring_prep_socket.3
@@ -34,7 +34,7 @@ is setup to use the communication domain defined by
 and use the communication type defined by
 .I type
 and the protocol set by
-.I protocol.
+.IR protocol .
 The
 .I flags
 argument are currently unused.
@@ -67,10 +67,10 @@ existing file with
 For a direct descriptor socket request, the
 .I file_index
 argument can be set to
-.B IORING_FILE_INDEX_ALLOC,
+.BR IORING_FILE_INDEX_ALLOC ,
 In this case a free entry in io_uring file table will
 be used automatically and the file index will be returned as CQE
-.I res.
+.IR res .
 .B -ENFILE
 is otherwise returned if there is no free entries in the io_uring file table.
 
@@ -85,7 +85,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_splice.3
+++ b/man/io_uring_prep_splice.3
@@ -17,7 +17,7 @@ io_uring_prep_splice \- prepare an splice request
 .BI "                          int64_t " off_out ","
 .BI "                          unsigned int " nbytes ","
 .BI "                          unsigned int " splice_flags ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_splice.3
+++ b/man/io_uring_prep_splice.3
@@ -74,4 +74,7 @@ directly in the CQE
 .I res
 field.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), io_uring_register (2), splice (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR io_uring_register (2),
+.BR splice (2)

--- a/man/io_uring_prep_splice.3
+++ b/man/io_uring_prep_splice.3
@@ -7,8 +7,8 @@
 io_uring_prep_splice \- prepare an splice request
 .SH SYNOPSIS
 .nf
-.BR "#include <fcntl.h>"
-.BR "#include <liburing.h>"
+.B #include <fcntl.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_splice(struct io_uring_sqe *" sqe ","
 .BI "                          int " fd_in ","

--- a/man/io_uring_prep_splice.3
+++ b/man/io_uring_prep_splice.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_splice 3 "March 13, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_splice  - prepare an splice request
-.fi
+io_uring_prep_splice \- prepare an splice request
 .SH SYNOPSIS
 .nf
 .BR "#include <fcntl.h>"

--- a/man/io_uring_prep_splice.3
+++ b/man/io_uring_prep_splice.3
@@ -27,11 +27,11 @@ function prepares a splice request. The submission queue entry
 is setup to use as input the file descriptor
 .I fd_in
 at offset
-.I off_in,
+.IR off_in ,
 splicing data to the file descriptor at
 .I fd_out
 and at offset
-.I off_out.
+.IR off_out .
 .I nbytes
 bytes of data should be spliced between the two descriptors.
 .I splice_flags
@@ -67,7 +67,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_statx.3
+++ b/man/io_uring_prep_statx.3
@@ -69,4 +69,6 @@ behavior by inspecting the
 flag passed back from
 .BR io_uring_queue_init_params (3).
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), statx (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR statx (2)

--- a/man/io_uring_prep_statx.3
+++ b/man/io_uring_prep_statx.3
@@ -7,11 +7,11 @@
 io_uring_prep_statx \- prepare a statx request
 .SH SYNOPSIS
 .nf
-.BR "#include <sys/types.h>"
-.BR "#include <sys/stat.h>"
-.BR "#include <unistd.h>"
-.BR "#include <fcntl.h>"
-.BR "#include <liburing.h>"
+.B #include <sys/types.h>
+.B #include <sys/stat.h>
+.B #include <unistd.h>
+.B #include <fcntl.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_statx(struct io_uring_sqe *" sqe ","
 .BI "                         int " dirfd ","

--- a/man/io_uring_prep_statx.3
+++ b/man/io_uring_prep_statx.3
@@ -35,7 +35,7 @@ and using the flags given in
 for the fields specified by
 .I mask
 and into the buffer located at
-.I statxbuf.
+.IR statxbuf .
 
 This function prepares an async
 .BR statx (2)
@@ -52,7 +52,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_statx.3
+++ b/man/io_uring_prep_statx.3
@@ -19,7 +19,7 @@ io_uring_prep_statx \- prepare a statx request
 .BI "                         int " flags ","
 .BI "                         unsigned " mask ","
 .BI "                         struct statx *" statxbuf ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_statx.3
+++ b/man/io_uring_prep_statx.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_statx 3 "March 13, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_statx  - prepare a statx request
-.fi
+io_uring_prep_statx \- prepare a statx request
 .SH SYNOPSIS
 .nf
 .BR "#include <sys/types.h>"

--- a/man/io_uring_prep_symlinkat.3
+++ b/man/io_uring_prep_symlinkat.3
@@ -15,7 +15,7 @@ io_uring_prep_symlinkat \- prepare a symlinkat request
 .BI "                             const char *" target ","
 .BI "                             int " newdirfd ","
 .BI "                             const char *" linkpath ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_symlinkat.3
+++ b/man/io_uring_prep_symlinkat.3
@@ -61,4 +61,6 @@ behavior by inspecting the
 flag passed back from
 .BR io_uring_queue_init_params (3).
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), symlinkat (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR symlinkat (2)

--- a/man/io_uring_prep_symlinkat.3
+++ b/man/io_uring_prep_symlinkat.3
@@ -27,7 +27,7 @@ is setup to symlink the target path pointed to by
 to the new destination indicated by
 .I newdirfd
 and
-.I linkpath.
+.IR linkpath .
 
 This function prepares an async
 .BR symlinkat (2)
@@ -44,7 +44,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_symlinkat.3
+++ b/man/io_uring_prep_symlinkat.3
@@ -7,9 +7,9 @@
 io_uring_prep_symlinkat \- prepare a symlinkat request
 .SH SYNOPSIS
 .nf
-.BR "#include <fcntl.h>"
-.BR "#include <unistd.h>"
-.BR "#include <liburing.h>"
+.B #include <fcntl.h>
+.B #include <unistd.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_symlinkat(struct io_uring_sqe *" sqe ","
 .BI "                             const char *" target ","

--- a/man/io_uring_prep_symlinkat.3
+++ b/man/io_uring_prep_symlinkat.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_symlinkat 3 "March 13, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_symlinkat  - prepare a symlinkat request
-.fi
+io_uring_prep_symlinkat \- prepare a symlinkat request
 .SH SYNOPSIS
 .nf
 .BR "#include <fcntl.h>"

--- a/man/io_uring_prep_sync_file_range.3
+++ b/man/io_uring_prep_sync_file_range.3
@@ -7,8 +7,8 @@
 io_uring_prep_sync_file_range \- prepare a sync_file_range request
 .SH SYNOPSIS
 .nf
-.BR "#include <fcntl.h>"
-.BR "#include <liburing.h>"
+.B #include <fcntl.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_sync_file_range(struct io_uring_sqe *" sqe ","
 .BI "                                   int " fd ","

--- a/man/io_uring_prep_sync_file_range.3
+++ b/man/io_uring_prep_sync_file_range.3
@@ -47,7 +47,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_sync_file_range.3
+++ b/man/io_uring_prep_sync_file_range.3
@@ -54,4 +54,6 @@ directly in the CQE
 .I res
 field.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), sync_file_range (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR sync_file_range (2)

--- a/man/io_uring_prep_sync_file_range.3
+++ b/man/io_uring_prep_sync_file_range.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_sync_file_range 3 "March 12, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_sync_file_range  - prepare a sync_file_range request
-.fi
+io_uring_prep_sync_file_range \- prepare a sync_file_range request
 .SH SYNOPSIS
 .nf
 .BR "#include <fcntl.h>"

--- a/man/io_uring_prep_sync_file_range.3
+++ b/man/io_uring_prep_sync_file_range.3
@@ -15,7 +15,7 @@ io_uring_prep_sync_file_range \- prepare a sync_file_range request
 .BI "                                   unsigned " len ","
 .BI "                                   __u64 " offset ","
 .BI "                                   int " flags ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_tee.3
+++ b/man/io_uring_prep_tee.3
@@ -60,7 +60,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_tee.3
+++ b/man/io_uring_prep_tee.3
@@ -15,7 +15,7 @@ io_uring_prep_tee \- prepare a tee request
 .BI "                       int " fd_out ","
 .BI "                       unsigned int " nbytes ","
 .BI "                       unsigned int " splice_flags ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_tee.3
+++ b/man/io_uring_prep_tee.3
@@ -67,4 +67,8 @@ directly in the CQE
 .I res
 field.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), io_uring_register (2), splice (2), tee (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR io_uring_register (2),
+.BR splice (2),
+.BR tee (2)

--- a/man/io_uring_prep_tee.3
+++ b/man/io_uring_prep_tee.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_tee 3 "March 13, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_tee  - prepare a tee request
-.fi
+io_uring_prep_tee \- prepare a tee request
 .SH SYNOPSIS
 .nf
 .BR "#include <fcntl.h>"

--- a/man/io_uring_prep_tee.3
+++ b/man/io_uring_prep_tee.3
@@ -7,8 +7,8 @@
 io_uring_prep_tee \- prepare a tee request
 .SH SYNOPSIS
 .nf
-.BR "#include <fcntl.h>"
-.BR "#include <liburing.h>"
+.B #include <fcntl.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_tee(struct io_uring_sqe *" sqe ","
 .BI "                       int " fd_in ","

--- a/man/io_uring_prep_timeout.3
+++ b/man/io_uring_prep_timeout.3
@@ -89,4 +89,7 @@ behavior by inspecting the
 flag passed back from
 .BR io_uring_queue_init_params (3).
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), io_uring_prep_timeout_remove (3), io_uring_prep_timeout_update (3)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR io_uring_prep_timeout_remove (3),
+.BR io_uring_prep_timeout_update (3)

--- a/man/io_uring_prep_timeout.3
+++ b/man/io_uring_prep_timeout.3
@@ -7,7 +7,7 @@
 io_uring_prep_timeoute \- prepare a timeout request
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_timeout(struct io_uring_sqe *" sqe ","
 .BI "                           struct __kernel_timespec *" ts ","

--- a/man/io_uring_prep_timeout.3
+++ b/man/io_uring_prep_timeout.3
@@ -74,7 +74,7 @@ where given, or the specified timeout seconds or nanoseconds where < 0.
 .TP
 .B -EFAULT
 io_uring was unable to access the data specified by
-.I ts.
+.IR ts .
 .TP
 .B -ECANCELED
 The timeout was canceled by a removal request.

--- a/man/io_uring_prep_timeout.3
+++ b/man/io_uring_prep_timeout.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_poll_timeout 3 "March 12, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_timeoute  - prepare a timeout request
-.fi
+io_uring_prep_timeoute \- prepare a timeout request
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_prep_timeout.3
+++ b/man/io_uring_prep_timeout.3
@@ -13,7 +13,7 @@ io_uring_prep_timeoute \- prepare a timeout request
 .BI "                           struct __kernel_timespec *" ts ","
 .BI "                           unsigned " count ","
 .BI "                           unsigned " flags ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_timeout_update.3
+++ b/man/io_uring_prep_timeout_update.3
@@ -93,4 +93,6 @@ behavior by inspecting the
 flag passed back from
 .BR io_uring_queue_init_params (3).
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), io_uring_prep_timeout (3)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR io_uring_prep_timeout (3)

--- a/man/io_uring_prep_timeout_update.3
+++ b/man/io_uring_prep_timeout_update.3
@@ -13,7 +13,7 @@ io_uring_prep_timeoute_update \- prepare a request to update an existing timeout
 .BI "                                  struct __kernel_timespec *" ts ","
 .BI "                                  __u64 " user_data ","
 .BI "                                  unsigned " flags ");"
-.BI "
+.PP
 .BI "void io_uring_prep_timeout_remove(struct io_uring_sqe *" sqe ","
 .BI "                                  __u64 " user_data ","
 .BI "                                  unsigned " flags ");"

--- a/man/io_uring_prep_timeout_update.3
+++ b/man/io_uring_prep_timeout_update.3
@@ -7,7 +7,7 @@
 io_uring_prep_timeoute_update \- prepare a request to update an existing timeout
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_timeout_update(struct io_uring_sqe *" sqe ","
 .BI "                                  struct __kernel_timespec *" ts ","

--- a/man/io_uring_prep_timeout_update.3
+++ b/man/io_uring_prep_timeout_update.3
@@ -26,7 +26,7 @@ queue entry
 is setup to arm a timeout update or removal specified by
 .I user_data
 and with modifier flags given by
-.I flags.
+.IR flags .
 Additionally, the update request includes a
 .I ts
 structure, which contains new timeout information.
@@ -81,7 +81,7 @@ where given, or the specified timeout seconds or nanoseconds where < 0.
 .TP
 .B -EFAULT
 io_uring was unable to access the data specified by
-.I ts.
+.IR ts .
 .SH NOTES
 As with any request that passes in data in a struct, that data must remain
 valid until the request has been successfully submitted. It need not remain

--- a/man/io_uring_prep_timeout_update.3
+++ b/man/io_uring_prep_timeout_update.3
@@ -17,7 +17,7 @@ io_uring_prep_timeoute_update \- prepare a request to update an existing timeout
 .BI "void io_uring_prep_timeout_remove(struct io_uring_sqe *" sqe ","
 .BI "                                  __u64 " user_data ","
 .BI "                                  unsigned " flags ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 These functions modify or cancel an existing timeout request. The submission

--- a/man/io_uring_prep_timeout_update.3
+++ b/man/io_uring_prep_timeout_update.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_poll_timeout_update 3 "March 12, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_timeoute_update - prepare a request to update an existing timeout
-.fi
+io_uring_prep_timeoute_update \- prepare a request to update an existing timeout
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_prep_unlinkat.3
+++ b/man/io_uring_prep_unlinkat.3
@@ -7,9 +7,9 @@
 io_uring_prep_unlinkat \- prepare an unlinkat request
 .SH SYNOPSIS
 .nf
-.BR "#include <fcntl.h>"
-.BR "#include <unistd.h>"
-.BR "#include <liburing.h>"
+.B #include <fcntl.h>
+.B #include <unistd.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_unlinkat(struct io_uring_sqe *" sqe ","
 .BI "                            int " dirfd ","

--- a/man/io_uring_prep_unlinkat.3
+++ b/man/io_uring_prep_unlinkat.3
@@ -15,7 +15,7 @@ io_uring_prep_unlinkat \- prepare an unlinkat request
 .BI "                            int " dirfd ","
 .BI "                            const char *" path ","
 .BI "                            int " flags ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_unlinkat.3
+++ b/man/io_uring_prep_unlinkat.3
@@ -27,7 +27,7 @@ is setup to use the directory file descriptor pointed to by
 to start an unlinkat operation on the path identified by
 .I path
 and using the flags given in
-.I flags.
+.IR flags .
 
 This function prepares an async
 .BR unlinkat (2)
@@ -44,7 +44,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_unlinkat.3
+++ b/man/io_uring_prep_unlinkat.3
@@ -61,4 +61,6 @@ behavior by inspecting the
 flag passed back from
 .BR io_uring_queue_init_params (3).
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3), unlinkat (2)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR unlinkat (2)

--- a/man/io_uring_prep_unlinkat.3
+++ b/man/io_uring_prep_unlinkat.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_unlinkat 3 "March 13, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_prep_unlinkat  - prepare an unlinkat request
-.fi
+io_uring_prep_unlinkat \- prepare an unlinkat request
 .SH SYNOPSIS
 .nf
 .BR "#include <fcntl.h>"

--- a/man/io_uring_prep_write.3
+++ b/man/io_uring_prep_write.3
@@ -7,7 +7,7 @@
 io_uring_prep_write \- prepare I/O write request
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_write(struct io_uring_sqe *" sqe ","
 .BI "                         int " fd ","

--- a/man/io_uring_prep_write.3
+++ b/man/io_uring_prep_write.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_write 3 "November 15, 2021" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_prep_write   - prepare I/O write request
-
+io_uring_prep_write \- prepare I/O write request
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_prep_write.3
+++ b/man/io_uring_prep_write.3
@@ -63,4 +63,5 @@ directly in the CQE
 .I res
 field.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_submit (3)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3)

--- a/man/io_uring_prep_write.3
+++ b/man/io_uring_prep_write.3
@@ -14,7 +14,7 @@ io_uring_prep_write \- prepare I/O write request
 .BI "                         const void *" buf ","
 .BI "                         unsigned " nbytes ","
 .BI "                         __u64 " offset ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_write.3
+++ b/man/io_uring_prep_write.3
@@ -28,10 +28,10 @@ to start writing
 from the buffer
 .I buf
 at the specified
-.I offset.
+.IR offset .
 
 On files that support seeking, if the offset is set to
-.B -1,
+.BR -1 ,
 the write operation commences at the file offset, and the file offset is
 incremented by the number of bytes written. See
 .BR write (2)
@@ -56,7 +56,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_write_fixed.3
+++ b/man/io_uring_prep_write_fixed.3
@@ -32,12 +32,13 @@ from the buffer
 at the specified
 .I offset
 and with the buffer matching the registered index of
-.I buf_index.
+.IR buf_index .
 
 This works just like
-.B io_uring_prep_write(3)
+.BR io_uring_prep_write (3)
 except it requires the use of buffers that have been registered with
-.B io_uring_register_buffers(3). The
+.BR io_uring_register_buffers (3).
+The
 .I buf
 and
 .I nbytes
@@ -60,7 +61,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_write_fixed.3
+++ b/man/io_uring_prep_write_fixed.3
@@ -15,7 +15,7 @@ io_uring_prep_write_fixed \- prepare I/O write request with registered buffer
 .BI "                        unsigned " nbytes ","
 .BI "                        __u64 " offset ","
 .BI "                        int " buf_index ");"
-
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_write_fixed.3
+++ b/man/io_uring_prep_write_fixed.3
@@ -7,7 +7,7 @@
 io_uring_prep_write_fixed \- prepare I/O write request with registered buffer
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_write_fixed(struct io_uring_sqe *" sqe ","
 .BI "                        int " fd ",

--- a/man/io_uring_prep_write_fixed.3
+++ b/man/io_uring_prep_write_fixed.3
@@ -68,4 +68,5 @@ directly in the CQE
 .I res
 field.
 .SH SEE ALSO
-.BR io_uring_prep_write (3), io_uring_register_buffers (3)
+.BR io_uring_prep_write (3),
+.BR io_uring_register_buffers (3)

--- a/man/io_uring_prep_write_fixed.3
+++ b/man/io_uring_prep_write_fixed.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_write 3 "February 13, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_prep_write_fixed   - prepare I/O write request with registered buffer
-
+io_uring_prep_write_fixed \- prepare I/O write request with registered buffer
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_prep_writev.3
+++ b/man/io_uring_prep_writev.3
@@ -29,10 +29,10 @@ to start writing
 from the
 .I iovecs
 array at the specified
-.I offset.
+.IR offset .
 
 On files that support seeking, if the offset is set to
-.B -1,
+.BR -1 ,
 the write operation commences at the file offset, and the file offset is
 incremented by the number of bytes written. See
 .BR write (2)
@@ -57,7 +57,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_prep_writev.3
+++ b/man/io_uring_prep_writev.3
@@ -7,8 +7,8 @@
 io_uring_prep_writev \- prepare vector I/O write request
 .SH SYNOPSIS
 .nf
-.BR "#include <sys/uio.h>"
-.BR "#include <liburing.h>"
+.B #include <sys/uio.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_writev(struct io_uring_sqe *" sqe ","
 .BI "                          int " fd ","

--- a/man/io_uring_prep_writev.3
+++ b/man/io_uring_prep_writev.3
@@ -79,4 +79,7 @@ behavior by inspecting the
 flag passed back from
 .BR io_uring_queue_init_params (3).
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_prep_write (3), io_uring_prep_writev2 (3), io_uring_submit (3)
+.BR io_uring_get_sqe (3),
+.BR io_uring_prep_write (3),
+.BR io_uring_prep_writev2 (3),
+.BR io_uring_submit (3)

--- a/man/io_uring_prep_writev.3
+++ b/man/io_uring_prep_writev.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_writev 3 "November 15, 2021" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_prep_writev  - prepare vector I/O write request
-
+io_uring_prep_writev \- prepare vector I/O write request
 .SH SYNOPSIS
 .nf
 .BR "#include <sys/uio.h>"

--- a/man/io_uring_prep_writev.3
+++ b/man/io_uring_prep_writev.3
@@ -15,7 +15,7 @@ io_uring_prep_writev \- prepare vector I/O write request
 .BI "                          const struct iovec *" iovecs ","
 .BI "                          unsigned " nr_vecs ","
 .BI "                          __u64 " offset ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_writev2.3
+++ b/man/io_uring_prep_writev2.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_prep_writev2 3 "November 15, 2021" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_prep_writev2 - prepare vector I/O write request with flags
-
+io_uring_prep_writev2 \- prepare vector I/O write request with flags
 .SH SYNOPSIS
 .nf
 .BR "#include <sys/uio.h>"

--- a/man/io_uring_prep_writev2.3
+++ b/man/io_uring_prep_writev2.3
@@ -17,7 +17,6 @@ io_uring_prep_writev2 \- prepare vector I/O write request with flags
 .BI "                           __u64 " offset ","
 .BI "                           int " flags ");"
 .fi
-.PP
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_prep_writev2.3
+++ b/man/io_uring_prep_writev2.3
@@ -7,8 +7,8 @@
 io_uring_prep_writev2 \- prepare vector I/O write request with flags
 .SH SYNOPSIS
 .nf
-.BR "#include <sys/uio.h>"
-.BR "#include <liburing.h>"
+.B #include <sys/uio.h>
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_writev2(struct io_uring_sqe *" sqe ","
 .BI "                           int " fd ","

--- a/man/io_uring_prep_writev2.3
+++ b/man/io_uring_prep_writev2.3
@@ -106,4 +106,7 @@ behavior by inspecting the
 flag passed back from
 .BR io_uring_queue_init_params (3).
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_prep_write (3), io_uring_prep_writev (3), io_uring_submit (3)
+.BR io_uring_get_sqe (3),
+.BR io_uring_prep_write (3),
+.BR io_uring_prep_writev (3),
+.BR io_uring_submit (3)

--- a/man/io_uring_prep_writev2.3
+++ b/man/io_uring_prep_writev2.3
@@ -31,7 +31,7 @@ to start writing
 from the
 .I iovecs
 array at the specified
-.I offset.
+.IR offset .
 The behavior of the function can be controlled with the
 .I flags
 parameter.
@@ -59,7 +59,7 @@ per-IO O_APPEND
 
 .P
 On files that support seeking, if the offset is set to
-.B -1,
+.BR -1 ,
 the write operation commences at the file offset, and the file offset is
 incremented by the number of bytes written. See
 .BR write (2)
@@ -84,7 +84,7 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.I errno.
+.IR errno .
 Instead it returns the negated
 .I errno
 directly in the CQE

--- a/man/io_uring_queue_exit.3
+++ b/man/io_uring_queue_exit.3
@@ -12,7 +12,6 @@ io_uring_queue_exit \- tear down io_uring submission and completion queues
 .PP
 .BI "void io_uring_queue_exit(struct io_uring *" ring ");"
 .fi
-.PP
 .SH DESCRIPTION
 .PP
 .BR io_uring_queue_exit (3)

--- a/man/io_uring_queue_exit.3
+++ b/man/io_uring_queue_exit.3
@@ -8,7 +8,7 @@
 io_uring_queue_exit \- tear down io_uring submission and completion queues
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_queue_exit(struct io_uring *" ring ");"
 .fi

--- a/man/io_uring_queue_exit.3
+++ b/man/io_uring_queue_exit.3
@@ -5,7 +5,7 @@
 .\"
 .TH io_uring_queue_exit 3 "July 10, 2020" "liburing-0.7" "liburing Manual"
 .SH NAME
-io_uring_queue_exit - tear down io_uring submission and completion queues
+io_uring_queue_exit \- tear down io_uring submission and completion queues
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_queue_init.3
+++ b/man/io_uring_queue_init.3
@@ -18,7 +18,6 @@ io_uring_queue_init \- setup io_uring submission and completion queues
 .BI "                               struct io_uring *" ring ","
 .BI "                               struct io_uring_params *" params ");"
 .fi
-.PP
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_queue_init.3
+++ b/man/io_uring_queue_init.3
@@ -8,7 +8,7 @@
 io_uring_queue_init \- setup io_uring submission and completion queues
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_queue_init(unsigned " entries ","
 .BI "                        struct io_uring *" ring ","
@@ -56,7 +56,7 @@ If the value isn't a power of 2, it will be rounded up to the nearest power of
 On success io_uring_queue_init() returns 0 and
 .I ring
 will point to the shared memory containing the io_uring queues. On failure
-.BR -errno
+.B -errno
 is returned.
 
 .I flags

--- a/man/io_uring_queue_init.3
+++ b/man/io_uring_queue_init.3
@@ -50,7 +50,7 @@ in
 .I struct io_uring_params
 will tell the kernel to allocate this many entries for the CQ ring, independent
 of the SQ ring size in given in
-.I entries.
+.IR entries .
 If the value isn't a power of 2, it will be rounded up to the nearest power of
 2.
 

--- a/man/io_uring_queue_init.3
+++ b/man/io_uring_queue_init.3
@@ -5,7 +5,7 @@
 .\"
 .TH io_uring_queue_init 3 "July 10, 2020" "liburing-0.7" "liburing Manual"
 .SH NAME
-io_uring_queue_init - setup io_uring submission and completion queues
+io_uring_queue_init \- setup io_uring submission and completion queues
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_queue_init.3
+++ b/man/io_uring_queue_init.3
@@ -13,7 +13,7 @@ io_uring_queue_init \- setup io_uring submission and completion queues
 .BI "int io_uring_queue_init(unsigned " entries ","
 .BI "                        struct io_uring *" ring ","
 .BI "                        unsigned " flags ");"
-.BI "
+.PP
 .BI "int io_uring_queue_init_params(unsigned " entries ","
 .BI "                               struct io_uring *" ring ","
 .BI "                               struct io_uring_params *" params ");"

--- a/man/io_uring_register_buf_ring.3
+++ b/man/io_uring_register_buf_ring.3
@@ -7,7 +7,7 @@
 io_uring_register_buf_ring \- register buffer ring for provided buffers
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_register_buf_ring(struct io_uring *" ring ",
 .BI "                               struct io_uring_buf_reg *" reg ",

--- a/man/io_uring_register_buf_ring.3
+++ b/man/io_uring_register_buf_ring.3
@@ -13,7 +13,7 @@ io_uring_register_buf_ring \- register buffer ring for provided buffers
 .BI "                               struct io_uring_buf_reg *" reg ",
 .BI "                               unsigned int " flags ");"
 .BI "
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_register_buf_ring.3
+++ b/man/io_uring_register_buf_ring.3
@@ -23,7 +23,7 @@ the request types that support it, provided buffers are given to the ring and
 one is selected by a request if it has
 .B IOSQE_BUFFER_SELECT
 set in the SQE
-.I flags,
+.IR flags ,
 when the request is ready to receive data. This allows both clear ownership
 of the buffer lifetime, and a way to have more read/receive type of operations
 in flight than buffers available.
@@ -53,7 +53,7 @@ The memory must be page aligned and hence allocated appropriately using eg
 or similar. The size of the ring is the product of
 .I ring_entries
 and the size of
-.I struct io_uring_buf.
+.IR "struct io_uring_buf" .
 .I ring_entries
 is the desired size of the ring, and must be a power-of-2 in size.
 .I bgid
@@ -129,6 +129,6 @@ Available since 5.19.
 On success
 .BR io_uring_register_buf_ring (3)
 returns 0. On failure it returns
-.B -errno.
+.BR -errno .
 .SH SEE ALSO
 .BR io_uring_buf_ring_alloc (3), io_uring_buf_ring_add (3), io_uring_buf_ring_advance (3), io_uring_buf_ring_cq_advance (3)

--- a/man/io_uring_register_buf_ring.3
+++ b/man/io_uring_register_buf_ring.3
@@ -131,4 +131,7 @@ On success
 returns 0. On failure it returns
 .BR -errno .
 .SH SEE ALSO
-.BR io_uring_buf_ring_alloc (3), io_uring_buf_ring_add (3), io_uring_buf_ring_advance (3), io_uring_buf_ring_cq_advance (3)
+.BR io_uring_buf_ring_alloc (3),
+.BR io_uring_buf_ring_add (3),
+.BR io_uring_buf_ring_advance (3),
+.BR io_uring_buf_ring_cq_advance (3)

--- a/man/io_uring_register_buf_ring.3
+++ b/man/io_uring_register_buf_ring.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_register_buf_ring 3 "May 18, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_register_buf_ring - register buffer ring for provided buffers
-.fi
+io_uring_register_buf_ring \- register buffer ring for provided buffers
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_register_buffers.3
+++ b/man/io_uring_register_buffers.3
@@ -7,7 +7,7 @@
 io_uring_register_buffers \- register buffers for fixed buffer operations
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_register_buffers(struct io_uring *" ring ",
 .BI "                              const struct iovec *" iovecs ",

--- a/man/io_uring_register_buffers.3
+++ b/man/io_uring_register_buffers.3
@@ -15,7 +15,7 @@ io_uring_register_buffers \- register buffers for fixed buffer operations
 .PP
 .BI "int io_uring_register_buffers_sparse(struct io_uring *" ring ",
 .BI "                              unsigned " nr_iovecs ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_register_buffers.3
+++ b/man/io_uring_register_buffers.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_register_buffers 3 "November 15, 2021" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_register_buffers - register buffers for fixed buffer operations
-.fi
+io_uring_register_buffers \- register buffers for fixed buffer operations
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_register_buffers.3
+++ b/man/io_uring_register_buffers.3
@@ -54,4 +54,8 @@ and
 return 0. On failure they return
 .BR -errno .
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_unregister_buffers (3), io_uring_register_buf_ring (3), io_uring_prep_read_fixed (3), io_uring_prep_write_fixed (3)
+.BR io_uring_get_sqe (3),
+.BR io_uring_unregister_buffers (3),
+.BR io_uring_register_buf_ring (3),
+.BR io_uring_prep_read_fixed (3),
+.BR io_uring_prep_write_fixed (3)

--- a/man/io_uring_register_buffers.3
+++ b/man/io_uring_register_buffers.3
@@ -25,14 +25,14 @@ function registers
 number of buffers defined by the array
 .I iovecs
 belonging to the
-.I ring.
+.IR ring .
 
 The
 .BR io_uring_register_buffers_sparse (3)
 function registers
 .I nr_iovecs
 empty buffers belonging to the
-.I ring.
+.IR ring .
 These buffers must be updated before use, using eg
 .BR io_uring_register_buffers_update_tag (3).
 
@@ -52,6 +52,6 @@ On success
 and
 .BR io_uring_register_buffers_sparse (3)
 return 0. On failure they return
-.B -errno.
+.BR -errno .
 .SH SEE ALSO
 .BR io_uring_get_sqe (3), io_uring_unregister_buffers (3), io_uring_register_buf_ring (3), io_uring_prep_read_fixed (3), io_uring_prep_write_fixed (3)

--- a/man/io_uring_register_buffers.3
+++ b/man/io_uring_register_buffers.3
@@ -12,7 +12,7 @@ io_uring_register_buffers \- register buffers for fixed buffer operations
 .BI "int io_uring_register_buffers(struct io_uring *" ring ",
 .BI "                              const struct iovec *" iovecs ",
 .BI "                              unsigned " nr_iovecs ");"
-.BI "
+.PP
 .BI "int io_uring_register_buffers_sparse(struct io_uring *" ring ",
 .BI "                              unsigned " nr_iovecs ");"
 .PP

--- a/man/io_uring_register_eventfd.3
+++ b/man/io_uring_register_eventfd.3
@@ -23,7 +23,7 @@ io_uring_register_eventfd \- register an eventfd with a ring
 registers the eventfd file descriptor
 .I fd
 with the ring identified by
-.I ring.
+.IR ring .
 
 Whenever completions are posted to the CQ ring, an eventfd notification
 is generated with the registered eventfd descriptor. If

--- a/man/io_uring_register_eventfd.3
+++ b/man/io_uring_register_eventfd.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_register_eventfd 3 "April 16, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_register_eventfd   - register an eventfd with a ring
-
+io_uring_register_eventfd \- register an eventfd with a ring
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_register_eventfd.3
+++ b/man/io_uring_register_eventfd.3
@@ -11,8 +11,10 @@ io_uring_register_eventfd \- register an eventfd with a ring
 .PP
 .BI "int io_uring_register_eventfd(struct io_uring *" ring ","
 .BI "                              int " fd ");"
+.PP
 .BI "int io_uring_register_eventfd_async(struct io_uring *" ring ","
 .BI "                                    int " fd ");"
+.PP
 .BI "int io_uring_unregister_eventfd(struct io_uring *" ring ");"
 
 .SH DESCRIPTION

--- a/man/io_uring_register_eventfd.3
+++ b/man/io_uring_register_eventfd.3
@@ -7,7 +7,7 @@
 io_uring_register_eventfd \- register an eventfd with a ring
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_register_eventfd(struct io_uring *" ring ","
 .BI "                              int " fd ");"

--- a/man/io_uring_register_eventfd.3
+++ b/man/io_uring_register_eventfd.3
@@ -16,7 +16,7 @@ io_uring_register_eventfd \- register an eventfd with a ring
 .BI "                                    int " fd ");"
 .PP
 .BI "int io_uring_unregister_eventfd(struct io_uring *" ring ");"
-
+.fi
 .SH DESCRIPTION
 .PP
 .BR io_uring_register_eventfd (3)

--- a/man/io_uring_register_files.3
+++ b/man/io_uring_register_files.3
@@ -44,6 +44,6 @@ On success
 and
 .BR io_uring_register_files_sparse (3)
 return 0. On failure they return
-.B -errno.
+.BR -errno .
 .SH SEE ALSO
 .BR io_uring_get_sqe (3), io_uring_unregister_files (3)

--- a/man/io_uring_register_files.3
+++ b/man/io_uring_register_files.3
@@ -15,7 +15,7 @@ io_uring_register_files \- register file descriptors
 .PP
 .BI "int io_uring_register_files_sparse(struct io_uring *" ring ","
 .BI "                            unsigned " nr_files ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_register_files.3
+++ b/man/io_uring_register_files.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_register_files 3 "November 15, 2021" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_register_files - register file descriptors
-.fi
+io_uring_register_files \- register file descriptors
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_register_files.3
+++ b/man/io_uring_register_files.3
@@ -12,7 +12,7 @@ io_uring_register_files \- register file descriptors
 .BI "int io_uring_register_files(struct io_uring *" ring ","
 .BI "                            const int *" files ","
 .BI "                            unsigned " nr_files ");"
-.BI
+.PP
 .BI "int io_uring_register_files_sparse(struct io_uring *" ring ","
 .BI "                            unsigned " nr_files ");"
 .PP

--- a/man/io_uring_register_files.3
+++ b/man/io_uring_register_files.3
@@ -7,7 +7,7 @@
 io_uring_register_files \- register file descriptors
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_register_files(struct io_uring *" ring ","
 .BI "                            const int *" files ","
@@ -29,7 +29,7 @@ belonging to the
 for subsequent operations.
 
 The
-.BR io_uring_register_files_sparse()
+.BR io_uring_register_files_sparse (3)
 function registers an empty file table of
 .I nr_files
 number of file descriptors. The sparse variant is available in kernels 5.19

--- a/man/io_uring_register_files.3
+++ b/man/io_uring_register_files.3
@@ -46,4 +46,5 @@ and
 return 0. On failure they return
 .BR -errno .
 .SH SEE ALSO
-.BR io_uring_get_sqe (3), io_uring_unregister_files (3)
+.BR io_uring_get_sqe (3),
+.BR io_uring_unregister_files (3)

--- a/man/io_uring_register_iowq_aff.3
+++ b/man/io_uring_register_iowq_aff.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_register_iowq_aff 3 "March 13, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_register_iowq_aff  - register async worker CPU affinities
-.fi
+io_uring_register_iowq_aff \- register async worker CPU affinities
 .SH SYNOPSIS
 .nf
 .BR "#include <sched.h>"

--- a/man/io_uring_register_iowq_aff.3
+++ b/man/io_uring_register_iowq_aff.3
@@ -57,4 +57,5 @@ or
 .I mask
 was NULL/0, or any other value specified was invalid.
 .SH SEE ALSO
-.BR io_uring_queue_init (3), io_uring_register (2)
+.BR io_uring_queue_init (3),
+.BR io_uring_register (2)

--- a/man/io_uring_register_iowq_aff.3
+++ b/man/io_uring_register_iowq_aff.3
@@ -7,8 +7,8 @@
 io_uring_register_iowq_aff \- register async worker CPU affinities
 .SH SYNOPSIS
 .nf
-.BR "#include <sched.h>"
-.BR "#include <liburing.h>"
+.B #include <sched.h>
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_register_iowq_aff(struct io_uring *" ring ","
 .BI "                               size_t " cpusz ","
@@ -27,7 +27,7 @@ the system. If this function is called with
 set to the ring in question and
 .I mask
 set to a pointer to a
-.BR cpu_set_t
+.B cpu_set_t
 value and
 .I cpusz
 set to the size of the CPU set, then async workers will only be allowed to run

--- a/man/io_uring_register_iowq_aff.3
+++ b/man/io_uring_register_iowq_aff.3
@@ -13,7 +13,7 @@ io_uring_register_iowq_aff \- register async worker CPU affinities
 .BI "int io_uring_register_iowq_aff(struct io_uring *" ring ","
 .BI "                               size_t " cpusz ","
 .BI "                               const cpu_set_t *" mask ");
-.BI "
+.PP
 .BI "void io_uring_unregister_iowq_aff(struct io_uring *" ring ");"
 .PP
 .SH DESCRIPTION

--- a/man/io_uring_register_iowq_aff.3
+++ b/man/io_uring_register_iowq_aff.3
@@ -15,7 +15,7 @@ io_uring_register_iowq_aff \- register async worker CPU affinities
 .BI "                               const cpu_set_t *" mask ");
 .PP
 .BI "void io_uring_unregister_iowq_aff(struct io_uring *" ring ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_register_iowq_max_workers.3
+++ b/man/io_uring_register_iowq_max_workers.3
@@ -7,7 +7,7 @@
 io_uring_register_iowq_max_workers \- modify the maximum allowed async workers
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_register_iowq_max_workers(struct io_uring *" ring ","
 .BI "                                       unsigned int *" values ");"
@@ -35,7 +35,7 @@ limit, as indicated by the rlimit
 limit.
 
 This can be modified by calling
-.BR io_uring_register_iowq_max_workers
+.B io_uring_register_iowq_max_workers
 with
 .I ring
 set to the ring in question, and

--- a/man/io_uring_register_iowq_max_workers.3
+++ b/man/io_uring_register_iowq_max_workers.3
@@ -67,4 +67,5 @@ was
 .B NULL
 or the new values exceeded the maximum allowed value.
 .SH SEE ALSO
-.BR io_uring_queue_init (3), io_uring_register (2)
+.BR io_uring_queue_init (3),
+.BR io_uring_register (2)

--- a/man/io_uring_register_iowq_max_workers.3
+++ b/man/io_uring_register_iowq_max_workers.3
@@ -11,7 +11,7 @@ io_uring_register_iowq_max_workers \- modify the maximum allowed async workers
 .PP
 .BI "int io_uring_register_iowq_max_workers(struct io_uring *" ring ","
 .BI "                                       unsigned int *" values ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 io_uring async workers are split into two types:

--- a/man/io_uring_register_iowq_max_workers.3
+++ b/man/io_uring_register_iowq_max_workers.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_register_iowq_max_workers 3 "March 13, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_register_iowq_max_workers  - modify the maximum allowed async workers
-.fi
+io_uring_register_iowq_max_workers \- modify the maximum allowed async workers
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_register_ring_fd.3
+++ b/man/io_uring_register_ring_fd.3
@@ -45,4 +45,5 @@ or
 .B -errno
 on error.
 .SH SEE ALSO
-.BR io_uring_unregister_ring_fd (3), io_uring_register_files (3)
+.BR io_uring_unregister_ring_fd (3),
+.BR io_uring_register_files (3)

--- a/man/io_uring_register_ring_fd.3
+++ b/man/io_uring_register_ring_fd.3
@@ -7,7 +7,7 @@
 io_uring_register_ring_fd \- register a ring file descriptor
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_register_ring_fd(struct io_uring *" ring ");"
 .fi

--- a/man/io_uring_register_ring_fd.3
+++ b/man/io_uring_register_ring_fd.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_register_ring_fd 3 "March 11, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_register_ring_fd   - register a ring file descriptor
-
+io_uring_register_ring_fd \- register a ring file descriptor
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_register_ring_fd.3
+++ b/man/io_uring_register_ring_fd.3
@@ -10,7 +10,7 @@ io_uring_register_ring_fd \- register a ring file descriptor
 .BR "#include <liburing.h>"
 .PP
 .BI "int io_uring_register_ring_fd(struct io_uring *" ring ");"
-
+.fi
 .SH DESCRIPTION
 .PP
 .BR io_uring_register_ring_fd (3)

--- a/man/io_uring_sq_ready.3
+++ b/man/io_uring_sq_ready.3
@@ -7,7 +7,7 @@
 io_uring_sq_ready \- number of unconsumed or unsubmitted entries in the SQ ring
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "unsigned io_uring_sq_ready(const struct io_uring *" ring ");"
 .fi

--- a/man/io_uring_sq_ready.3
+++ b/man/io_uring_sq_ready.3
@@ -4,7 +4,7 @@
 .\"
 .TH io_uring_sq_ready "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_sq_ready - number of unconsumed or unsubmitted entries in the SQ ring
+io_uring_sq_ready \- number of unconsumed or unsubmitted entries in the SQ ring
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_sq_ready.3
+++ b/man/io_uring_sq_ready.3
@@ -11,7 +11,6 @@ io_uring_sq_ready \- number of unconsumed or unsubmitted entries in the SQ ring
 .PP
 .BI "unsigned io_uring_sq_ready(const struct io_uring *" ring ");"
 .fi
-.PP
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_sq_space_left.3
+++ b/man/io_uring_sq_space_left.3
@@ -11,7 +11,6 @@ io_uring_sq_space_left \- free space in the SQ ring
 .PP
 .BI "unsigned io_uring_sq_space_left(const struct io_uring *" ring ");"
 .fi
-.PP
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_sq_space_left.3
+++ b/man/io_uring_sq_space_left.3
@@ -7,7 +7,7 @@
 io_uring_sq_space_left \- free space in the SQ ring
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "unsigned io_uring_sq_space_left(const struct io_uring *" ring ");"
 .fi

--- a/man/io_uring_sq_space_left.3
+++ b/man/io_uring_sq_space_left.3
@@ -4,7 +4,7 @@
 .\"
 .TH io_uring_sq_space-left "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_sq_space_left - free space in the SQ ring
+io_uring_sq_space_left \- free space in the SQ ring
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_sqe_set_data.3
+++ b/man/io_uring_sqe_set_data.3
@@ -4,7 +4,7 @@
 .\"
 .TH io_uring_sqe_set_data 3 "November 15, 2021" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_sqe_set_data - set user data for submission queue event
+io_uring_sqe_set_data \- set user data for submission queue event
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_sqe_set_data.3
+++ b/man/io_uring_sqe_set_data.3
@@ -29,4 +29,5 @@ function io_uring_cqe_get_data() can be called to identify the user request.
 .SH RETURN VALUE
 None
 .SH SEE ALSO
-.BR io_uring_get_sqe (3),  io_uring_cqe_get_data (3)
+.BR io_uring_get_sqe (3),
+.BR io_uring_cqe_get_data (3)

--- a/man/io_uring_sqe_set_data.3
+++ b/man/io_uring_sqe_set_data.3
@@ -20,7 +20,7 @@ The
 function stores a
 .I user_data
 pointer with the submission queue entry
-.I sqe.
+.IR sqe .
 
 After the caller has requested an submission queue entry (SQE) with io_uring_get_sqe(),
 he can associate a data pointer with the SQE. Once the completion arrives, the

--- a/man/io_uring_sqe_set_data.3
+++ b/man/io_uring_sqe_set_data.3
@@ -7,7 +7,7 @@
 io_uring_sqe_set_data \- set user data for submission queue event
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_sqe_set_data(struct io_uring_sqe *" sqe ","
 .BI "                           void *" user_data ");"

--- a/man/io_uring_sqe_set_data.3
+++ b/man/io_uring_sqe_set_data.3
@@ -12,7 +12,6 @@ io_uring_sqe_set_data \- set user data for submission queue event
 .BI "void io_uring_sqe_set_data(struct io_uring_sqe *" sqe ","
 .BI "                           void *" user_data ");"
 .fi
-.PP
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_sqe_set_flags.3
+++ b/man/io_uring_sqe_set_flags.3
@@ -7,7 +7,7 @@
 io_uring_sqe_set_flags \- set flags for submission queue entry
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "void io_uring_sqe_set_flags(struct io_uring_sqe *" sqe ","
 .BI "                            unsigned " flags ");"
@@ -59,4 +59,4 @@ one completes.
 None
 .SH SEE ALSO
 .BR io_uring_submit (3),
-.BR io_uring_register(3)
+.BR io_uring_register (3)

--- a/man/io_uring_sqe_set_flags.3
+++ b/man/io_uring_sqe_set_flags.3
@@ -12,7 +12,6 @@ io_uring_sqe_set_flags \- set flags for submission queue entry
 .BI "void io_uring_sqe_set_flags(struct io_uring_sqe *" sqe ","
 .BI "                            unsigned " flags ");"
 .fi
-.PP
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_sqe_set_flags.3
+++ b/man/io_uring_sqe_set_flags.3
@@ -59,4 +59,5 @@ one completes.
 .SH RETURN VALUE
 None
 .SH SEE ALSO
-.BR io_uring_submit (3),  io_uring_register(3)
+.BR io_uring_submit (3),
+.BR io_uring_register(3)

--- a/man/io_uring_sqe_set_flags.3
+++ b/man/io_uring_sqe_set_flags.3
@@ -4,7 +4,7 @@
 .\"
 .TH io_uring_sqe_set_flags "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_sqe_set_flags - set flags for submission queue entry
+io_uring_sqe_set_flags \- set flags for submission queue entry
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_sqring_wait.3
+++ b/man/io_uring_sqring_wait.3
@@ -11,7 +11,6 @@ io_uring_sqring_wait \- wait for free space in the SQ ring
 .PP
 .BI "int io_uring_sqring_wait(struct io_uring *" ring ");"
 .fi
-.PP
 .SH DESCRIPTION
 .PP
 The function

--- a/man/io_uring_sqring_wait.3
+++ b/man/io_uring_sqring_wait.3
@@ -28,4 +28,6 @@ This feature can only be used when SQPOLL is enabled.
 On success it returns the free space. If the kernel does not support the
 feature, -EINVAL is returned.
 .SH SEE ALSO
-.BR io_uring_submit (3),  io_uring_wait_cqe (3),  io_uring_wait_cqes (3)
+.BR io_uring_submit (3),
+.BR io_uring_wait_cqe (3),
+.BR io_uring_wait_cqes (3)

--- a/man/io_uring_sqring_wait.3
+++ b/man/io_uring_sqring_wait.3
@@ -4,7 +4,7 @@
 .\"
 .TH io_uring_sqring_wait "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_sqring_wait - wait for free space in the SQ ring
+io_uring_sqring_wait \- wait for free space in the SQ ring
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_sqring_wait.3
+++ b/man/io_uring_sqring_wait.3
@@ -7,7 +7,7 @@
 io_uring_sqring_wait \- wait for free space in the SQ ring
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_sqring_wait(struct io_uring *" ring ");"
 .fi

--- a/man/io_uring_submit.3
+++ b/man/io_uring_submit.3
@@ -16,7 +16,7 @@ io_uring_submit \- submit requests to the submission queue
 The
 .BR io_uring_submit (3)
 function submits the next events to the submission queue belonging to the
-.I ring.
+.IR ring .
 
 After the caller retrieves a submission queue entry (SQE) with
 .BR io_uring_get_sqe (3)
@@ -26,7 +26,7 @@ and prepares the SQE, it can be submitted with io_uring_submit().
 On success
 .BR io_uring_submit (3)
 returns the number of submitted submission queue entries. On failure it returns
-.B -errno.
+.BR -errno .
 .SH NOTES
 For any request that passes in data in a struct, that data must remain
 valid until the request has been successfully submitted. It need not remain

--- a/man/io_uring_submit.3
+++ b/man/io_uring_submit.3
@@ -10,7 +10,7 @@ io_uring_submit \- submit requests to the submission queue
 .BR "#include <liburing.h>"
 .PP
 .BI "int io_uring_submit(struct io_uring *" ring ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_submit.3
+++ b/man/io_uring_submit.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_submit 3 "November 15, 2021" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_submit - submit requests to the submission queue
-.fi
+io_uring_submit \- submit requests to the submission queue
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_submit.3
+++ b/man/io_uring_submit.3
@@ -40,4 +40,6 @@ flag passed back from
 In general, the man pages for the individual prep helpers will have a note
 mentioning this fact as well, if required for the given command.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3),  io_uring_submit_and_wait (3), io_uring_submit_and_wait_timeout (3)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit_and_wait (3),
+.BR io_uring_submit_and_wait_timeout (3)

--- a/man/io_uring_submit.3
+++ b/man/io_uring_submit.3
@@ -7,7 +7,7 @@
 io_uring_submit \- submit requests to the submission queue
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_submit(struct io_uring *" ring ");"
 .fi

--- a/man/io_uring_submit_and_wait.3
+++ b/man/io_uring_submit_and_wait.3
@@ -30,4 +30,6 @@ On success
 .BR io_uring_submit_and_wait (3)
 returns the number of submitted submission queue entries. On failure it returns -errno.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3),  io_uring_submit (3), io_uring_submit_and_wait_timeout (3)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR io_uring_submit_and_wait_timeout (3)

--- a/man/io_uring_submit_and_wait.3
+++ b/man/io_uring_submit_and_wait.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_submit_and_wait 3 "November 15, 2021" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_submit_and_wait - submit requests to the submission queue and wait for completion
-.fi
+io_uring_submit_and_wait \- submit requests to the submission queue and wait for completion
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_submit_and_wait.3
+++ b/man/io_uring_submit_and_wait.3
@@ -7,7 +7,7 @@
 io_uring_submit_and_wait \- submit requests to the submission queue and wait for completion
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_submit_and_wait(struct io_uring *" ring ","
 .BI "                             unsigned " wait_nr ");"

--- a/man/io_uring_submit_and_wait.3
+++ b/man/io_uring_submit_and_wait.3
@@ -11,7 +11,7 @@ io_uring_submit_and_wait \- submit requests to the submission queue and wait for
 .PP
 .BI "int io_uring_submit_and_wait(struct io_uring *" ring ","
 .BI "                             unsigned " wait_nr ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_submit_and_wait_timeout.3
+++ b/man/io_uring_submit_and_wait_timeout.3
@@ -4,9 +4,8 @@
 .\"
 .TH io_uring_submit_and_wait_timeout 3 "November 15, 2021" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_submit_and_wait_timeout - submit requests to the submission queue and
+io_uring_submit_and_wait_timeout \- submit requests to the submission queue and
 wait for the completion with timeout
-.fi
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_submit_and_wait_timeout.3
+++ b/man/io_uring_submit_and_wait_timeout.3
@@ -27,8 +27,8 @@ and waits for
 completion events or until the timeout
 .I ts
 expires. The completion events are stored in the
-.I cqe_ptr array.
-The
+.I cqe_ptr
+array. The
 .I sigmask
 specifies the set of signals to block. The prevailing signal mask is restored
 before returning.

--- a/man/io_uring_submit_and_wait_timeout.3
+++ b/man/io_uring_submit_and_wait_timeout.3
@@ -15,7 +15,7 @@ wait for the completion with timeout
 .BI "                                     unsigned " wait_nr ","
 .BI "                                     struct __kernel_timespec *" ts ","
 .BI "                                     sigset_t *" sigmask ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_submit_and_wait_timeout.3
+++ b/man/io_uring_submit_and_wait_timeout.3
@@ -42,4 +42,7 @@ On success
 .BR io_uring_submit_and_wait_timeout (3)
 returns the number of submitted submission queue entries. On failure it returns -errno.
 .SH SEE ALSO
-.BR io_uring_get_sqe (3),  io_uring_submit (3), io_uring_submit_and_wait (3), io_uring_wait_cqe (3)
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR io_uring_submit_and_wait (3),
+.BR io_uring_wait_cqe (3)

--- a/man/io_uring_submit_and_wait_timeout.3
+++ b/man/io_uring_submit_and_wait_timeout.3
@@ -8,7 +8,7 @@ io_uring_submit_and_wait_timeout \- submit requests to the submission queue and
 wait for the completion with timeout
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_submit_and_wait_timeout(struct io_uring *" ring ","
 .BI "                                     struct io_uring_cqe **" cqe_ptr ","

--- a/man/io_uring_unregister_buf_ring.3
+++ b/man/io_uring_unregister_buf_ring.3
@@ -7,7 +7,7 @@
 io_uring_unregister_buf_ring \- unregister a previously registered buffer ring
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_unregister_buf_ring(struct io_uring *" ring ",
 .BI "                                 int " bgid ");"

--- a/man/io_uring_unregister_buf_ring.3
+++ b/man/io_uring_unregister_buf_ring.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_unregister_buf_ring 3 "May 18, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_unregister_buf_ring - unregister a previously registered buffer ring
-.fi
+io_uring_unregister_buf_ring \- unregister a previously registered buffer ring
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_unregister_buf_ring.3
+++ b/man/io_uring_unregister_buf_ring.3
@@ -12,7 +12,7 @@ io_uring_unregister_buf_ring \- unregister a previously registered buffer ring
 .BI "int io_uring_unregister_buf_ring(struct io_uring *" ring ",
 .BI "                                 int " bgid ");"
 .BI "
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_unregister_buf_ring.3
+++ b/man/io_uring_unregister_buf_ring.3
@@ -18,12 +18,12 @@ io_uring_unregister_buf_ring \- unregister a previously registered buffer ring
 The
 .BR io_uring_unregister_buf_ring (3)
 function unregisters a previously registered shared buffer ring indicated by
-.I bgid.
+.IR bgid .
 
 .SH RETURN VALUE
 On success
 .BR io_uring_unregister_buf_ring (3)
 returns 0. On failure it returns
-.B -errno.
+.BR -errno .
 .SH SEE ALSO
 .BR io_uring_register_buf_ring (3), io_uring_buf_ring_free (3)

--- a/man/io_uring_unregister_buf_ring.3
+++ b/man/io_uring_unregister_buf_ring.3
@@ -26,4 +26,5 @@ On success
 returns 0. On failure it returns
 .BR -errno .
 .SH SEE ALSO
-.BR io_uring_register_buf_ring (3), io_uring_buf_ring_free (3)
+.BR io_uring_register_buf_ring (3),
+.BR io_uring_buf_ring_free (3)

--- a/man/io_uring_unregister_buffers.3
+++ b/man/io_uring_unregister_buffers.3
@@ -10,7 +10,7 @@ io_uring_unregister_buffers \- unregister buffers for fixed buffer operations
 .BR "#include <liburing.h>"
 .PP
 .BI "int io_uring_unregister_buffers(struct io_uring *" ring ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_unregister_buffers.3
+++ b/man/io_uring_unregister_buffers.3
@@ -7,7 +7,7 @@
 io_uring_unregister_buffers \- unregister buffers for fixed buffer operations
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_unregister_buffers(struct io_uring *" ring ");"
 .fi

--- a/man/io_uring_unregister_buffers.3
+++ b/man/io_uring_unregister_buffers.3
@@ -16,7 +16,7 @@ io_uring_unregister_buffers \- unregister buffers for fixed buffer operations
 The
 .BR io_uring_unregister_buffers (3)
 function unregisters the fixed buffers previously registered to the
-.I ring.
+.IR ring .
 
 .SH RETURN VALUE
 On success

--- a/man/io_uring_unregister_buffers.3
+++ b/man/io_uring_unregister_buffers.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_unregister_buffers 3 "November 15, 2021" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_unregister_buffers - unregister buffers for fixed buffer operations
-.fi
+io_uring_unregister_buffers \- unregister buffers for fixed buffer operations
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_unregister_files.3
+++ b/man/io_uring_unregister_files.3
@@ -10,7 +10,7 @@ io_uring_unregister_files \- unregister file descriptors
 .BR "#include <liburing.h>"
 .PP
 .BI "int io_uring_unregister_files(struct io_uring *" ring ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_unregister_files.3
+++ b/man/io_uring_unregister_files.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_unregister_files 3 "November 15, 2021" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_unregister_files - unregister file descriptors
-.fi
+io_uring_unregister_files \- unregister file descriptors
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_unregister_files.3
+++ b/man/io_uring_unregister_files.3
@@ -16,7 +16,7 @@ io_uring_unregister_files \- unregister file descriptors
 The
 .BR io_uring_unregister_files (3)
 function unregisters the file descriptors previously registered to the
-.I ring.
+.IR ring .
 
 .SH RETURN VALUE
 On success

--- a/man/io_uring_unregister_files.3
+++ b/man/io_uring_unregister_files.3
@@ -7,7 +7,7 @@
 io_uring_unregister_files \- unregister file descriptors
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_unregister_files(struct io_uring *" ring ");"
 .fi

--- a/man/io_uring_unregister_ring_fd.3
+++ b/man/io_uring_unregister_ring_fd.3
@@ -4,8 +4,7 @@
 .\"
 .TH io_uring_unregister_ring_fd 3 "March 11, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
-io_uring_unregister_ring_fd   - unregister a ring file descriptor
-
+io_uring_unregister_ring_fd \- unregister a ring file descriptor
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_unregister_ring_fd.3
+++ b/man/io_uring_unregister_ring_fd.3
@@ -10,7 +10,7 @@ io_uring_unregister_ring_fd \- unregister a ring file descriptor
 .BR "#include <liburing.h>"
 .PP
 .BI "int io_uring_unregister_ring_fd(struct io_uring *" ring ");"
-
+.fi
 .SH DESCRIPTION
 .PP
 .BR io_uring_unregister_ring_fd (3)

--- a/man/io_uring_unregister_ring_fd.3
+++ b/man/io_uring_unregister_ring_fd.3
@@ -7,7 +7,7 @@
 io_uring_unregister_ring_fd \- unregister a ring file descriptor
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_unregister_ring_fd(struct io_uring *" ring ");"
 .fi
@@ -24,8 +24,7 @@ For more information on ring descriptor registration, see
 .BR io_uring_register_ring_fd (3)
 
 .SH RETURN VALUE
-Returns 1 on success, indicating that one file descriptor was unregistered,
-or
+Returns 1 on success, indicating that one file descriptor was unregistered, or
 .B -errno
 on error.
 .SH SEE ALSO

--- a/man/io_uring_unregister_ring_fd.3
+++ b/man/io_uring_unregister_ring_fd.3
@@ -29,4 +29,5 @@ or
 .B -errno
 on error.
 .SH SEE ALSO
-.BR io_uring_register_ring_fd (3), io_uring_register_files (3)
+.BR io_uring_register_ring_fd (3),
+.BR io_uring_register_files (3)

--- a/man/io_uring_wait_cqe.3
+++ b/man/io_uring_wait_cqe.3
@@ -12,7 +12,6 @@ io_uring_wait_cqe \- wait for one io_uring completion event
 .BI "int io_uring_wait_cqe(struct io_uring *" ring ","
 .BI "                      struct io_uring_cqe **" cqe_ptr ");"
 .fi
-.PP
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_wait_cqe.3
+++ b/man/io_uring_wait_cqe.3
@@ -33,7 +33,7 @@ the application can retrieve the completion with
 On success
 .BR io_uring_wait_cqe (3)
 returns 0 and the cqe_ptr parm is filled in. On failure it returns
-.B -errno.
+.BR -errno .
 The return value indicates the result of waiting for a CQE, and it has no
 relation to the CQE result itself.
 .SH SEE ALSO

--- a/man/io_uring_wait_cqe.3
+++ b/man/io_uring_wait_cqe.3
@@ -7,7 +7,7 @@
 io_uring_wait_cqe \- wait for one io_uring completion event
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_wait_cqe(struct io_uring *" ring ","
 .BI "                      struct io_uring_cqe **" cqe_ptr ");"
@@ -37,4 +37,4 @@ The return value indicates the result of waiting for a CQE, and it has no
 relation to the CQE result itself.
 .SH SEE ALSO
 .BR io_uring_submit (3),
-.BR io_uring_wait_cqes(3)
+.BR io_uring_wait_cqes (3)

--- a/man/io_uring_wait_cqe.3
+++ b/man/io_uring_wait_cqe.3
@@ -37,4 +37,5 @@ returns 0 and the cqe_ptr parm is filled in. On failure it returns
 The return value indicates the result of waiting for a CQE, and it has no
 relation to the CQE result itself.
 .SH SEE ALSO
-.BR io_uring_submit (3),  io_uring_wait_cqes(3)
+.BR io_uring_submit (3),
+.BR io_uring_wait_cqes(3)

--- a/man/io_uring_wait_cqe.3
+++ b/man/io_uring_wait_cqe.3
@@ -4,7 +4,7 @@
 .\"
 .TH io_uring_wait_cqe 3 "November 15, 2021" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_wait_cqe - wait for one io_uring completion event
+io_uring_wait_cqe \- wait for one io_uring completion event
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_wait_cqe_nr.3
+++ b/man/io_uring_wait_cqe_nr.3
@@ -13,7 +13,6 @@ io_uring_wait_cqe_nr \- wait for one or more io_uring completion events
 .BI "                         struct io_uring_cqe **" cqe_ptr ","
 .BI "                         unsigned " wait_nr ");"
 .fi
-.PP
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_wait_cqe_nr.3
+++ b/man/io_uring_wait_cqe_nr.3
@@ -7,7 +7,7 @@
 io_uring_wait_cqe_nr \- wait for one or more io_uring completion events
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_wait_cqe_nr(struct io_uring *" ring ","
 .BI "                         struct io_uring_cqe **" cqe_ptr ","

--- a/man/io_uring_wait_cqe_nr.3
+++ b/man/io_uring_wait_cqe_nr.3
@@ -40,4 +40,5 @@ returns 0 and the cqe_ptr parm is filled in. On failure it returns
 The return value indicates the result of waiting for a CQE, and it has no
 relation to the CQE result itself.
 .SH SEE ALSO
-.BR io_uring_submit (3),  io_uring_wait_cqes (3)
+.BR io_uring_submit (3),
+.BR io_uring_wait_cqes (3)

--- a/man/io_uring_wait_cqe_nr.3
+++ b/man/io_uring_wait_cqe_nr.3
@@ -4,7 +4,7 @@
 .\"
 .TH io_uring_wait_cqe_nr 3 "November 15, 2021" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_wait_cqe_nr - wait for one or more io_uring completion events
+io_uring_wait_cqe_nr \- wait for one or more io_uring completion events
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_wait_cqe_nr.3
+++ b/man/io_uring_wait_cqe_nr.3
@@ -36,7 +36,7 @@ the application can retrieve the completion with
 On success
 .BR io_uring_wait_cqe_nr (3)
 returns 0 and the cqe_ptr parm is filled in. On failure it returns
-.B -errno.
+.BR -errno .
 The return value indicates the result of waiting for a CQE, and it has no
 relation to the CQE result itself.
 .SH SEE ALSO

--- a/man/io_uring_wait_cqe_timeout.3
+++ b/man/io_uring_wait_cqe_timeout.3
@@ -47,4 +47,6 @@ returns 0 and the cqe_ptr parm is filled in. On failure it returns -errno. The
 return value indicates the result of waiting for a CQE, and it has no relation
 to the CQE result itself.
 .SH SEE ALSO
-.BR io_uring_submit (3),  io_uring_wait_cqe_timeout (3), io_uring_wait_cqe(3).
+.BR io_uring_submit (3),
+.BR io_uring_wait_cqe_timeout (3),
+.BR io_uring_wait_cqe(3)

--- a/man/io_uring_wait_cqe_timeout.3
+++ b/man/io_uring_wait_cqe_timeout.3
@@ -4,7 +4,7 @@
 .\"
 .TH io_uring_wait_cqe_timeout 3 "November 15, 2021" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_wait_cqe_timeout - wait for one io_uring completion event with timeout
+io_uring_wait_cqe_timeout \- wait for one io_uring completion event with timeout
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_wait_cqe_timeout.3
+++ b/man/io_uring_wait_cqe_timeout.3
@@ -7,7 +7,7 @@
 io_uring_wait_cqe_timeout \- wait for one io_uring completion event with timeout
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_wait_cqe_timeout(struct io_uring *" ring ","
 .BI "                              struct io_uring_cqe **" cqe_ptr ","
@@ -49,4 +49,4 @@ to the CQE result itself.
 .SH SEE ALSO
 .BR io_uring_submit (3),
 .BR io_uring_wait_cqe_timeout (3),
-.BR io_uring_wait_cqe(3)
+.BR io_uring_wait_cqe (3)

--- a/man/io_uring_wait_cqe_timeout.3
+++ b/man/io_uring_wait_cqe_timeout.3
@@ -16,12 +16,13 @@ io_uring_wait_cqe_timeout - wait for one io_uring completion event with timeout
 .SH DESCRIPTION
 .PP
 The
-.BR io_uring_wait_cqe_timeout (3) function waits for one IO completion to be
-available from the queue belonging to the
+.BR io_uring_wait_cqe_timeout (3)
+function waits for one IO completion to be available from the queue belonging
+to the
 .I ring
 param, waiting for it if necessary or until the timeout
 .I ts
-expires.If an event is already available in the ring when invoked, no waiting
+expires. If an event is already available in the ring when invoked, no waiting
 will occur.
 
 The
@@ -42,8 +43,8 @@ when waiting for a request.
 .SH RETURN VALUE
 On success
 .BR io_uring_wait_cqes (3)
-returns 0 and the cqe_ptr parm is filled in. On failure it returns -errno.
-The return value indicates the result of waiting for a CQE, and it has no
-relation to the CQE result itself.
+returns 0 and the cqe_ptr parm is filled in. On failure it returns -errno. The
+return value indicates the result of waiting for a CQE, and it has no relation
+to the CQE result itself.
 .SH SEE ALSO
 .BR io_uring_submit (3),  io_uring_wait_cqe_timeout (3), io_uring_wait_cqe(3).

--- a/man/io_uring_wait_cqe_timeout.3
+++ b/man/io_uring_wait_cqe_timeout.3
@@ -12,7 +12,7 @@ io_uring_wait_cqe_timeout \- wait for one io_uring completion event with timeout
 .BI "int io_uring_wait_cqe_timeout(struct io_uring *" ring ","
 .BI "                              struct io_uring_cqe **" cqe_ptr ","
 .BI "                              struct __kernel_timespec *" ts ");"
-.PP
+.fi
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_wait_cqes.3
+++ b/man/io_uring_wait_cqes.3
@@ -7,7 +7,7 @@
 io_uring_wait_cqes \- wait for one or more io_uring completion events
 .SH SYNOPSIS
 .nf
-.BR "#include <liburing.h>"
+.B #include <liburing.h>
 .PP
 .BI "int io_uring_wait_cqes(struct io_uring *" ring ","
 .BI "                       struct io_uring_cqe **" cqe_ptr ","
@@ -53,4 +53,4 @@ returns 0 and the cqe_ptr parm is filled in. On failure it returns
 .SH SEE ALSO
 .BR io_uring_submit (3),
 .BR io_uring_wait_cqe_timeout (3),
-.BR io_uring_wait_cqe(3)
+.BR io_uring_wait_cqe (3)

--- a/man/io_uring_wait_cqes.3
+++ b/man/io_uring_wait_cqes.3
@@ -52,4 +52,6 @@ On success
 returns 0 and the cqe_ptr parm is filled in. On failure it returns
 .BR -errno .
 .SH SEE ALSO
-.BR io_uring_submit (3),  io_uring_wait_cqe_timeout (3), io_uring_wait_cqe(3).
+.BR io_uring_submit (3),
+.BR io_uring_wait_cqe_timeout (3),
+.BR io_uring_wait_cqe(3)

--- a/man/io_uring_wait_cqes.3
+++ b/man/io_uring_wait_cqes.3
@@ -4,7 +4,7 @@
 .\"
 .TH io_uring_wait_cqes 3 "November 15, 2021" "liburing-2.1" "liburing Manual"
 .SH NAME
-io_uring_wait_cqes - wait for one or more io_uring completion events
+io_uring_wait_cqes \- wait for one or more io_uring completion events
 .SH SYNOPSIS
 .nf
 .BR "#include <liburing.h>"

--- a/man/io_uring_wait_cqes.3
+++ b/man/io_uring_wait_cqes.3
@@ -15,7 +15,6 @@ io_uring_wait_cqes \- wait for one or more io_uring completion events
 .BI "                       struct __kernel_timespec *" ts ","
 .BI "                       sigset_t *" sigmask ");
 .fi
-.PP
 .SH DESCRIPTION
 .PP
 The

--- a/man/io_uring_wait_cqes.3
+++ b/man/io_uring_wait_cqes.3
@@ -50,6 +50,6 @@ when waiting for a request.
 On success
 .BR io_uring_wait_cqes (3)
 returns 0 and the cqe_ptr parm is filled in. On failure it returns
-.B -errno.
+.BR -errno .
 .SH SEE ALSO
 .BR io_uring_submit (3),  io_uring_wait_cqe_timeout (3), io_uring_wait_cqe(3).


### PR DESCRIPTION
I noticed some [small mistakes](https://github.com/axboe/liburing/commit/50b3d7b47ba0eea68798b335d18fd6ccfe3d01f3#diff-664402edc837e5a118ae09d6ec6e2dbfad085a8685784e12e0a5cc180e3e6577R18) in a recent commit and I thought I'd fix them.  While I was there, I also fixed some other small things.

I admit I hadn't written a man page before, but a light reading of `groff(7)` and `groff_man(7)` got me up to speed.

----
## git request-pull output:
```
The following changes since commit c7d274054fea5e0a2fc2aa645b0c728643c355a6:

  Tweaks to close+unregister of direct descriptor (2022-05-30 16:53:47 -0600)

are available in the Git repository at:

  https://github.com/otommod/liburing master

for you to fetch changes up to d6617d37bd8dda5c0603ff3918cf782dce7bb760:

  man: fix and simplify bold usage (2022-06-01 00:03:55 +0300)

----------------------------------------------------------------
Otto Modinos (7):
      man: keep the function names in their own lines
      man: be consistent with description dash
      man: use PP betwen multiple function definitions
      man: fix bold/italic punctuation
      man: put SEE ALSO suggestions on their own .BRs
      man: no empty paragraphs before DESCRIPTION
      man: fix and simplify bold usage

 man/io_uring_buf_ring_add.3              | 13 +++++++------
 man/io_uring_buf_ring_advance.3          | 13 +++++++------
 man/io_uring_buf_ring_cq_advance.3       | 13 +++++++------
 man/io_uring_cq_advance.3                | 12 ++++++++----
 man/io_uring_cq_ready.3                  |  8 ++++----
 man/io_uring_cqe_get_data.3              | 15 ++++++++-------
 man/io_uring_cqe_seen.3                  | 12 ++++++++----
 man/io_uring_free_probe.3                |  5 ++---
 man/io_uring_get_probe.3                 |  5 ++---
 man/io_uring_get_sqe.3                   | 10 +++++-----
 man/io_uring_opcode_supported.3          |  5 ++---
 man/io_uring_peek_cqe.3                  | 11 ++++++-----
 man/io_uring_prep_accept.3               | 34 ++++++++++++++++++----------------
 man/io_uring_prep_cancel.3               | 19 ++++++++++---------
 man/io_uring_prep_close.3                | 23 ++++++++++++-----------
 man/io_uring_prep_connect.3              | 19 ++++++++++---------
 man/io_uring_prep_fadvise.3              | 18 ++++++++++--------
 man/io_uring_prep_fallocate.3            | 15 ++++++++-------
 man/io_uring_prep_files_update.3         | 15 ++++++++-------
 man/io_uring_prep_fsync.3                | 14 ++++++++------
 man/io_uring_prep_linkat.3               | 19 ++++++++++---------
 man/io_uring_prep_madvise.3              | 18 ++++++++++--------
 man/io_uring_prep_mkdirat.3              | 19 ++++++++++---------
 man/io_uring_prep_msg_ring.3             | 21 ++++++++++-----------
 man/io_uring_prep_openat.3               | 24 +++++++++++++-----------
 man/io_uring_prep_openat2.3              | 26 ++++++++++++++------------
 man/io_uring_prep_poll_add.3             | 18 ++++++++++--------
 man/io_uring_prep_poll_remove.3          | 11 ++++++-----
 man/io_uring_prep_poll_update.3          | 16 +++++++++-------
 man/io_uring_prep_provide_buffers.3      | 20 +++++++++++---------
 man/io_uring_prep_read.3                 | 18 ++++++++++--------
 man/io_uring_prep_read_fixed.3           | 20 ++++++++++----------
 man/io_uring_prep_readv.3                | 20 +++++++++++---------
 man/io_uring_prep_readv2.3               | 20 ++++++++++----------
 man/io_uring_prep_recv.3                 | 15 ++++++++-------
 man/io_uring_prep_recvmsg.3              | 17 +++++++++--------
 man/io_uring_prep_remove_buffers.3       | 14 ++++++++------
 man/io_uring_prep_renameat.3             | 20 +++++++++++---------
 man/io_uring_prep_send.3                 | 15 ++++++++-------
 man/io_uring_prep_sendmsg.3              | 17 +++++++++--------
 man/io_uring_prep_shutdown.3             | 15 ++++++++-------
 man/io_uring_prep_socket.3               | 23 ++++++++++++-----------
 man/io_uring_prep_splice.3               | 20 +++++++++++---------
 man/io_uring_prep_statx.3                | 23 ++++++++++++-----------
 man/io_uring_prep_symlinkat.3            | 19 ++++++++++---------
 man/io_uring_prep_sync_file_range.3      | 15 ++++++++-------
 man/io_uring_prep_tee.3                  | 17 ++++++++++-------
 man/io_uring_prep_timeout.3              | 14 ++++++++------
 man/io_uring_prep_timeout_update.3       | 17 +++++++++--------
 man/io_uring_prep_unlinkat.3             | 19 ++++++++++---------
 man/io_uring_prep_write.3                | 16 ++++++++--------
 man/io_uring_prep_write_fixed.3          | 19 ++++++++++---------
 man/io_uring_prep_writev.3               | 20 +++++++++++---------
 man/io_uring_prep_writev2.3              | 19 ++++++++++---------
 man/io_uring_queue_exit.3                |  5 ++---
 man/io_uring_queue_init.3                | 11 +++++------
 man/io_uring_register_buf_ring.3         | 18 ++++++++++--------
 man/io_uring_register_buffers.3          | 21 ++++++++++++---------
 man/io_uring_register_eventfd.3          | 11 ++++++-----
 man/io_uring_register_files.3            | 16 ++++++++--------
 man/io_uring_register_iowq_aff.3         | 16 ++++++++--------
 man/io_uring_register_iowq_max_workers.3 | 12 ++++++------
 man/io_uring_register_ring_fd.3          | 10 +++++-----
 man/io_uring_sq_ready.3                  |  5 ++---
 man/io_uring_sq_space_left.3             |  5 ++---
 man/io_uring_sqe_set_data.3              | 10 +++++-----
 man/io_uring_sqe_set_flags.3             |  8 ++++----
 man/io_uring_sqring_wait.3               |  9 +++++----
 man/io_uring_submit.3                    | 15 ++++++++-------
 man/io_uring_submit_and_wait.3           | 11 ++++++-----
 man/io_uring_submit_and_wait_timeout.3   | 16 +++++++++-------
 man/io_uring_unregister_buf_ring.3       | 14 +++++++-------
 man/io_uring_unregister_buffers.3        |  9 ++++-----
 man/io_uring_unregister_files.3          |  9 ++++-----
 man/io_uring_unregister_ring_fd.3        | 13 ++++++-------
 man/io_uring_wait_cqe.3                  | 10 +++++-----
 man/io_uring_wait_cqe_nr.3               | 10 +++++-----
 man/io_uring_wait_cqe_timeout.3          | 23 +++++++++++++----------
 man/io_uring_wait_cqes.3                 | 11 ++++++-----
 79 files changed, 637 insertions(+), 564 deletions(-)
```

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
