### PR TITLE
[GIT PULL] GitHub bot updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,13 @@ jobs:
             cc: arm-linux-gnueabi-gcc
             cxx: arm-linux-gnueabi-g++
 
+          # powerpc64
+          - arch: powerpc64
+            cc_pkg: gcc-powerpc64-linux-gnu
+            cxx_pkg: g++-powerpc64-linux-gnu
+            cc: powerpc64-linux-gnu-gcc
+            cxx: powerpc64-linux-gnu-g++
+
     env:
       FLAGS: -g -O2 -Wall -Wextra -Werror
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,8 +57,15 @@ jobs:
 
     - name: Install Compilers
       run: |
-        sudo apt-get update -y;
-        sudo apt-get install -y ${{matrix.cc_pkg}} ${{matrix.cxx_pkg}};
+        if [[ "${{matrix.cc_pkg}}" == "clang" ]]; then \
+            wget https://apt.llvm.org/llvm.sh -O /tmp/llvm.sh; \
+            sudo bash /tmp/llvm.sh 15; \
+            sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 400; \
+            sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 400; \
+        else \
+            sudo apt-get update -y; \
+            sudo apt-get install -y ${{matrix.cc_pkg}} ${{matrix.cxx_pkg}}; \
+        fi;
 
     - name: Display compiler versions
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,13 @@ jobs:
             cc: alpha-linux-gnu-gcc
             cxx: alpha-linux-gnu-g++
 
+          # mips64
+          - arch: mips64
+            cc_pkg: gcc-mips64-linux-gnuabi64
+            cxx_pkg: g++-mips64-linux-gnuabi64
+            cc: mips64-linux-gnuabi64-gcc
+            cxx: mips64-linux-gnuabi64-g++
+
     env:
       FLAGS: -g -O2 -Wall -Wextra -Werror
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,13 @@ jobs:
             cc: powerpc64-linux-gnu-gcc
             cxx: powerpc64-linux-gnu-g++
 
+          # powerpc
+          - arch: powerpc
+            cc_pkg: gcc-powerpc-linux-gnu
+            cxx_pkg: g++-powerpc-linux-gnu
+            cc: powerpc-linux-gnu-gcc
+            cxx: powerpc-linux-gnu-g++
+
     env:
       FLAGS: -g -O2 -Wall -Wextra -Werror
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,13 @@ jobs:
             cc: powerpc-linux-gnu-gcc
             cxx: powerpc-linux-gnu-g++
 
+          # alpha
+          - arch: alpha
+            cc_pkg: gcc-alpha-linux-gnu
+            cxx_pkg: g++-alpha-linux-gnu
+            cc: alpha-linux-gnu-gcc
+            cxx: alpha-linux-gnu-g++
+
     env:
       FLAGS: -g -O2 -Wall -Wextra -Werror
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,13 @@ jobs:
             cc: mips64-linux-gnuabi64-gcc
             cxx: mips64-linux-gnuabi64-g++
 
+          # mips
+          - arch: mips
+            cc_pkg: gcc-mips-linux-gnu
+            cxx_pkg: g++-mips-linux-gnu
+            cc: mips-linux-gnu-gcc
+            cxx: mips-linux-gnu-g++
+
     env:
       FLAGS: -g -O2 -Wall -Wextra -Werror
 


### PR DESCRIPTION
Hi Jens,

GitHub bot updates this time:

  - Use clang latest version for better issue coverage.

  - Add more architectures for GitHub bot: powerpc64, powerpc, alpha,
    mips64, mips.

Please pull!
```
The following changes since commit a12f209d0133b71648da3f0d7d71997b35f75359:

  test/socket: fix argument order for socket prep (2022-06-01 08:16:08 -0600)

are available in the Git repository at:

  https://github.com/ammarfaizi2/liburing tags/github-bot-2022-06-02

for you to fetch changes up to df9874a6ff66bd22edf99b558e78af0ddfa999ed:

  .github: Add mips build for GitHub bot (2022-06-02 08:10:21 +0700)

----------------------------------------------------------------
Pull GitHub bot updates from Ammar Faizi:

  - Use clang latest version for better issue coverage.

  - Add more architectures for GitHub bot: powerpc64, powerpc, alpha,
    mips64, mips.

Link: https://github.com/axboe/liburing/pull/590

----------------------------------------------------------------
Ammar Faizi (6):
      .github: Use clang latest version
      .github: Add powerpc64 build for GitHub bot
      .github: Add powerpc build for GitHub bot
      .github: Add alpha build for GitHub bot
      .github: Add mips64 build for GitHub bot
      .github: Add mips build for GitHub bot

 .github/workflows/build.yml | 46 ++++++++++++++++++++++++++++++++++++++--
 1 file changed, 44 insertions(+), 2 deletions(-)
```