### PR TITLE
queue: return unsigned from __io_uring_flush_sq()

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -175,7 +175,7 @@ done:
  * Sync internal state with kernel ring state on the SQ side. Returns the
  * number of pending items in the SQ ring, for the shared ring.
  */
-int __io_uring_flush_sq(struct io_uring *ring)
+unsigned __io_uring_flush_sq(struct io_uring *ring)
 {
 	struct io_uring_sq *sq = &ring->sq;
 	const unsigned mask = sq->ring_mask;

--- a/test/io_uring_passthrough.c
+++ b/test/io_uring_passthrough.c
@@ -268,7 +268,7 @@ static int test_io(const char *file, int tc, int read, int sqthread,
 	return ret;
 }
 
-extern int __io_uring_flush_sq(struct io_uring *ring);
+extern unsigned __io_uring_flush_sq(struct io_uring *ring);
 
 /*
  * Send a passthrough command that nvme will fail during submission.

--- a/test/iopoll.c
+++ b/test/iopoll.c
@@ -201,7 +201,7 @@ err:
 	return 1;
 }
 
-extern int __io_uring_flush_sq(struct io_uring *ring);
+extern unsigned __io_uring_flush_sq(struct io_uring *ring);
 
 /*
  * if we are polling io_uring_submit needs to always enter the


### PR DESCRIPTION
This function can't fail and returns a count of SQEs ready to submit.
Most callers implicitly cast the return value to `unsigned` anyways:
- `__io_uring_submit_timeout()` returns it as an `int`, since it can fail
- `io_uring_submit_and_wait_timeout()` stores it in an `unsigned` field
  or passes it as an `unsigned` parameter
- `__io_uring_submit_and_wait()` passes it as an `unsigned` parameter
- The tests pass it as an `unsigned` parameter

----
## git request-pull output:
```
The following changes since commit b1486931117f643b0ad6612beb3f9563b508126c:

  Merge branch 'refactor/cache-ring-size' of https://github.com/calebsander/liburing (2022-08-28 14:06:55 -0600)

are available in the Git repository at:

  git@github.com:calebsander/liburing.git fix/flush-sq-unsigned

for you to fetch changes up to 16eea44736b728d959ad534188a662a3aac2d237:

  queue: return unsigned from __io_uring_flush_sq() (2022-08-28 19:16:57 -0600)

----------------------------------------------------------------
Caleb Sander (1):
      queue: return unsigned from __io_uring_flush_sq()

 src/queue.c                 | 2 +-
 test/io_uring_passthrough.c | 2 +-
 test/iopoll.c               | 2 +-
 3 files changed, 3 insertions(+), 3 deletions(-)
```
----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
