### PR TITLE
[GIT PULL] queue: enter if CQ needs it, even if SQ doesn't

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -343,12 +343,13 @@ int io_uring_wait_cqe_timeout(struct io_uring *ring,
 static int __io_uring_submit(struct io_uring *ring, unsigned submitted,
 			     unsigned wait_nr)
 {
+	bool cq_needs_enter = wait_nr || cq_ring_needs_enter(ring);
 	unsigned flags;
 	int ret;
 
 	flags = 0;
-	if (sq_ring_needs_enter(ring, submitted, &flags) || wait_nr) {
-		if (wait_nr || (ring->flags & IORING_SETUP_IOPOLL))
+	if (sq_ring_needs_enter(ring, submitted, &flags) || cq_needs_enter) {
+		if (cq_needs_enter)
 			flags |= IORING_ENTER_GETEVENTS;
 		if (ring->int_flags & INT_FLAG_REG_RING)
 			flags |= IORING_ENTER_REGISTERED_RING;


### PR DESCRIPTION
Even when not submitting SQEs, `io_uring_enter()`
may be needed for IOPOLL mode or if the CQ overflowed.
Let `io_uring_submit()` still make the syscall in this case.

Fixes: 504efe18c213 ("queue: avoid io_uring_enter() with no SQEs")

----
## git request-pull output:
```
The following changes since commit 243477691678af27dafe378f1e19be5df61e9daf:

  Revert "src/queue: always enter for IOPOLL" (2022-08-29 15:10:15 -0600)

are available in the Git repository at:

  git@github.com:calebsander/liburing.git fix/iopoll-submit

for you to fetch changes up to e5297de76bdb1d3593ff947b0100eead52c9b148:

  queue: enter if CQ needs it, even if SQ doesn't (2022-08-29 18:21:57 -0600)

----------------------------------------------------------------
Caleb Sander (1):
      queue: enter if CQ needs it, even if SQ doesn't

 src/queue.c | 5 +++--
 1 file changed, 3 insertions(+), 2 deletions(-)
```
----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
