### PR TITLE
[GIT PULL] man: clarify non-seekable file read/write API

### DIFF
--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -253,7 +253,7 @@ and
 .BR pwritev2 (2).
 If the file is not seekable,
 .I off
-must be set to zero.
+must be set to zero or -1.
 
 .TP
 .B IORING_OP_READ_FIXED
@@ -789,7 +789,7 @@ contains the read or write offset. If
 .I fd
 does not refer to a seekable file,
 .I off
-must be set to zero. If
+must be set to zero or -1. If
 .I offs
 is set to
 .B -1

--- a/man/io_uring_prep_read.3
+++ b/man/io_uring_prep_read.3
@@ -40,7 +40,7 @@ current file offset may result in unpredictable behavior, unless access
 to the file is serialized. It is not encouraged to use this feature, if it's
 possible to provide the desired IO offset from the application or library.
 
-On files that are not capable of seeking, the offset is ignored.
+On files that are not capable of seeking, the offset must be 0 or -1.
 
 After the read has been prepared it can be submitted with one of the submit
 functions.

--- a/man/io_uring_prep_readv.3
+++ b/man/io_uring_prep_readv.3
@@ -41,7 +41,7 @@ current file offset may result in unpredictable behavior, unless access
 to the file is serialized. It is not encouraged to use this feature, if it's
 possible to provide the desired IO offset from the application or library.
 
-On files that are not capable of seeking, the offset is ignored.
+On files that are not capable of seeking, the offset must be 0 or -1.
 
 After the write has been prepared it can be submitted with one of the submit
 functions.

--- a/man/io_uring_prep_readv2.3
+++ b/man/io_uring_prep_readv2.3
@@ -67,7 +67,7 @@ current file offset may result in unpredictable behavior, unless access
 to the file is serialized. It is not encouraged to use this feature, if it's
 possible to provide the desired IO offset from the application or library.
 
-On files that are not capable of seeking, the offset is ignored.
+On files that are not capable of seeking, the offset must be 0 or -1.
 
 After the write has been prepared, it can be submitted with one of the submit
 functions.

--- a/man/io_uring_prep_write.3
+++ b/man/io_uring_prep_write.3
@@ -40,7 +40,7 @@ current file offset may result in unpredictable behavior, unless access
 to the file is serialized. It is not encouraged to use this feature if it's
 possible to provide the desired IO offset from the application or library.
 
-On files that are not capable of seeking, the offset is ignored.
+On files that are not capable of seeking, the offset must be 0 or -1.
 
 After the write has been prepared, it can be submitted with one of the submit
 functions.

--- a/man/io_uring_prep_writev.3
+++ b/man/io_uring_prep_writev.3
@@ -41,7 +41,7 @@ current file offset may result in unpredictable behavior, unless access
 to the file is serialized. It is not encouraged to use this feature if it's
 possible to provide the desired IO offset from the application or library.
 
-On files that are not capable of seeking, the offset is ignored.
+On files that are not capable of seeking, the offset must be 0 or -1.
 
 After the write has been prepared it can be submitted with one of the submit
 functions.

--- a/man/io_uring_prep_writev2.3
+++ b/man/io_uring_prep_writev2.3
@@ -67,7 +67,7 @@ current file offset may result in unpredictable behavior, unless access
 to the file is serialized. It is not encouraged to use this feature if it's
 possible to provide the desired IO offset from the application or library.
 
-On files that are not capable of seeking, the offset is ignored.
+On files that are not capable of seeking, the offset must be 0 or -1.
 
 After the write has been prepared, it can be submitted with one of the submit
 functions.


### PR DESCRIPTION
I'd like to use io_uring with a mix of seekable and non-seekable files and it isn't clear from the docs how to do that safely. This is a proposal to tweak the API contract a bit towards that end. Thanks.

----
## git request-pull output:
```
The following changes since commit af3da48f6387fcd530177a3ecfc04c4d5e5698d8:

  man/io_uring_register_sync_cancel.3: line up 2nd line properly (2022-09-29 07:17:35 -0600)

are available in the Git repository at:

  https://github.com/fkm3/liburing.git clarify_seekable

for you to fetch changes up to 3efaca5ea0b27b07de01ae84365ed96df3b4c2f9:

  man: clarify non-seekable file read/write API (2022-09-30 01:14:40 +0000)

----------------------------------------------------------------
Frederick Mayle (1):
      man: clarify non-seekable file read/write API

 man/io_uring_enter.2        | 4 ++--
 man/io_uring_prep_read.3    | 2 +-
 man/io_uring_prep_readv.3   | 2 +-
 man/io_uring_prep_readv2.3  | 2 +-
 man/io_uring_prep_write.3   | 2 +-
 man/io_uring_prep_writev.3  | 2 +-
 man/io_uring_prep_writev2.3 | 2 +-
 7 files changed, 8 insertions(+), 8 deletions(-)
```