### PR TITLE
Change type of `flags` in `io_uring_prep_renameat()` to `unsigned int`

### DIFF
--- a/man/io_uring_prep_renameat.3
+++ b/man/io_uring_prep_renameat.3
@@ -16,12 +16,12 @@ io_uring_prep_renameat \- prepare a renameat request
 .BI "                            const char *" oldpath ","
 .BI "                            int " newdirfd ","
 .BI "                            const char *" newpath ","
-.BI "                            int " flags ");"
+.BI "                            unsigned int " flags ");"
 .PP
 .BI "void io_uring_prep_rename(struct io_uring_sqe *" sqe ","
 .BI "                          const char *" oldpath ","
 .BI "                          const char *" newpath ","
-.BI "                          int " flags ");"
+.BI "                          unsigned int " flags ");"
 .fi
 .SH DESCRIPTION
 .PP

--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -735,7 +735,7 @@ static inline void io_uring_prep_unlink(struct io_uring_sqe *sqe,
 
 static inline void io_uring_prep_renameat(struct io_uring_sqe *sqe, int olddfd,
 					  const char *oldpath, int newdfd,
-					  const char *newpath, int flags)
+					  const char *newpath, unsigned int flags)
 {
 	io_uring_prep_rw(IORING_OP_RENAMEAT, sqe, olddfd, oldpath,
 				(__u32) newdfd,


### PR DESCRIPTION
According to:
https://man7.org/linux/man-pages/man2/rename.2.html `renameat2`
`flags` takes `unsigned int`

Signed-off-by: Ritesh public@ritesh.ca