### PR TITLE
[GIT PULL] test/sigfd-deadlock: improve error handling

### DIFF
--- a/test/sigfd-deadlock.c
+++ b/test/sigfd-deadlock.c
@@ -50,7 +50,10 @@ static int test_uring(int sfd)
 	kill(getpid(), SIGINT);
 
 	io_uring_wait_cqe(&ring, &cqe);
-	if (cqe->res < 0) {
+	if (cqe->res == -EOPNOTSUPP) {
+		fprintf(stderr, "signalfd poll not supported\n");
+		ret = T_EXIT_SKIP;
+	} else if (cqe->res < 0) {
 		fprintf(stderr, "poll failed: %d\n", cqe->res);
 		ret = T_EXIT_FAIL;
 	} else if (cqe->res & POLLIN) {
@@ -77,7 +80,7 @@ int main(int argc, char *argv[])
 		return T_EXIT_FAIL;
 
 	ret = test_uring(sfd);
-	if (ret)
+	if (ret == T_EXIT_FAIL)
 		fprintf(stderr, "test_uring signalfd failed\n");
 
 	close(sfd);

--- a/test/sigfd-deadlock.c
+++ b/test/sigfd-deadlock.c
@@ -11,6 +11,7 @@
 #include <poll.h>
 #include <stdio.h>
 #include "liburing.h"
+#include "helpers.h"
 
 static int setup_signal(void)
 {
@@ -34,22 +35,32 @@ static int test_uring(int sfd)
 	struct io_uring ring;
 	int ret;
 
-	io_uring_queue_init(32, &ring, 0);
+	ret = io_uring_queue_init(32, &ring, 0);
+	if (ret)
+		return T_EXIT_FAIL;
 
 	sqe = io_uring_get_sqe(&ring);
 	io_uring_prep_poll_add(sqe, sfd, POLLIN);
-	io_uring_submit(&ring);
+	ret = io_uring_submit(&ring);
+	if (ret < 0) {
+		ret = T_EXIT_FAIL;
+		goto err_exit;
+	}
 
 	kill(getpid(), SIGINT);
 
 	io_uring_wait_cqe(&ring, &cqe);
-	if (cqe->res & POLLIN) {
-		ret = 0;
+	if (cqe->res < 0) {
+		fprintf(stderr, "poll failed: %d\n", cqe->res);
+		ret = T_EXIT_FAIL;
+	} else if (cqe->res & POLLIN) {
+		ret = T_EXIT_PASS;
 	} else {
 		fprintf(stderr, "Unexpected poll mask %x\n", cqe->res);
-		ret = 1;
+		ret = T_EXIT_FAIL;
 	}
 	io_uring_cqe_seen(&ring, cqe);
+err_exit:
 	io_uring_queue_exit(&ring);
 	return ret;
 }
@@ -59,11 +70,11 @@ int main(int argc, char *argv[])
 	int sfd, ret;
 
 	if (argc > 1)
-		return 0;
+		return T_EXIT_PASS;
 
 	sfd = setup_signal();
 	if (sfd < 0)
-		return 1;
+		return T_EXIT_FAIL;
 
 	ret = test_uring(sfd);
 	if (ret)


### PR DESCRIPTION
A couple of minor changes for `test/sigfd-deadlock`:
- check for `-errno` before flagging success on `(cqe->res & POLLIN)`
- skip on `-EOPNOTSUPP` poll error; it may be returned by Stable kernels carrying
  `fc78b2fc21f1 ("io_uring: disable polling pollfree files")`
- use `enum t_test_result` values

----
## git request-pull output:
```
The following changes since commit 1cba5d6c9e41e2f55ac4c3f93f5e05f9b5082a3e:

  tests: test async_data double-free with sendzc (2022-09-26 08:33:49 -0600)

are available in the Git repository at:

  https://github.com/ddiss/liburing test-sigfd-deadlock

for you to fetch changes up to 29ad0c893d5b1f79cff2e0ebe18fd887eface63c:

  test/sigfd-deadlock: skip test if poll returns -EOPNOTSUPP (2022-09-27 20:02:27 +0200)

----------------------------------------------------------------
David Disseldorp (2):
      test/sigfd-deadlock: improve error handling
      test/sigfd-deadlock: skip test if poll returns -EOPNOTSUPP

 test/sigfd-deadlock.c | 30 ++++++++++++++++++++++--------
 1 file changed, 22 insertions(+), 8 deletions(-)
```