### PR TITLE
Typos and man page fixes

### DIFF
--- a/man/io_uring.7
+++ b/man/io_uring.7
@@ -2,7 +2,7 @@
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
 
-.TH IO_URING 7 2020-07-26 "Linux" "Linux Programmer's Manual"
+.TH io_uring 7 2020-07-26 "Linux" "Linux Programmer's Manual"
 .SH NAME
 io_uring \- Asynchronous I/O facility
 .SH SYNOPSIS

--- a/man/io_uring_cq_ready.3
+++ b/man/io_uring_cq_ready.3
@@ -15,7 +15,7 @@ io_uring_cq_ready \- returns number of unconsumed ready entries in the CQ ring
 .PP
 The
 .BR io_uring_cq_ready (3)
-function retuns the number of unconsumed entries that are ready belonging to the
+function returns the number of unconsumed entries that are ready belonging to the
 .I ring
 param.
 

--- a/man/io_uring_cq_ready.3
+++ b/man/io_uring_cq_ready.3
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_cq_ready "January 25, 2022" "liburing-2.1" "liburing Manual"
+.TH io_uring_cq_ready 3 "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
 io_uring_cq_ready \- returns number of unconsumed ready entries in the CQ ring
 .SH SYNOPSIS

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -3,7 +3,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH IO_URING_ENTER 2 2019-01-22 "Linux" "Linux Programmer's Manual"
+.TH io_uring_enter 2 2019-01-22 "Linux" "Linux Programmer's Manual"
 .SH NAME
 io_uring_enter \- initiate and/or complete asynchronous I/O
 .SH SYNOPSIS

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -34,7 +34,7 @@ specifies the number of I/Os to submit from the submission queue.
 is a bitmask of the following values:
 .TP
 .B IORING_ENTER_GETEVENTS
-If this flag is set, then the system call will wait for the specificied
+If this flag is set, then the system call will wait for the specified
 number of events in
 .I min_complete
 before returning. This flag can be set along with

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -1052,7 +1052,7 @@ set, and a
 field matching the
 .I off
 value being passed in. This request type can be used to either just wake or
-interrupt anyone waiting for completions on the target ring, ot it can be used
+interrupt anyone waiting for completions on the target ring, or it can be used
 to pass messages via the two fields. Available since 5.18.
 
 .PP
@@ -1143,7 +1143,7 @@ linked timeout has the flag set, it's guaranteed to not post a CQE.
 
 The semantics are chosen to accommodate several use cases. First, when all but
 the last request of a normal link without linked timeouts are marked with the
-flag, only one CQE per lin is posted. Additionally, it enables supression of
+flag, only one CQE per lin is posted. Additionally, it enables suppression of
 CQEs in cases where the side effects of a successfully executed operation is
 enough for userspace to know the state of the system. One such example would
 be writing to a synchronisation file.

--- a/man/io_uring_free_probe.3
+++ b/man/io_uring_free_probe.3
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_free_probe "January 25, 2022" "liburing-2.1" "liburing Manual"
+.TH io_uring_free_probe 3 "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
 io_uring_free_probe \- free probe instance
 .SH SYNOPSIS

--- a/man/io_uring_get_probe.3
+++ b/man/io_uring_get_probe.3
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_get_probe "January 25, 2022" "liburing-2.1" "liburing Manual"
+.TH io_uring_get_probe 3 "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
 io_uring_get_probe \- get probe instance
 .SH SYNOPSIS

--- a/man/io_uring_opcode_supported.3
+++ b/man/io_uring_opcode_supported.3
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_opcode_supported "January 25, 2022" "liburing-2.1" "liburing Manual"
+.TH io_uring_opcode_supported 3 "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
 io_uring_opcode_supported \- is op code supported?
 .SH SYNOPSIS

--- a/man/io_uring_prep_read_fixed.3
+++ b/man/io_uring_prep_read_fixed.3
@@ -42,7 +42,7 @@ The
 .I buf
 and
 .I nbytes
-arguments must fall within a region specificed by
+arguments must fall within a region specified by
 .I buf_index
 in the previously registered buffer. The buffer need not be aligned with
 the start of the registered buffer.

--- a/man/io_uring_prep_write_fixed.3
+++ b/man/io_uring_prep_write_fixed.3
@@ -42,7 +42,7 @@ The
 .I buf
 and
 .I nbytes
-arguments must fall within a region specificed by
+arguments must fall within a region specified by
 .I buf_index
 in the previously registered buffer. The buffer need not be aligned with
 the start of the registered buffer.

--- a/man/io_uring_register.2
+++ b/man/io_uring_register.2
@@ -3,7 +3,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH IO_URING_REGISTER 2 2019-01-17 "Linux" "Linux Programmer's Manual"
+.TH io_uring_register 2 2019-01-17 "Linux" "Linux Programmer's Manual"
 .SH NAME
 io_uring_register \- register files or user buffers for asynchronous I/O 
 .SH SYNOPSIS

--- a/man/io_uring_register_buf_ring.3
+++ b/man/io_uring_register_buf_ring.3
@@ -64,7 +64,7 @@ field, and the associated CQE will have
 .B IORING_CQE_F_BUFFER
 set in their
 .I flags
-member, which will also contain the specific ID of the buffer seleted. The rest
+member, which will also contain the specific ID of the buffer selected. The rest
 of the fields are reserved and must be cleared to zero.
 
 The

--- a/man/io_uring_setup.2
+++ b/man/io_uring_setup.2
@@ -4,7 +4,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH IO_URING_SETUP 2 2019-01-29 "Linux" "Linux Programmer's Manual"
+.TH io_uring_setup 2 2019-01-29 "Linux" "Linux Programmer's Manual"
 .SH NAME
 io_uring_setup \- setup a context for performing asynchronous I/O
 .SH SYNOPSIS

--- a/man/io_uring_sq_ready.3
+++ b/man/io_uring_sq_ready.3
@@ -15,7 +15,7 @@ io_uring_sq_ready \- number of unconsumed or unsubmitted entries in the SQ ring
 .PP
 The
 .BR io_uring_sq_ready (3)
-function retuns the number of unconsumed (if SQPOLL) or unsubmitted entries
+function returns the number of unconsumed (if SQPOLL) or unsubmitted entries
 that exist in the SQ ring belonging to the
 .I ring
 param.

--- a/man/io_uring_sq_ready.3
+++ b/man/io_uring_sq_ready.3
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_sq_ready "January 25, 2022" "liburing-2.1" "liburing Manual"
+.TH io_uring_sq_ready 3 "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
 io_uring_sq_ready \- number of unconsumed or unsubmitted entries in the SQ ring
 .SH SYNOPSIS

--- a/man/io_uring_sq_space_left.3
+++ b/man/io_uring_sq_space_left.3
@@ -15,7 +15,7 @@ io_uring_sq_space_left \- free space in the SQ ring
 .PP
 The
 .BR io_uring_sq_space_left (3)
-function retuns how much space is left in the SQ ring belonging to the
+function returns how much space is left in the SQ ring belonging to the
 .I ring
 param.
 

--- a/man/io_uring_sq_space_left.3
+++ b/man/io_uring_sq_space_left.3
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_sq_space-left "January 25, 2022" "liburing-2.1" "liburing Manual"
+.TH io_uring_sq_space-left 3 "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
 io_uring_sq_space_left \- free space in the SQ ring
 .SH SYNOPSIS

--- a/man/io_uring_sqe_set_flags.3
+++ b/man/io_uring_sqe_set_flags.3
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_sqe_set_flags "January 25, 2022" "liburing-2.1" "liburing Manual"
+.TH io_uring_sqe_set_flags 3 "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
 io_uring_sqe_set_flags \- set flags for submission queue entry
 .SH SYNOPSIS

--- a/man/io_uring_sqe_set_flags.3
+++ b/man/io_uring_sqe_set_flags.3
@@ -65,7 +65,7 @@ one completes.
 .B IOSQE_CQE_SKIP_SUCCESS
 Request that no CQE be generated for this request, if it completes successfully.
 This can be useful in cases where the application doesn't need to know when
-a specific request completed, if it completed succesfully.
+a specific request completed, if it completed successfully.
 .TP
 .B IOSQE_BUFFER_SELECT
 If set, and if the request types supports it, select an IO buffer from the

--- a/man/io_uring_sqring_wait.3
+++ b/man/io_uring_sqring_wait.3
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_sqring_wait "January 25, 2022" "liburing-2.1" "liburing Manual"
+.TH io_uring_sqring_wait 3 "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
 io_uring_sqring_wait \- wait for free space in the SQ ring
 .SH SYNOPSIS

--- a/man/io_uring_wait_cqe.3
+++ b/man/io_uring_wait_cqe.3
@@ -31,7 +31,7 @@ the application can retrieve the completion with
 .SH RETURN VALUE
 On success
 .BR io_uring_wait_cqe (3)
-returns 0 and the cqe_ptr parm is filled in. On failure it returns
+returns 0 and the cqe_ptr param is filled in. On failure it returns
 .BR -errno .
 The return value indicates the result of waiting for a CQE, and it has no
 relation to the CQE result itself.

--- a/man/io_uring_wait_cqe_nr.3
+++ b/man/io_uring_wait_cqe_nr.3
@@ -34,7 +34,7 @@ the application can retrieve the completion with
 .SH RETURN VALUE
 On success
 .BR io_uring_wait_cqe_nr (3)
-returns 0 and the cqe_ptr parm is filled in. On failure it returns
+returns 0 and the cqe_ptr param is filled in. On failure it returns
 .BR -errno .
 The return value indicates the result of waiting for a CQE, and it has no
 relation to the CQE result itself.

--- a/man/io_uring_wait_cqe_timeout.3
+++ b/man/io_uring_wait_cqe_timeout.3
@@ -43,7 +43,7 @@ when waiting for a request.
 .SH RETURN VALUE
 On success
 .BR io_uring_wait_cqes (3)
-returns 0 and the cqe_ptr parm is filled in. On failure it returns
+returns 0 and the cqe_ptr param is filled in. On failure it returns
 .BR -errno .
 The return value indicates the result of waiting for a CQE, and it has no
 relation to the CQE result itself.

--- a/man/io_uring_wait_cqes.3
+++ b/man/io_uring_wait_cqes.3
@@ -48,7 +48,7 @@ when waiting for a request.
 .SH RETURN VALUE
 On success
 .BR io_uring_wait_cqes (3)
-returns 0 and the cqe_ptr parm is filled in. On failure it returns
+returns 0 and the cqe_ptr param is filled in. On failure it returns
 .BR -errno .
 .SH SEE ALSO
 .BR io_uring_submit (3),

--- a/test/fixed-link.c
+++ b/test/fixed-link.c
@@ -28,7 +28,7 @@ int main(int argc, char *argv[])
 	}
 
 	if (io_uring_queue_init(32, &ring, 0) < 0) {
-		fprintf(stderr, "Faild to init io_uring\n");
+		fprintf(stderr, "Failed to init io_uring\n");
 		close(fd);
 		return T_EXIT_FAIL;
 	}

--- a/test/multicqes_drain.c
+++ b/test/multicqes_drain.c
@@ -117,7 +117,7 @@ __u8 generate_flags(int sqe_op)
 	/*
 	 * avoid below case:
 	 * sqe0(multishot, link)->sqe1(nop, link)->sqe2(nop)->sqe3(cancel_sqe0)
-	 * sqe3 may excute before sqe0 so that sqe0 isn't cancelled
+	 * sqe3 may execute before sqe0 so that sqe0 isn't cancelled
 	 */
 	if (sqe_op == multi)
 		flags &= ~IOSQE_IO_LINK;

--- a/test/rsrc_tags.c
+++ b/test/rsrc_tags.c
@@ -182,7 +182,7 @@ static int test_buffers_update(void)
 		return 1;
 	}
 
-	/* test that CQE is not emmited before we're done with a buffer */
+	/* test that CQE is not emitted before we're done with a buffer */
 	sqe = io_uring_get_sqe(&ring);
 	io_uring_prep_read_fixed(sqe, pipes[0], tmp_buf, 10, 0, 0);
 	sqe->user_data = 100;

--- a/test/rw_merge_test.c
+++ b/test/rw_merge_test.c
@@ -79,7 +79,7 @@ int main(int argc, char *argv[])
 	assert(ret == 1);
 
 	/*
-	 * Read may stuck because of bug there request was be incorrecly
+	 * Read may stuck because of bug there request was be incorrectly
 	 * merged with <REQ1> request
 	 */
 	ret = io_uring_wait_cqe_timeout(&ring, &cqe, &ts);

--- a/test/single-issuer.c
+++ b/test/single-issuer.c
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
 	/* test that the creator iw allowed to submit */
 	ret = try_submit(&ring);
 	if (ret) {
-		fprintf(stderr, "the creater can't submit %i\n", ret);
+		fprintf(stderr, "the creator can't submit %i\n", ret);
 		return T_EXIT_FAIL;
 	}
 

--- a/test/timeout.c
+++ b/test/timeout.c
@@ -156,7 +156,7 @@ static int test_single_timeout_nr(struct io_uring *ring, int nr)
 
 		/*
 		 * NOP commands have user_data as 1. Check that we get the
-		 * at least 'nr' NOPs first, then the successfully removed timout.
+		 * at least 'nr' NOPs first, then the successfully removed timeout.
 		 */
 		if (io_uring_cqe_get_data(cqe) == NULL) {
 			if (i < nr) {
@@ -588,7 +588,7 @@ static int test_multi_timeout(struct io_uring *ring)
 		}
 
 		if (cqe->user_data != user_data) {
-			fprintf(stderr, "%s: unexpected timeout req %d sequece\n",
+			fprintf(stderr, "%s: unexpected timeout req %d sequence\n",
 				__FUNCTION__, i+1);
 			goto err;
 		}
@@ -678,7 +678,7 @@ static int test_multi_timeout_nr(struct io_uring *ring)
 		case 1:
 			/* Should be timeout req_2 */
 			if (cqe->user_data != 2) {
-				fprintf(stderr, "%s: unexpected timeout req %d sequece\n",
+				fprintf(stderr, "%s: unexpected timeout req %d sequence\n",
 					__FUNCTION__, i+1);
 				goto err;
 			}
@@ -691,7 +691,7 @@ static int test_multi_timeout_nr(struct io_uring *ring)
 		case 2:
 			/* Should be timeout req_1 */
 			if (cqe->user_data != 1) {
-				fprintf(stderr, "%s: unexpected timeout req %d sequece\n",
+				fprintf(stderr, "%s: unexpected timeout req %d sequence\n",
 					__FUNCTION__, i+1);
 				goto err;
 			}


### PR DESCRIPTION
Several typo and man page fixes.

----
## git request-pull output:
```
The following changes since commit bf3fedba890e66d644692910964fe1d8cbf4fb1b:

  test/xattr: don't rely on NUL-termination (2022-08-16 06:23:05 -0600)

are available in the Git repository at:

  https://github.com/guillemj/liburing pu/man-fixes

for you to fetch changes up to bf46399506adb26465f0da065b32d4318f9e7e68:

  man: Lowercase man page name in title header (2022-08-16 21:21:25 +0200)

----------------------------------------------------------------
Guillem Jover (7):
      Fix typo for "cancellation"
      Fix typo for "returns"
      Fix typo for "suppression"
      Fix typo for "successfully"
      Fix typo for "or"
      man: Add missing section numbers
      man: Lowercase man page name in title header

 CHANGELOG                       |  2 +-
 man/io_uring.7                  |  2 +-
 man/io_uring_cq_ready.3         |  4 ++--
 man/io_uring_enter.2            |  8 ++++----
 man/io_uring_free_probe.3       |  2 +-
 man/io_uring_get_probe.3        |  2 +-
 man/io_uring_opcode_supported.3 |  2 +-
 man/io_uring_prep_cancel.3      | 24 ++++++++++++------------
 man/io_uring_prep_poll_remove.3 |  6 +++---
 man/io_uring_prep_poll_update.3 |  6 +++---
 man/io_uring_register.2         |  2 +-
 man/io_uring_setup.2            |  2 +-
 man/io_uring_sq_ready.3         |  4 ++--
 man/io_uring_sq_space_left.3    |  4 ++--
 man/io_uring_sqe_set_flags.3    |  4 ++--
 man/io_uring_sqring_wait.3      |  2 +-
 src/include/liburing/io_uring.h |  4 ++--
 17 files changed, 40 insertions(+), 40 deletions(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
