### PR TITLE
[GIT PULL] Fix constant correctness error in `io_uring_register_files_update`

### DIFF
--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -170,7 +170,7 @@ int io_uring_register_files_update_tag(struct io_uring *ring, unsigned off,
 
 int io_uring_unregister_files(struct io_uring *ring);
 int io_uring_register_files_update(struct io_uring *ring, unsigned off,
-				   int *files, unsigned nr_files);
+				   const int *files, unsigned nr_files);
 int io_uring_register_eventfd(struct io_uring *ring, int fd);
 int io_uring_register_eventfd_async(struct io_uring *ring, int fd);
 int io_uring_unregister_eventfd(struct io_uring *ring);

--- a/src/register.c
+++ b/src/register.c
@@ -94,7 +94,7 @@ int io_uring_register_files_update_tag(struct io_uring *ring, unsigned off,
  * Returns number of files updated on success, -ERROR on failure.
  */
 int io_uring_register_files_update(struct io_uring *ring, unsigned off,
-				   int *files, unsigned nr_files)
+				   const int *files, unsigned nr_files)
 {
 	struct io_uring_files_update up = {
 		.offset	= off,


### PR DESCRIPTION
`io_uring_register_files_update` took a pointer to a mutable integer array despite neither liburing nor the kernel modifying it.

----
## git request-pull output:
```
The following changes since commit 860db521db4c86a1cb5d0b672a8fba83a89f01f0:

  examples: adjust zc bench to the new uapi (2022-09-02 05:56:53 -0600)

are available in the Git repository at:

  https://github.com/Thalhammer/liburing patch-2

for you to fetch changes up to 2b2a26d8ba1db96fcff4a824400bf214029d36b7:

  Fix constant correctness error in `io_uring_register_files_update` (2022-09-03 13:42:33 +0200)

----------------------------------------------------------------
Dominik Thalhammer (1):
      Fix constant correctness error in `io_uring_register_files_update`

 src/include/liburing.h | 2 +-
 src/register.c         | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```
----

## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
