### PR TITLE
[GIT PULL] queue: assume direct SQ-SQE mapping

### DIFF
--- a/src/setup.c
+++ b/src/setup.c
@@ -148,6 +148,8 @@ __cold int io_uring_queue_init_params(unsigned entries, struct io_uring *ring,
 				      struct io_uring_params *p)
 {
 	int fd, ret;
+	unsigned *sq_array;
+	unsigned sq_entries, index;
 
 	fd = __sys_io_uring_setup(entries, p);
 	if (fd < 0)
@@ -158,6 +160,14 @@ __cold int io_uring_queue_init_params(unsigned entries, struct io_uring *ring,
 		__sys_close(fd);
 		return ret;
 	}
+
+	/*
+	 * Directly map SQ slots to SQEs
+	 */
+	sq_array = ring->sq.array;
+	sq_entries = ring->sq.ring_entries;
+	for (index = 0; index < sq_entries; index++)
+		sq_array[index] = index;
 
 	ring->features = p->features;
 	return 0;


### PR DESCRIPTION
`_io_uring_get_sqe()` assumes SQ and SQE indices are interchangeable,
as it checks whether `sqe_tail - sq_head <= ring_entries`.
Under this assumption, we can set the SQ array during initialization
instead of every time SQEs are submitted.
We can also avoid dereferencing `ktail`, since `*ktail == sqe_head`.

----
## git request-pull output:
```
The following changes since commit bf248850dc2ae45d29d4fdde688e90d24f3dd6d2:

  Merge branch 'fix/flush-sq-unsigned' of https://github.com/calebsander/liburing (2022-08-28 19:27:44 -0600)

are available in the Git repository at:

  git@github.com:calebsander/liburing.git refactor/sq-init

for you to fetch changes up to c65a873711d74d521f24a914d23653985bc7fa6d:

  queue: assume direct SQ-SQE mapping (2022-08-29 11:07:00 -0600)

----------------------------------------------------------------
Caleb Sander (1):
      queue: assume direct SQ-SQE mapping

 src/queue.c | 33 ++++++++++-----------------------
 src/setup.c | 10 ++++++++++
 2 files changed, 20 insertions(+), 23 deletions(-)
```
----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
