### PR TITLE
Exitcode protocol for reporting tests as skipped

### DIFF
--- a/test/ce593a6c480a.c
+++ b/test/ce593a6c480a.c
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
 	/* Setup the ring with a registered event fd to be notified on events */
 	ret = t_create_ring_params(8, &ring, &p);
 	if (ret == T_SETUP_SKIP)
-		return 0;
+		return 77;
 	else if (ret < 0)
 		return ret;
 

--- a/test/d4ae271dfaae.c
+++ b/test/d4ae271dfaae.c
@@ -31,7 +31,7 @@ int main(int argc, char *argv[])
 	p.flags = IORING_SETUP_SQPOLL;
 	ret = t_create_ring_params(4, &ring, &p);
 	if (ret == T_SETUP_SKIP)
-		return 0;
+		return 77;
 	else if (ret < 0)
 		return 1;
 

--- a/test/d77a67ed5f27.c
+++ b/test/d77a67ed5f27.c
@@ -31,7 +31,7 @@ int main(int argc, char *argv[])
 	p.flags = IORING_SETUP_SQPOLL;
 	ret = t_create_ring_params(4, &ring, &p);
 	if (ret == T_SETUP_SKIP)
-		return 0;
+		return 77;
 	else if (ret < 0)
 		return 1;
 

--- a/test/defer.c
+++ b/test/defer.c
@@ -305,7 +305,7 @@ int main(int argc, char *argv[])
 	ret = t_create_ring(RING_SIZE, &sqthread_ring,
 				IORING_SETUP_SQPOLL | IORING_SETUP_IOPOLL);
 	if (ret == T_SETUP_SKIP)
-		return 0;
+		return 77;
 	else if (ret < 0)
 		return 1;
 

--- a/test/empty-eownerdead.c
+++ b/test/empty-eownerdead.c
@@ -24,7 +24,7 @@ int main(int argc, char *argv[])
 
 	ret = t_create_ring_params(1, &ring, &p);
 	if (ret == T_SETUP_SKIP)
-		return 0;
+		return 77;
 	else if (ret < 0)
 		goto err;
 

--- a/test/fixed-buf-iter.c
+++ b/test/fixed-buf-iter.c
@@ -63,7 +63,7 @@ static int test(struct io_uring *ring)
 		return 1;
 	}
 
-	if (cqe->res < 0) { 
+	if (cqe->res < 0) {
 		fprintf(stderr, "Error in async operation: %s\n", strerror(-cqe->res));
 		return 1;
 	}
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
 
 	ret = t_create_ring(8, &ring, 0);
 	if (ret == T_SETUP_SKIP)
-		return 0;
+		return 77;
 	else if (ret < 0)
 		return 1;
 

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -112,6 +112,9 @@ run_test()
 	if [ "$status" -eq 124 ]; then
 		echo "Test $test_name timed out (may not be a failure)"
 		TIMED_OUT="$TIMED_OUT <$test_string>"
+	elif [ "$status" -eq 77 ]; then
+		echo "Test $test_name skipped itself"
+		SKIPPED="$SKIPPED <$test_string>"
 	elif [ "$status" -ne 0 ]; then
 		echo "Test $test_name failed with ret $status"
 		FAILED="$FAILED <$test_string>"
@@ -164,6 +167,8 @@ fi
 if [ "${RET}" -ne 0 ]; then
 	echo "Tests failed: $FAILED"
 	exit $RET
+elif [ -n "$SKIPPED" ] && [ -n "$TEST_GNU_EXITCODE" ]; then
+	exit 77
 else
 	echo "All tests passed"
 	exit 0

--- a/test/rw_merge_test.c
+++ b/test/rw_merge_test.c
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
 
 	ret = t_create_ring(4, &ring, 0);
 	if (ret == T_SETUP_SKIP)
-		return 0;
+		return 77;
 	else if (ret < 0)
 		return 1;
 

--- a/test/skip-cqe.c
+++ b/test/skip-cqe.c
@@ -325,7 +325,7 @@ int main(int argc, char *argv[])
 
 	if (!(ring.features & IORING_FEAT_CQE_SKIP)) {
 		printf("IOSQE_CQE_SKIP_SUCCESS is not supported, skip\n");
-		return 0;
+		return 77;
 	}
 
 	for (i = 0; i < 4; i++) {

--- a/test/tty-write-dpoll.c
+++ b/test/tty-write-dpoll.c
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 
 	ret = t_create_ring(SQES, &ring, 0);
 	if (ret == T_SETUP_SKIP)
-		return 0;
+		return 77;
 	else if (ret < 0)
 		return 1;
 


### PR DESCRIPTION
Inspired by the attempts at using other build systems with liburing, I took a look at how the testsuite is set up. I noticed that when tests are skipped due to lack of requirements in setting up the tests, they are reported as "passing" by the test harness, and the only real visibility into the fact that they were skipped is the log messages they emit.

GNU automake has a standard exitcode for tests like that -- just exit 77 -- and Meson respects it by default. (Even cmake can be made to respect it via `SKIP_RETURN_CODE`.) So it seems like a good idea to follow in the same footsteps as these existing practices. It's as good a choice as anything else, and has the benefit of consistency -- if the project ever switches build systems, this will already work without any further effort.

This PR changes runtests.sh to detect the special exitcode and list those tests together with "Tests skipped", and ports a few tests over to use it as well -- I don't thoroughly understand the test flow of many of the test programs, so I stuck to the obviously correct cases because a) it has to start somewhere, b) it demonstrates the basic idea of how to structure things.