### PR TITLE
[GIT PULL] man: clarify "never uses errno" refers to ring ops

### DIFF
--- a/man/io_uring_prep_accept.3
+++ b/man/io_uring_prep_accept.3
@@ -136,8 +136,8 @@ non-direct accept. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_close.3
+++ b/man/io_uring_prep_close.3
@@ -47,8 +47,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_connect.3
+++ b/man/io_uring_prep_connect.3
@@ -44,8 +44,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_fadvise.3
+++ b/man/io_uring_prep_fadvise.3
@@ -46,8 +46,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_fallocate.3
+++ b/man/io_uring_prep_fallocate.3
@@ -47,8 +47,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_fsync.3
+++ b/man/io_uring_prep_fsync.3
@@ -57,8 +57,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_linkat.3
+++ b/man/io_uring_prep_linkat.3
@@ -68,8 +68,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_madvise.3
+++ b/man/io_uring_prep_madvise.3
@@ -43,8 +43,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_mkdirat.3
+++ b/man/io_uring_prep_mkdirat.3
@@ -60,8 +60,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_openat.3
+++ b/man/io_uring_prep_openat.3
@@ -94,8 +94,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_openat2.3
+++ b/man/io_uring_prep_openat2.3
@@ -94,8 +94,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_poll_add.3
+++ b/man/io_uring_prep_poll_add.3
@@ -59,8 +59,8 @@ man page for details. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_read.3
+++ b/man/io_uring_prep_read.3
@@ -56,8 +56,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_read_fixed.3
+++ b/man/io_uring_prep_read_fixed.3
@@ -61,8 +61,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_readv.3
+++ b/man/io_uring_prep_readv.3
@@ -57,8 +57,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_readv2.3
+++ b/man/io_uring_prep_readv2.3
@@ -83,8 +83,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_recv.3
+++ b/man/io_uring_prep_recv.3
@@ -93,8 +93,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_recvmsg.3
+++ b/man/io_uring_prep_recvmsg.3
@@ -102,8 +102,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_renameat.3
+++ b/man/io_uring_prep_renameat.3
@@ -72,8 +72,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_send.3
+++ b/man/io_uring_prep_send.3
@@ -45,8 +45,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_sendmsg.3
+++ b/man/io_uring_prep_sendmsg.3
@@ -47,8 +47,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_shutdown.3
+++ b/man/io_uring_prep_shutdown.3
@@ -41,8 +41,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_socket.3
+++ b/man/io_uring_prep_socket.3
@@ -85,8 +85,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_splice.3
+++ b/man/io_uring_prep_splice.3
@@ -67,8 +67,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_statx.3
+++ b/man/io_uring_prep_statx.3
@@ -52,8 +52,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_symlinkat.3
+++ b/man/io_uring_prep_symlinkat.3
@@ -62,8 +62,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_sync_file_range.3
+++ b/man/io_uring_prep_sync_file_range.3
@@ -47,8 +47,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_tee.3
+++ b/man/io_uring_prep_tee.3
@@ -60,8 +60,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_unlinkat.3
+++ b/man/io_uring_prep_unlinkat.3
@@ -59,8 +59,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_write.3
+++ b/man/io_uring_prep_write.3
@@ -56,8 +56,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_write_fixed.3
+++ b/man/io_uring_prep_write_fixed.3
@@ -61,8 +61,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_writev.3
+++ b/man/io_uring_prep_writev.3
@@ -57,8 +57,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res

--- a/man/io_uring_prep_writev2.3
+++ b/man/io_uring_prep_writev2.3
@@ -83,8 +83,8 @@ details on possible values. Note that where synchronous system calls will return
 on failure and set
 .I errno
 to the actual error value, io_uring never uses
-.IR errno .
-Instead it returns the negated
+.IR errno
+for operations submitted to the ring. Instead it returns the negated
 .I errno
 directly in the CQE
 .I res


### PR DESCRIPTION
"io_uring never uses `errno`" is too strong; io_uring syscalls set `errno`.
Clarify in the `io_uring_prep_*()` man pages that `errno` is not used
only for the results of ring operations.

----
## git request-pull output:
```
The following changes since commit b1486931117f643b0ad6612beb3f9563b508126c:

  Merge branch 'refactor/cache-ring-size' of https://github.com/calebsander/liburing (2022-08-28 14:06:55 -0600)

are available in the Git repository at:

  git@github.com:calebsander/liburing.git fix/man-errno

for you to fetch changes up to 8769cd893a85bdb518ae99b7b9ddc7d55c10eaf3:

  man: clarify "never uses errno" refers to ring ops (2022-08-28 17:07:47 -0600)

----------------------------------------------------------------
Caleb Sander (1):
      man: clarify "never uses errno" refers to ring ops

 man/io_uring_prep_accept.3          | 4 ++--
 man/io_uring_prep_close.3           | 4 ++--
 man/io_uring_prep_connect.3         | 4 ++--
 man/io_uring_prep_fadvise.3         | 4 ++--
 man/io_uring_prep_fallocate.3       | 4 ++--
 man/io_uring_prep_fsync.3           | 4 ++--
 man/io_uring_prep_linkat.3          | 4 ++--
 man/io_uring_prep_madvise.3         | 4 ++--
 man/io_uring_prep_mkdirat.3         | 4 ++--
 man/io_uring_prep_openat.3          | 4 ++--
 man/io_uring_prep_openat2.3         | 4 ++--
 man/io_uring_prep_poll_add.3        | 4 ++--
 man/io_uring_prep_read.3            | 4 ++--
 man/io_uring_prep_read_fixed.3      | 4 ++--
 man/io_uring_prep_readv.3           | 4 ++--
 man/io_uring_prep_readv2.3          | 4 ++--
 man/io_uring_prep_recv.3            | 4 ++--
 man/io_uring_prep_recvmsg.3         | 4 ++--
 man/io_uring_prep_renameat.3        | 4 ++--
 man/io_uring_prep_send.3            | 4 ++--
 man/io_uring_prep_sendmsg.3         | 4 ++--
 man/io_uring_prep_shutdown.3        | 4 ++--
 man/io_uring_prep_socket.3          | 4 ++--
 man/io_uring_prep_splice.3          | 4 ++--
 man/io_uring_prep_statx.3           | 4 ++--
 man/io_uring_prep_symlinkat.3       | 4 ++--
 man/io_uring_prep_sync_file_range.3 | 4 ++--
 man/io_uring_prep_tee.3             | 4 ++--
 man/io_uring_prep_unlinkat.3        | 4 ++--
 man/io_uring_prep_write.3           | 4 ++--
 man/io_uring_prep_write_fixed.3     | 4 ++--
 man/io_uring_prep_writev.3          | 4 ++--
 man/io_uring_prep_writev2.3         | 4 ++--
 33 files changed, 66 insertions(+), 66 deletions(-)
```
----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
