### PR TITLE
[GIT PULL] man page and build warning fixes

### DIFF
--- a/man/io_uring_buf_ring_advance.3
+++ b/man/io_uring_buf_ring_advance.3
@@ -9,8 +9,8 @@ io_uring_buf_ring_advance \- advance index of provided buffer in buffer ring
 .nf
 .B #include <liburing.h>
 .PP
-.BI "int io_uring_buf_ring_advance(struct io_uring_buf_ring *" br ",
-.BI "                              int " count ");"
+.BI "void io_uring_buf_ring_advance(struct io_uring_buf_ring *" br ",
+.BI "                               int " count ");"
 .fi
 .SH DESCRIPTION
 .PP

--- a/man/io_uring_buf_ring_cq_advance.3
+++ b/man/io_uring_buf_ring_cq_advance.3
@@ -9,9 +9,9 @@ io_uring_buf_ring_cq_advance \- advance index of provided buffer and CQ ring
 .nf
 .B #include <liburing.h>
 .PP
-.BI "int io_uring_buf_ring_cq_advance(struct io_uring *" ring ",
-.BI "                                 struct io_uring_buf_ring *" br ",
-.BI "                                 int " count ");"
+.BI "void io_uring_buf_ring_cq_advance(struct io_uring *" ring ",
+.BI "                                  struct io_uring_buf_ring *" br ",
+.BI "                                  int " count ");"
 .fi
 .SH DESCRIPTION
 .PP

--- a/test/helpers.h
+++ b/test/helpers.h
@@ -10,6 +10,7 @@ extern "C" {
 #endif
 
 #include "liburing.h"
+#include <arpa/inet.h>
 
 enum t_setup_ret {
 	T_SETUP_OK	= 0,


### PR DESCRIPTION
Hi Jens,

- Fix the wrong return type in io_uring_buf_ring_advance
  and io_uring_buf_ring_cq_advance man page (Alviro)

- Clean up a build warning when compiling with clang v13.0.1 (me)

Please pull!

```
The following changes since commit 409ad09c69a003a4cc69f690155023ecec9999b7:

  Merge branch 'master' of https://github.com/ilikdoge/liburing (2022-10-17 15:57:12 -0700)

are available in the Git repository at:

  https://github.com/ammarfaizi2/liburing tags/liburing-fixes-2022-10-19

for you to fetch changes up to 877d41862ac111fdd85344804c4d656ac7267c93:

  test/helpers: Fix clang warning (2022-10-19 04:46:03 +0700)

----------------------------------------------------------------
liburing-fixes-2022-10-19

----------------------------------------------------------------
Alviro Iskandar Setiawan (2):
      man/io_uring_buf_ring_advance.3: Fix return type
      man/io_uring_buf_ring_cq_advance.3: Fix return type

Ammar Faizi (1):
      test/helpers: Fix clang warning

 man/io_uring_buf_ring_advance.3    | 4 ++--
 man/io_uring_buf_ring_cq_advance.3 | 6 +++---
 test/helpers.h                     | 1 +
 3 files changed, 6 insertions(+), 5 deletions(-)
```