### PR TITLE
[GIT PULL] man/io_uring_setup.2: fix typo

### DIFF
--- a/man/io_uring_setup.2
+++ b/man/io_uring_setup.2
@@ -171,7 +171,7 @@ then it will be clamped at
 .B IORING_MAX_CQ_ENTRIES .
 .TP
 .B IORING_SETUP_ATTACH_WQ
-This flag should be set in conjunction with 
+This flag should be set in conjunction with
 .IR "struct io_uring_params.wq_fd"
 being set to an existing io_uring ring file descriptor. When set, the
 io_uring instance being created will share the asynchronous worker
@@ -188,7 +188,7 @@ for details on how to enable the ring. Available since 5.10.
 .B IORING_SETUP_SUBMIT_ALL
 Normally io_uring stops submitting a batch of request, if one of these requests
 results in an error. This can cause submission of less than what is expected,
-if a request ends in error while being submitted. If the ring is creted with
+if a request ends in error while being submitted. If the ring is created with
 this flag,
 .BR io_uring_enter (2)
 will continue submitting requests even if it encounters an error submitting


### PR DESCRIPTION
Signed-off-by: 李通洲 <carter.li@eoitek.com>


<!-- Explain your changes here... -->

`creted` => `created`

----
## git request-pull output:
```
The following changes since commit a9e941d4986261332365292ffabf7f71383a9eef:

  Remove IORING_CLOSE_FD_AND_FILE_SLOT (2022-06-15 09:54:17 -0600)

are available in the Git repository at:

  git@github.com:CarterLi/liburing.git master

for you to fetch changes up to ed55ffb31421684abe409dde38e4682eb207437a:

  man/io_uring_setup.2: fix typo (2022-06-16 00:34:31 +0800)

----------------------------------------------------------------
李通洲 (1):
      man/io_uring_setup.2: fix typo

 man/io_uring_setup.2 | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
