### PR TITLE
[GIT PULL] Fix constant correctness error in `getxattr`/`fgetxattr`

### DIFF
--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -957,7 +957,7 @@ static inline void io_uring_prep_msg_ring(struct io_uring_sqe *sqe, int fd,
 
 static inline void io_uring_prep_getxattr(struct io_uring_sqe *sqe,
 					  const char *name,
-					  const char *value,
+					  char *value,
 					  const char *path,
 					  size_t len)
 {
@@ -983,7 +983,7 @@ static inline void io_uring_prep_setxattr(struct io_uring_sqe *sqe,
 static inline void io_uring_prep_fgetxattr(struct io_uring_sqe *sqe,
 		                           int         fd,
 					   const char *name,
-					   const char *value,
+					   char *value,
 					   size_t      len)
 {
 	io_uring_prep_rw(IORING_OP_FGETXATTR, sqe, fd, name, len,


### PR DESCRIPTION
The system calls `getxattr` and `fgetxattr` return data in the pointer passed as `value`, as is clearly layed out in the [man page](https://man7.org/linux/man-pages/man2/getxattr.2.html) for the actual syscalls.

----
## git request-pull output:
```
The following changes since commit a71d56ef3259216739677473ddb17ad861c3a964:

  queue: Remove unnecessary goto and label (2022-08-30 19:00:13 -0600)

are available in the Git repository at:

  https://github.com/Thalhammer/liburing patch-1

for you to fetch changes up to c9906af5dd00210fc31cf867bb7c4dd0ce08ba9a:

  Fix constant correctness error in `getxattr`/`fgetxattr` (2022-09-01 13:19:45 +0200)

----------------------------------------------------------------
Dominik Thalhammer (1):
      Fix constant correctness error in `getxattr`/`fgetxattr`

 src/include/liburing.h | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```
----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
