### PR TITLE
[GIT PULL] Support using a ring exclusively via registered index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /src/include/liburing/compat.h
 /src/include/liburing/io_uring_version.h
 
+/examples/io_uring-close-test
 /examples/io_uring-cp
 /examples/io_uring-test
 /examples/io_uring-udp

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ liburing-2.4 release
 - Add io_uring_prep_msg_ring_cqe_flags() function.
 - Deprecate --nolibc configure option.
 - CONFIG_NOLIBC is always enabled on x86-64, x86, and aarch64.
+- Add support for IORING_REGISTER_USE_REGISTERED_RING and use if available.
 
 liburing-2.3 release
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ liburing-2.4 release
 - Deprecate --nolibc configure option.
 - CONFIG_NOLIBC is always enabled on x86-64, x86, and aarch64.
 - Add support for IORING_REGISTER_USE_REGISTERED_RING and use if available.
+- Add io_uring_close_ring_fd() function.
 
 liburing-2.3 release
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -11,6 +11,7 @@ include ../config-host.mak
 endif
 
 example_srcs := \
+	io_uring-close-test.c \
 	io_uring-cp.c \
 	io_uring-test.c \
 	io_uring-udp.c \

--- a/examples/io_uring-close-test.c
+++ b/examples/io_uring-close-test.c
@@ -1,0 +1,123 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Simple app that demonstrates how to setup an io_uring interface, and use it
+ * via a registered ring fd, without leaving the original fd open.
+ *
+ * gcc -Wall -O2 -D_GNU_SOURCE -o io_uring-close-test io_uring-close-test.c -luring
+ */
+#include <stdio.h>
+#include <fcntl.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include "liburing.h"
+
+#define QD	4
+
+int main(int argc, char *argv[])
+{
+	struct io_uring ring;
+	int i, fd, ret, pending, done;
+	struct io_uring_sqe *sqe;
+	struct io_uring_cqe *cqe;
+	struct iovec *iovecs;
+	struct stat sb;
+	ssize_t fsize;
+	off_t offset;
+	void *buf;
+
+	if (argc < 2) {
+		printf("%s: file\n", argv[0]);
+		return 1;
+	}
+
+	ret = io_uring_queue_init(QD, &ring, 0);
+	if (ret < 0) {
+		fprintf(stderr, "queue_init: %s\n", strerror(-ret));
+		return 1;
+	}
+
+	ret = io_uring_register_ring_fd(&ring);
+	if (ret < 0) {
+		fprintf(stderr, "register_ring_fd: %s\n", strerror(-ret));
+		return 1;
+	}
+	ret = io_uring_close_ring_fd(&ring);
+	if (ret < 0) {
+		fprintf(stderr, "close_ring_fd: %s\n", strerror(-ret));
+		return 1;
+	}
+
+	fd = open(argv[1], O_RDONLY);
+	if (fd < 0) {
+		perror("open");
+		return 1;
+	}
+
+	if (fstat(fd, &sb) < 0) {
+		perror("fstat");
+		return 1;
+	}
+
+	fsize = 0;
+	iovecs = calloc(QD, sizeof(struct iovec));
+	for (i = 0; i < QD; i++) {
+		if (posix_memalign(&buf, 4096, 4096))
+			return 1;
+		iovecs[i].iov_base = buf;
+		iovecs[i].iov_len = 4096;
+		fsize += 4096;
+	}
+
+	offset = 0;
+	i = 0;
+	do {
+		sqe = io_uring_get_sqe(&ring);
+		if (!sqe)
+			break;
+		io_uring_prep_readv(sqe, fd, &iovecs[i], 1, offset);
+		offset += iovecs[i].iov_len;
+		i++;
+		if (offset > sb.st_size)
+			break;
+	} while (1);
+
+	ret = io_uring_submit(&ring);
+	if (ret < 0) {
+		fprintf(stderr, "io_uring_submit: %s\n", strerror(-ret));
+		return 1;
+	} else if (ret != i) {
+		fprintf(stderr, "io_uring_submit submitted less %d\n", ret);
+		return 1;
+	}
+
+	done = 0;
+	pending = ret;
+	fsize = 0;
+	for (i = 0; i < pending; i++) {
+		ret = io_uring_wait_cqe(&ring, &cqe);
+		if (ret < 0) {
+			fprintf(stderr, "io_uring_wait_cqe: %s\n", strerror(-ret));
+			return 1;
+		}
+
+		done++;
+		ret = 0;
+		if (cqe->res != 4096 && cqe->res + fsize != sb.st_size) {
+			fprintf(stderr, "ret=%d, wanted 4096\n", cqe->res);
+			ret = 1;
+		}
+		fsize += cqe->res;
+		io_uring_cqe_seen(&ring, cqe);
+		if (ret)
+			break;
+	}
+
+	printf("Submitted=%d, completed=%d, bytes=%lu\n", pending, done,
+						(unsigned long) fsize);
+	close(fd);
+	io_uring_queue_exit(&ring);
+	return 0;
+}

--- a/man/io_uring_close_ring_fd.3
+++ b/man/io_uring_close_ring_fd.3
@@ -1,0 +1,43 @@
+.\" Copyright (C) 2022 Jens Axboe <axboe@kernel.dk>
+.\" Copyright (C) 2022 Josh Triplett <josh@joshtriplett.org>
+.\"
+.\" SPDX-License-Identifier: LGPL-2.0-or-later
+.\"
+.TH io_uring_close_ring_fd 3 "September 25, 2022" "liburing-2.4" "liburing Manual"
+.SH NAME
+io_uring_close_ring_fd \- close a ring file descriptor and use it only via registered index
+.SH SYNOPSIS
+.nf
+.B #include <liburing.h>
+.PP
+.BI "int io_uring_close_ring_fd(struct io_uring *" ring ");"
+.fi
+.SH DESCRIPTION
+.PP
+.BR io_uring_close_ring_fd (3)
+closes the ring file descriptor, which must have been previously registered.
+The file will remain open, but accessible only via the registered index, not
+via any file descriptor. Subsequent liburing calls will continue to work, using
+the registered ring fd.
+
+The kernel must support
+.BR IORING_FEAT_REG_REG_RING .
+
+Libraries that must avoid disrupting their users' uses of file descriptors, and
+must continue working even in the face of
+.BR close_range (2)
+and similar, can use
+.BR io_uring_close_ring_fd (3)
+to work with liburing without having any open file descriptor.
+
+.SH NOTES
+Each thread that wants to make use of io_uring must register the fd. A library
+that may get called from arbitrary theads may need to detect when it gets
+called on a previously unseen thread and create and register a ring for that
+thread.
+.SH RETURN VALUE
+Returns 1 on success, or
+.BR -errno
+on error.
+.SH SEE ALSO
+.BR io_uring_register_ring_fd (3)

--- a/man/io_uring_register.2
+++ b/man/io_uring_register.2
@@ -31,6 +31,14 @@ application memory, greatly reducing per-I/O overhead.
 .I fd
 is the file descriptor returned by a call to
 .BR io_uring_setup (2).
+If
+.I opcode
+has the flag
+.B IORING_REGISTER_USE_REGISTERED_RING
+ored into it,
+.I fd
+is instead the index of a registered ring fd.
+
 .I opcode
 can be one of:
 

--- a/man/io_uring_setup.2
+++ b/man/io_uring_setup.2
@@ -467,6 +467,13 @@ are used with open or accept, then file assignment needs to happen post
 execution of that SQE. If this flag is set, then the kernel will defer
 file assignment until execution of a given request is started. Available since
 kernel 5.17.
+.TP
+.B IORING_FEAT_REG_REG_RING
+If this flag is set, then io_uring supports calling
+.BR io_uring_register (2)
+using a registered ring fd, via
+.BR IORING_REGISTER_USE_REGISTERED_RING .
+Available since kernel 6.xx.
 
 .PP
 The rest of the fields in the

--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -231,6 +231,7 @@ int io_uring_register_iowq_max_workers(struct io_uring *ring,
 				       unsigned int *values);
 int io_uring_register_ring_fd(struct io_uring *ring);
 int io_uring_unregister_ring_fd(struct io_uring *ring);
+int io_uring_close_ring_fd(struct io_uring *ring);
 int io_uring_register_buf_ring(struct io_uring *ring,
 			       struct io_uring_buf_reg *reg, unsigned int flags);
 int io_uring_unregister_buf_ring(struct io_uring *ring, int bgid);

--- a/src/include/liburing/io_uring.h
+++ b/src/include/liburing/io_uring.h
@@ -472,6 +472,7 @@ struct io_uring_params {
 #define IORING_FEAT_RSRC_TAGS		(1U << 10)
 #define IORING_FEAT_CQE_SKIP		(1U << 11)
 #define IORING_FEAT_LINKED_FILE		(1U << 12)
+#define IORING_FEAT_REG_REG_RING	(1U << 13)
 
 /*
  * io_uring_register(2) opcodes and arguments
@@ -519,7 +520,10 @@ enum {
 	IORING_REGISTER_FILE_ALLOC_RANGE	= 25,
 
 	/* this goes last */
-	IORING_REGISTER_LAST
+	IORING_REGISTER_LAST,
+
+	/* flag added to the opcode to use a registered ring fd */
+	IORING_REGISTER_USE_REGISTERED_RING	= 1U << 31
 };
 
 /* io-wq worker categories */

--- a/src/int_flags.h
+++ b/src/int_flags.h
@@ -4,6 +4,7 @@
 
 enum {
 	INT_FLAG_REG_RING	= 1,
+	INT_FLAG_REG_REG_RING	= 2,
 };
 
 #endif

--- a/src/liburing-ffi.map
+++ b/src/liburing-ffi.map
@@ -46,6 +46,7 @@ LIBURING_2.4 {
 		io_uring_register_buffers_sparse;
 		io_uring_register_buf_ring;
 		io_uring_unregister_buf_ring;
+		io_uring_close_ring_fd;
 
 		io_uring_register_sync_cancel;
 		io_uring_register_file_alloc_range;

--- a/src/liburing.map
+++ b/src/liburing.map
@@ -74,6 +74,7 @@ LIBURING_2.4 {
 		io_uring_minor_version;
 		io_uring_check_version;
 
+		io_uring_close_ring_fd;
 		io_uring_enable_rings;
 		io_uring_register_restrictions;
 } LIBURING_2.3;

--- a/src/register.c
+++ b/src/register.c
@@ -11,6 +11,11 @@
 static inline int do_register(struct io_uring *ring, unsigned int opcode,
 			      const void *arg, unsigned int nr_args)
 {
+	if (ring->features & IORING_FEAT_REG_REG_RING
+	    && ring->int_flags & INT_FLAG_REG_RING) {
+		opcode |= IORING_REGISTER_USE_REGISTERED_RING;
+		return __sys_io_uring_register(ring->enter_ring_fd, opcode, arg, nr_args);
+	}
 	return __sys_io_uring_register(ring->ring_fd, opcode, arg, nr_args);
 }
 

--- a/src/register.c
+++ b/src/register.c
@@ -291,6 +291,20 @@ int io_uring_unregister_ring_fd(struct io_uring *ring)
 	return ret;
 }
 
+int io_uring_close_ring_fd(struct io_uring *ring)
+{
+	if (!(ring->features & IORING_FEAT_REG_REG_RING))
+		return -EOPNOTSUPP;
+	if (!(ring->int_flags & INT_FLAG_REG_RING))
+		return -EINVAL;
+	if (ring->ring_fd == -1)
+		return -EBADF;
+
+	__sys_close(ring->ring_fd);
+	ring->ring_fd = -1;
+	return 1;
+}
+
 int io_uring_register_buf_ring(struct io_uring *ring,
 			       struct io_uring_buf_reg *reg,
 			       unsigned int __maybe_unused flags)

--- a/src/register.c
+++ b/src/register.c
@@ -8,6 +8,12 @@
 #include "liburing/compat.h"
 #include "liburing/io_uring.h"
 
+static inline int do_register(struct io_uring *ring, unsigned int opcode,
+			      const void *arg, unsigned int nr_args)
+{
+	return __sys_io_uring_register(ring->ring_fd, opcode, arg, nr_args);
+}
+
 int io_uring_register_buffers_update_tag(struct io_uring *ring, unsigned off,
 					 const struct iovec *iovecs,
 					 const __u64 *tags,
@@ -20,8 +26,7 @@ int io_uring_register_buffers_update_tag(struct io_uring *ring, unsigned off,
 		.nr = nr,
 	};
 
-	return __sys_io_uring_register(ring->ring_fd,IORING_REGISTER_BUFFERS_UPDATE, &up,
-					 sizeof(up));
+	return do_register(ring, IORING_REGISTER_BUFFERS_UPDATE, &up, sizeof(up));
 }
 
 int io_uring_register_buffers_tags(struct io_uring *ring,
@@ -35,9 +40,7 @@ int io_uring_register_buffers_tags(struct io_uring *ring,
 		.tags = (unsigned long)tags,
 	};
 
-	return __sys_io_uring_register(ring->ring_fd,
-				       IORING_REGISTER_BUFFERS2, &reg,
-				       sizeof(reg));
+	return do_register(ring, IORING_REGISTER_BUFFERS2, &reg, sizeof(reg));
 }
 
 int io_uring_register_buffers_sparse(struct io_uring *ring, unsigned nr)
@@ -47,21 +50,18 @@ int io_uring_register_buffers_sparse(struct io_uring *ring, unsigned nr)
 		.nr = nr,
 	};
 
-	return __sys_io_uring_register(ring->ring_fd, IORING_REGISTER_BUFFERS2,
-				       &reg, sizeof(reg));
+	return do_register(ring, IORING_REGISTER_BUFFERS2, &reg, sizeof(reg));
 }
 
 int io_uring_register_buffers(struct io_uring *ring, const struct iovec *iovecs,
 			      unsigned nr_iovecs)
 {
-	return __sys_io_uring_register(ring->ring_fd, IORING_REGISTER_BUFFERS,
-				       iovecs, nr_iovecs);
+	return do_register(ring, IORING_REGISTER_BUFFERS, iovecs, nr_iovecs);
 }
 
 int io_uring_unregister_buffers(struct io_uring *ring)
 {
-	return __sys_io_uring_register(ring->ring_fd, IORING_UNREGISTER_BUFFERS,
-				       NULL, 0);
+	return do_register(ring, IORING_UNREGISTER_BUFFERS, NULL, 0);
 }
 
 int io_uring_register_files_update_tag(struct io_uring *ring, unsigned off,
@@ -75,9 +75,7 @@ int io_uring_register_files_update_tag(struct io_uring *ring, unsigned off,
 		.nr = nr_files,
 	};
 
-	return __sys_io_uring_register(ring->ring_fd,
-				       IORING_REGISTER_FILES_UPDATE2, &up,
-				       sizeof(up));
+	return do_register(ring, IORING_REGISTER_FILES_UPDATE2, &up, sizeof(up));
 }
 
 /*
@@ -95,9 +93,7 @@ int io_uring_register_files_update(struct io_uring *ring, unsigned off,
 		.fds	= (unsigned long) files,
 	};
 
-	return __sys_io_uring_register(ring->ring_fd,
-				       IORING_REGISTER_FILES_UPDATE, &up,
-				       nr_files);
+	return do_register(ring, IORING_REGISTER_FILES_UPDATE, &up, nr_files);
 }
 
 static int increase_rlimit_nofile(unsigned nr)
@@ -126,9 +122,7 @@ int io_uring_register_files_sparse(struct io_uring *ring, unsigned nr)
 	int ret, did_increase = 0;
 
 	do {
-		ret = __sys_io_uring_register(ring->ring_fd,
-					      IORING_REGISTER_FILES2, &reg,
-					      sizeof(reg));
+		ret = do_register(ring, IORING_REGISTER_FILES2, &reg, sizeof(reg));
 		if (ret >= 0)
 			break;
 		if (ret == -EMFILE && !did_increase) {
@@ -153,9 +147,7 @@ int io_uring_register_files_tags(struct io_uring *ring, const int *files,
 	int ret, did_increase = 0;
 
 	do {
-		ret = __sys_io_uring_register(ring->ring_fd,
-					      IORING_REGISTER_FILES2, &reg,
-					      sizeof(reg));
+		ret = do_register(ring, IORING_REGISTER_FILES2, &reg, sizeof(reg));
 		if (ret >= 0)
 			break;
 		if (ret == -EMFILE && !did_increase) {
@@ -175,9 +167,7 @@ int io_uring_register_files(struct io_uring *ring, const int *files,
 	int ret, did_increase = 0;
 
 	do {
-		ret = __sys_io_uring_register(ring->ring_fd,
-					      IORING_REGISTER_FILES, files,
-					      nr_files);
+		ret = do_register(ring, IORING_REGISTER_FILES, files, nr_files);
 		if (ret >= 0)
 			break;
 		if (ret == -EMFILE && !did_increase) {
@@ -193,61 +183,50 @@ int io_uring_register_files(struct io_uring *ring, const int *files,
 
 int io_uring_unregister_files(struct io_uring *ring)
 {
-	return __sys_io_uring_register(ring->ring_fd, IORING_UNREGISTER_FILES,
-				       NULL, 0);
+	return do_register(ring, IORING_UNREGISTER_FILES, NULL, 0);
 }
 
 int io_uring_register_eventfd(struct io_uring *ring, int event_fd)
 {
-	return __sys_io_uring_register(ring->ring_fd, IORING_REGISTER_EVENTFD,
-				       &event_fd, 1);
+	return do_register(ring, IORING_REGISTER_EVENTFD, &event_fd, 1);
 }
 
 int io_uring_unregister_eventfd(struct io_uring *ring)
 {
-	return __sys_io_uring_register(ring->ring_fd, IORING_UNREGISTER_EVENTFD,
-				       NULL, 0);
+	return do_register(ring, IORING_UNREGISTER_EVENTFD, NULL, 0);
 }
 
 int io_uring_register_eventfd_async(struct io_uring *ring, int event_fd)
 {
-	return __sys_io_uring_register(ring->ring_fd,
-				       IORING_REGISTER_EVENTFD_ASYNC, &event_fd,
-				       1);
+	return do_register(ring, IORING_REGISTER_EVENTFD_ASYNC, &event_fd, 1);
 }
 
 int io_uring_register_probe(struct io_uring *ring, struct io_uring_probe *p,
 			    unsigned int nr_ops)
 {
-	return __sys_io_uring_register(ring->ring_fd, IORING_REGISTER_PROBE, p,
-				       nr_ops);
+	return do_register(ring, IORING_REGISTER_PROBE, p, nr_ops);
 }
 
 int io_uring_register_personality(struct io_uring *ring)
 {
-	return __sys_io_uring_register(ring->ring_fd,
-				       IORING_REGISTER_PERSONALITY, NULL, 0);
+	return do_register(ring, IORING_REGISTER_PERSONALITY, NULL, 0);
 }
 
 int io_uring_unregister_personality(struct io_uring *ring, int id)
 {
-	return __sys_io_uring_register(ring->ring_fd,
-				       IORING_UNREGISTER_PERSONALITY, NULL, id);
+	return do_register(ring, IORING_UNREGISTER_PERSONALITY, NULL, id);
 }
 
 int io_uring_register_restrictions(struct io_uring *ring,
 				   struct io_uring_restriction *res,
 				   unsigned int nr_res)
 {
-	return __sys_io_uring_register(ring->ring_fd,
-				       IORING_REGISTER_RESTRICTIONS, res,
-				       nr_res);
+	return do_register(ring, IORING_REGISTER_RESTRICTIONS, res, nr_res);
 }
 
 int io_uring_enable_rings(struct io_uring *ring)
 {
-	return __sys_io_uring_register(ring->ring_fd,
-				       IORING_REGISTER_ENABLE_RINGS, NULL, 0);
+	return do_register(ring, IORING_REGISTER_ENABLE_RINGS, NULL, 0);
 }
 
 int io_uring_register_iowq_aff(struct io_uring *ring, size_t cpusz,
@@ -256,21 +235,17 @@ int io_uring_register_iowq_aff(struct io_uring *ring, size_t cpusz,
 	if (cpusz >= (1U << 31))
 		return -EINVAL;
 
-	return __sys_io_uring_register(ring->ring_fd, IORING_REGISTER_IOWQ_AFF,
-					mask, (int) cpusz);
+	return do_register(ring, IORING_REGISTER_IOWQ_AFF, mask, (int) cpusz);
 }
 
 int io_uring_unregister_iowq_aff(struct io_uring *ring)
 {
-	return __sys_io_uring_register(ring->ring_fd,
-				       IORING_UNREGISTER_IOWQ_AFF, NULL, 0);
+	return do_register(ring, IORING_UNREGISTER_IOWQ_AFF, NULL, 0);
 }
 
 int io_uring_register_iowq_max_workers(struct io_uring *ring, unsigned int *val)
 {
-	return __sys_io_uring_register(ring->ring_fd,
-				       IORING_REGISTER_IOWQ_MAX_WORKERS, val,
-				       2);
+	return do_register(ring, IORING_REGISTER_IOWQ_MAX_WORKERS, val, 2);
 }
 
 int io_uring_register_ring_fd(struct io_uring *ring)
@@ -281,8 +256,7 @@ int io_uring_register_ring_fd(struct io_uring *ring)
 	};
 	int ret;
 
-	ret = __sys_io_uring_register(ring->ring_fd, IORING_REGISTER_RING_FDS,
-				      &up, 1);
+	ret = do_register(ring, IORING_REGISTER_RING_FDS, &up, 1);
 	if (ret == 1) {
 		ring->enter_ring_fd = up.offset;
 		ring->int_flags |= INT_FLAG_REG_RING;
@@ -298,8 +272,7 @@ int io_uring_unregister_ring_fd(struct io_uring *ring)
 	};
 	int ret;
 
-	ret = __sys_io_uring_register(ring->ring_fd, IORING_UNREGISTER_RING_FDS,
-				      &up, 1);
+	ret = do_register(ring, IORING_UNREGISTER_RING_FDS, &up, 1);
 	if (ret == 1) {
 		ring->enter_ring_fd = ring->ring_fd;
 		ring->int_flags &= ~INT_FLAG_REG_RING;
@@ -311,23 +284,20 @@ int io_uring_register_buf_ring(struct io_uring *ring,
 			       struct io_uring_buf_reg *reg,
 			       unsigned int __maybe_unused flags)
 {
-	return __sys_io_uring_register(ring->ring_fd, IORING_REGISTER_PBUF_RING,
-				       reg, 1);
+	return do_register(ring, IORING_REGISTER_PBUF_RING, reg, 1);
 }
 
 int io_uring_unregister_buf_ring(struct io_uring *ring, int bgid)
 {
 	struct io_uring_buf_reg reg = { .bgid = bgid };
 
-	return __sys_io_uring_register(ring->ring_fd,
-				       IORING_UNREGISTER_PBUF_RING, &reg, 1);
+	return do_register(ring, IORING_UNREGISTER_PBUF_RING, &reg, 1);
 }
 
 int io_uring_register_sync_cancel(struct io_uring *ring,
 				  struct io_uring_sync_cancel_reg *reg)
 {
-	return __sys_io_uring_register(ring->ring_fd,
-				       IORING_REGISTER_SYNC_CANCEL, reg, 1);
+	return do_register(ring, IORING_REGISTER_SYNC_CANCEL, reg, 1);
 }
 
 int io_uring_register_file_alloc_range(struct io_uring *ring,
@@ -338,7 +308,5 @@ int io_uring_register_file_alloc_range(struct io_uring *ring,
 		.len = len
 	};
 
-	return __sys_io_uring_register(ring->ring_fd,
-				       IORING_REGISTER_FILE_ALLOC_RANGE, &range,
-				       0);
+	return do_register(ring, IORING_REGISTER_FILE_ALLOC_RANGE, &range, 0);
 }

--- a/src/register.c
+++ b/src/register.c
@@ -11,8 +11,7 @@
 static inline int do_register(struct io_uring *ring, unsigned int opcode,
 			      const void *arg, unsigned int nr_args)
 {
-	if (ring->features & IORING_FEAT_REG_REG_RING
-	    && ring->int_flags & INT_FLAG_REG_RING) {
+	if (ring->int_flags & INT_FLAG_REG_REG_RING) {
 		opcode |= IORING_REGISTER_USE_REGISTERED_RING;
 		return __sys_io_uring_register(ring->enter_ring_fd, opcode, arg, nr_args);
 	}
@@ -268,6 +267,9 @@ int io_uring_register_ring_fd(struct io_uring *ring)
 	if (ret == 1) {
 		ring->enter_ring_fd = up.offset;
 		ring->int_flags |= INT_FLAG_REG_RING;
+		if (ring->features & IORING_FEAT_REG_REG_RING) {
+			ring->int_flags |= INT_FLAG_REG_REG_RING;
+		}
 	}
 	return ret;
 }
@@ -286,7 +288,7 @@ int io_uring_unregister_ring_fd(struct io_uring *ring)
 	ret = do_register(ring, IORING_UNREGISTER_RING_FDS, &up, 1);
 	if (ret == 1) {
 		ring->enter_ring_fd = ring->ring_fd;
-		ring->int_flags &= ~INT_FLAG_REG_RING;
+		ring->int_flags &= ~(INT_FLAG_REG_RING | INT_FLAG_REG_REG_RING);
 	}
 	return ret;
 }

--- a/src/register.c
+++ b/src/register.c
@@ -256,6 +256,9 @@ int io_uring_register_ring_fd(struct io_uring *ring)
 	};
 	int ret;
 
+	if (ring->int_flags & INT_FLAG_REG_RING)
+		return -EEXIST;
+
 	ret = do_register(ring, IORING_REGISTER_RING_FDS, &up, 1);
 	if (ret == 1) {
 		ring->enter_ring_fd = up.offset;
@@ -271,6 +274,9 @@ int io_uring_unregister_ring_fd(struct io_uring *ring)
 		.offset = ring->enter_ring_fd,
 	};
 	int ret;
+
+	if (!(ring->int_flags & INT_FLAG_REG_RING))
+		return -EINVAL;
 
 	ret = do_register(ring, IORING_UNREGISTER_RING_FDS, &up, 1);
 	if (ret == 1) {

--- a/src/setup.c
+++ b/src/setup.c
@@ -205,7 +205,8 @@ __cold void io_uring_queue_exit(struct io_uring *ring)
 	 */
 	if (ring->int_flags & INT_FLAG_REG_RING)
 		io_uring_unregister_ring_fd(ring);
-	__sys_close(ring->ring_fd);
+	if (ring->ring_fd != -1)
+		__sys_close(ring->ring_fd);
 }
 
 __cold struct io_uring_probe *io_uring_get_probe_ring(struct io_uring *ring)

--- a/test/Makefile
+++ b/test/Makefile
@@ -141,6 +141,7 @@ test_srcs := \
 	recv-msgall.c \
 	recv-msgall-stream.c \
 	recv-multishot.c \
+	reg-reg-ring.c \
 	register-restrictions.c \
 	rename.c \
 	ringbuf-read.c \

--- a/test/reg-reg-ring.c
+++ b/test/reg-reg-ring.c
@@ -1,0 +1,90 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Test io_uring_register with a registered ring (IORING_REGISTER_USE_REGISTERED_RING)
+ *
+ */
+#include <stdio.h>
+
+#include "helpers.h"
+
+int main(int argc, char *argv[])
+{
+	struct io_uring ring;
+	unsigned values[2];
+	int ret;
+
+	if (argc > 1)
+		return T_EXIT_SKIP;
+
+	ret = io_uring_queue_init(8, &ring, 0);
+	if (ret) {
+		fprintf(stderr, "ring setup failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	if (!(ring.features & IORING_FEAT_REG_REG_RING)) {
+		fprintf(stderr, "IORING_FEAT_REG_REG_RING not available in kernel\n");
+		io_uring_queue_exit(&ring);
+		return T_EXIT_SKIP;
+	}
+
+	ret = io_uring_close_ring_fd(&ring);
+	if (ret != -EINVAL) {
+		fprintf(stderr, "closing ring fd should EINVAL before register\n");
+		goto err;
+	}
+
+	ret = io_uring_unregister_ring_fd(&ring);
+	if (ret != -EINVAL) {
+		fprintf(stderr, "unregistering not-registered ring fd should fail\n");
+		goto err;
+	}
+
+	ret = io_uring_register_ring_fd(&ring);
+	if (ret != 1) {
+		fprintf(stderr, "registering ring fd failed\n");
+		goto err;
+	}
+
+	ret = io_uring_register_ring_fd(&ring);
+	if (ret != -EEXIST) {
+		fprintf(stderr, "registering already-registered ring fd should fail\n");
+		goto err;
+	}
+
+	/* Test a simple io_uring_register operation expected to work.
+	 * io_uring_register_iowq_max_workers is arbitrary.
+	 */
+	values[0] = values[1] = 0;
+	ret = io_uring_register_iowq_max_workers(&ring, values);
+	if (ret || (values[0] == 0 && values[1] == 0)) {
+		fprintf(stderr, "io_uring_register operation failed before closing ring fd\n");
+		goto err;
+	}
+
+	ret = io_uring_close_ring_fd(&ring);
+	if (ret != 1) {
+		fprintf(stderr, "closing ring fd failed\n");
+		goto err;
+	}
+
+	values[0] = values[1] = 0;
+	ret = io_uring_register_iowq_max_workers(&ring, values);
+	if (ret || (values[0] == 0 && values[1] == 0)) {
+		fprintf(stderr, "io_uring_register operation failed after closing ring fd\n");
+		goto err;
+	}
+
+	ret = io_uring_close_ring_fd(&ring);
+	if (ret != -EBADF) {
+		fprintf(stderr, "closing already-closed ring fd should fail\n");
+		goto err;
+	}
+
+	io_uring_queue_exit(&ring);
+	return T_EXIT_PASS;
+
+err:
+	io_uring_queue_exit(&ring);
+	return T_EXIT_FAIL;
+}


### PR DESCRIPTION
This provides the userspace corresponding to the kernel patch at
https://lore.kernel.org/io-uring/3cbedc531b633af4fe8632f7276aa843b5a54875.1664123680.git.josh@joshtriplett.org/T/
.

With this change, a caller of liburing can handle a ring internally without
leaving a file descriptor open that might disrupt its caller, which makes it
safer to retrofit existing libraries with strict compatibility requirements to
use `io_uring`.

Libraries with even more stringent requirements (e.g. never even transiently
having a file descriptor open) will need two additional pieces:
- Adding a flag to `io_uring_setup` to set up the ring directly as a registered
  file descriptor, without ever putting it in the file descriptor table.
- Supporting the initial `mmap` via a registered file descriptor, such as via
  an `io_uring_register` call.

----
## git request-pull output:
```
The following changes since commit 65791341a5d7e79aa601c96be9df0e7ed4603e05:

  Merge branch 'test_print_counts' of https://github.com/ddiss/liburing (2022-09-23 18:58:59 -0600)

are available in the Git repository at:

  https://github.com/joshtriplett/liburing registered-ring-close

for you to fetch changes up to 5ba0c3c73f979d73e385e1d5a8acdac4c57a9ea8:

  Add example of closing a ring fd and using it via registered index (2022-09-25 21:54:47 +0100)

----------------------------------------------------------------
Josh Triplett (5):
      src/register.c: Call __sys_io_uring_register via a helper taking the ring
      Error on duplicate ring fd registration
      Support using IORING_REGISTER_USE_REGISTERED_RING
      Support closing the ring fd and using it exclusively via registered index
      Add example of closing a ring fd and using it via registered index

 examples/Makefile               |   1 +
 examples/io_uring-close-test.c  | 123 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 man/io_uring_close_ring_fd.3    |  43 +++++++++++++++++++++++++++++++++++++++++++
 man/io_uring_register.2         |   8 ++++++++
 man/io_uring_setup.2            |   7 +++++++
 src/include/liburing.h          |   1 +
 src/include/liburing/io_uring.h |   6 +++++-
 src/liburing.map                |   1 +
 src/register.c                  | 125 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++------------------------------------------------------------------
 src/setup.c                     |   3 ++-
 10 files changed, 250 insertions(+), 68 deletions(-)
 create mode 100644 examples/io_uring-close-test.c
 create mode 100644 man/io_uring_close_ring_fd.3
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
