### PR TITLE
man: fix typo in manual for io_uring_enter

### DIFF
--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -460,7 +460,7 @@ suspend while having a timeout request in-flight.
 
 .B IORING_TIMEOUT_REALTIME
 If set, then the clocksource used is
-.I CLOCK_BOOTTIME
+.I CLOCK_REALTIME
 instead of
 .I CLOCK_MONOTONIC.
 .EE


### PR DESCRIPTION
Fix typo in the manual for `io_uring_enter`.