### PR TITLE
changelog: fix wrong man page reference

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,7 +11,7 @@ liburing-2.2 release
 - Add support for newer request cancelation features.
 - Add support for IORING_SETUP_COOP_TASKRUN, which can help reduce the
   overhead of io_uring in general. Most applications should set this flag,
-  see the io_uring_enter.3 man page for details.
+  see the io_uring_setup.2 man page for details.
 - Add support for registering a sparse buffer and file set.
 - Add support for a new buffer provide scheme, see
   io_uring_register_buf_ring.3 for details.


### PR DESCRIPTION
During reading the recently added CHANGELOG I stumbled over
IORING_SETUP_COOP_TASKRUN which is documented in man/io_uring_setup.2
rather than in man/io_uring_enter.3.

Fixes: b7911762 ("Add CHANGELOG file")
Signed-off-by: Florian Fischer <florian.fischer@muhq.space>


<!-- Explain your changes here... -->

----
## git request-pull output:
```
The following changes since commit 807c8169e153a3985f1a4deddc302846673ef979:

  Merge branch 'fix/man-madvise' of https://github.com/topecongiro/liburing (2022-06-07 00:42:16 -0600)

are available in the Git repository at:

  https://github.com/fischerling/liburing/ fix-changelog-man-reference

for you to fetch changes up to ed447b9aa0d84aaf5402021c68cba3d62c3d7a37:

  changelog: fix wrong man page reference (2022-06-13 14:16:34 +0200)

----------------------------------------------------------------
Florian Fischer (1):
      changelog: fix wrong man page reference

 CHANGELOG | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
