### PR TITLE
[GIT PULL] liburing: cache ring sizes and masks

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -142,7 +142,7 @@ again:
 	ready = io_uring_cq_ready(ring);
 	if (ready) {
 		unsigned head = *ring->cq.khead;
-		unsigned mask = *ring->cq.kring_mask;
+		unsigned mask = ring->cq.ring_mask;
 		unsigned last;
 		int i = 0;
 
@@ -178,7 +178,7 @@ done:
 int __io_uring_flush_sq(struct io_uring *ring)
 {
 	struct io_uring_sq *sq = &ring->sq;
-	const unsigned mask = *sq->kring_mask;
+	const unsigned mask = sq->ring_mask;
 	unsigned ktail = *sq->ktail;
 	unsigned to_submit = sq->sqe_tail - sq->sqe_head;
 

--- a/test/accept-reuse.c
+++ b/test/accept-reuse.c
@@ -26,7 +26,7 @@ int submit_sqe(void)
 	struct io_uring_sq *sq = &io_uring.sq;
 	const unsigned tail = *sq->ktail;
 
-	sq->array[tail & *sq->kring_mask] = 0;
+	sq->array[tail & sq->ring_mask] = 0;
 	io_uring_smp_store_release(sq->ktail, tail + 1);
 
 	return sys_io_uring_enter(io_uring.ring_fd, 1, 0, 0, NULL);

--- a/test/accept.c
+++ b/test/accept.c
@@ -240,7 +240,7 @@ static void cause_overflow(struct io_uring *ring)
 {
 	int i, ret;
 
-	for (i = 0; i < *ring->cq.kring_entries; i++) {
+	for (i = 0; i < ring->cq.ring_entries; i++) {
 		struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
 
 		io_uring_prep_nop(sqe);

--- a/test/io_uring_enter.c
+++ b/test/io_uring_enter.c
@@ -194,7 +194,7 @@ int main(int argc, char **argv)
 		perror("io_uring_queue_init");
 		exit(T_EXIT_FAIL);
 	}
-	mask = *sq->kring_mask;
+	mask = sq->ring_mask;
 
 	/* invalid flags */
 	status |= try_io_uring_enter(ring.ring_fd, 1, 0, ~0U, NULL, -EINVAL);
@@ -209,7 +209,7 @@ int main(int argc, char **argv)
 	status |= try_io_uring_enter(ring.ring_fd, 0, 0, 0, NULL, 0);
 
 	/* fill the sq ring */
-	sq_entries = *ring.sq.kring_entries;
+	sq_entries = ring.sq.ring_entries;
 	submit_io(&ring, sq_entries);
 	ret = __sys_io_uring_enter(ring.ring_fd, 0, sq_entries,
 					IORING_ENTER_GETEVENTS, NULL);
@@ -235,7 +235,7 @@ int main(int argc, char **argv)
 	 * Add an invalid index to the submission queue.  This should
 	 * result in the dropped counter increasing.
 	 */
-	index = *sq->kring_entries + 1; // invalid index
+	index = sq->ring_entries + 1; // invalid index
 	dropped = *sq->kdropped;
 	ktail = *sq->ktail;
 	sq->array[ktail & mask] = index;


### PR DESCRIPTION
Avoid an additional pointer indirection to `ring_mask` and `ring_entries`,
since their values can't change after the ring is created.
The fields `kring_mask` and `kring_entries` are no longer needed,
but kept for backwards compatibility since `liburing.h` exposes them.
They can be removed in a future major release, saving 8 bytes per queue.

----
## git request-pull output:
```
The following changes since commit 8af924d6d3ac6a92c4af1df847cf713e4d2b67e3:

  liburing: fix return code for test/hardlink.t (2022-08-26 12:42:25 -0600)

are available in the Git repository at:

  git@github.com:calebsander/liburing.git refactor/cache-ring-size

for you to fetch changes up to f5cd4eb2b50840510a4c6bbe5ba34a5a2058a2ae:

  liburing: cache ring sizes and masks (2022-08-28 13:24:23 -0600)

----------------------------------------------------------------
Caleb Sander (1):
      liburing: cache ring sizes and masks

 src/include/liburing.h | 24 +++++++++++++++++-------
 src/queue.c            |  4 ++--
 src/setup.c            |  9 +++++++--
 test/accept-reuse.c    |  2 +-
 test/accept.c          |  2 +-
 test/io_uring_enter.c  |  6 +++---
 6 files changed, 31 insertions(+), 16 deletions(-)
```

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
