### PR TITLE
[GIT PULL] man: fix SYNOPSIS of `io_uring_register_sync_cancel`

### DIFF
--- a/man/io_uring_register_sync_cancel.3
+++ b/man/io_uring_register_sync_cancel.3
@@ -9,7 +9,7 @@ io_uring_register_sync_cancel \- issue a synchronous cancelation request
 .nf
 .B #include <liburing.h>
 .PP
-.BI "int io_uring_register_buffers(struct io_uring *" ring ",
+.BI "int io_uring_register_sync_cancel(struct io_uring *" ring ",
 .BI "                              struct io_uring_sync_cancel_reg *" reg ");
 .PP
 .SH DESCRIPTION


### PR DESCRIPTION
The SYNOPSIS of `io_uring_register_sync_cancel` was originally `int io_uring_register_buffers(...)` but now it has been corrected.

----
## git request-pull output:
```
The following changes since commit 82a4dfc212478935f81f0f385da01458e8d5d7ec:

  liburing: add more zc helpers (2022-09-28 07:53:52 -0600)

are available in the Git repository at:

  https://github.com/Codesire-Deng/liburing master

for you to fetch changes up to b6b17b5436de673731e2dcfa036290536d543125:

  man: fix SYNOPSIS of `io_uring_register_sync_cancel` (2022-09-29 18:22:54 +0800)

----------------------------------------------------------------
Zifeng Deng (1):
      man: fix SYNOPSIS of `io_uring_register_sync_cancel`

 man/io_uring_register_sync_cancel.3 | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```
----

## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
