### PR TITLE
[GIT PULL] man/io_uring_prep_accept.3: fix parameter types

### DIFF
--- a/man/io_uring_prep_accept.3
+++ b/man/io_uring_prep_accept.3
@@ -13,26 +13,26 @@ io_uring_prep_accept \- prepare an accept request
 .BI "void io_uring_prep_accept(struct io_uring_sqe *" sqe ","
 .BI "                          int " sockfd ","
 .BI "                          struct sockaddr *" addr ","
-.BI "                          socklen_t " addrlen ","
+.BI "                          socklen_t *" addrlen ","
 .BI "                          int " flags ");"
 .PP
 .BI "void io_uring_prep_accept_direct(struct io_uring_sqe *" sqe ","
 .BI "                                 int " sockfd ","
 .BI "                                 struct sockaddr *" addr ","
-.BI "                                 socklen_t " addrlen ","
+.BI "                                 socklen_t *" addrlen ","
 .BI "                                 int " flags ","
 .BI "                                 unsigned int " file_index ");"
 .PP
 .BI "void io_uring_prep_multishot_accept(struct io_uring_sqe *" sqe ","
 .BI "                                    int " sockfd ","
 .BI "                                    struct sockaddr *" addr ","
-.BI "                                    socklen_t " addrlen ","
+.BI "                                    socklen_t *" addrlen ","
 .BI "                                    int " flags ");"
 .PP
 .BI "void io_uring_prep_multishot_accept_direct(struct io_uring_sqe *" sqe ","
 .BI "                                           int " sockfd ","
 .BI "                                           struct sockaddr *" addr ","
-.BI "                                           socklen_t " addrlen ","
+.BI "                                           socklen_t *" addrlen ","
 .BI "                                           int " flags ");"
 .fi
 .SH DESCRIPTION


### PR DESCRIPTION
`io_uring_prep_accept` and its variants accept `socklen_t *` not
`socklen_t`.

Signed-off-by: Seiichi Uchida <topecongiro@fastmail.com>


<!-- Explain your changes here... -->

----
## git request-pull output:
```
The following changes since commit a7fb522e3b03b6ecc53355305a587164dbec2df8:

  cHANGELOG: add a few more updates (2022-06-04 06:07:36 -0600)

are available in the Git repository at:

  https://github.com/topecongiro/liburing fix/man-accept

for you to fetch changes up to 1f4041a064df14e1bdfd7b7a540b64ea7e85d1fb:

  man/io_uring_prep_accept.3: fix parameter types (2022-06-06 10:00:37 +0900)

----------------------------------------------------------------
Seiichi Uchida (1):
      man/io_uring_prep_accept.3: fix parameter types

 man/io_uring_prep_accept.3 | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)
```