### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README
+++ b/README
@@ -39,6 +39,19 @@ setups. This affects 5.11 and earlier, new kernels are less dependent
 on RLIMIT_MEMLOCK as it is only used for registering buffers.
 
 
+Building liburing - Using vcpkg
+-------------------------------
+
+You can download and install liburing using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install liburing
+
+The liburing port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 Regressions tests
 -----------------
 


### PR DESCRIPTION
liburing is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for liburing and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build liburing, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/liburing/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)