### PR TITLE
[GIT PULL] Add compile-time and run-time version check API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /src/liburing.a
 /src/liburing.so*
 /src/include/liburing/compat.h
+/src/include/liburing/io_uring_version.h
 
 /examples/io_uring-cp
 /examples/io_uring-test

--- a/Makefile.common
+++ b/Makefile.common
@@ -3,4 +3,5 @@ NAME=liburing
 SPECFILE=$(TOP)/$(NAME).spec
 VERSION=$(shell awk '/Version:/ { print $$2 }' $(SPECFILE))
 VERSION_MAJOR=$(shell echo $(VERSION) | cut -d. -f1)
+VERSION_MINOR=$(shell echo $(VERSION) | cut -d. -f2)
 TAG = $(NAME)-$(VERSION)

--- a/configure
+++ b/configure
@@ -428,6 +428,22 @@ print_config "CC" "$cc"
 echo "CXX=$cxx" >> $config_host_mak
 print_config "CXX" "$cxx"
 
+# generate io_uring_version.h
+MAKE_PRINT_VARS="include Makefile.common\nprint-%: ; @echo \$(\$*)\n"
+VERSION_MAJOR=$(env echo -e "$MAKE_PRINT_VARS" | make -s -f - print-VERSION_MAJOR)
+VERSION_MINOR=$(env echo -e "$MAKE_PRINT_VARS" | make -s -f - print-VERSION_MINOR)
+io_uring_version_h="src/include/liburing/io_uring_version.h"
+cat > $io_uring_version_h << EOF
+/* SPDX-License-Identifier: MIT */
+#ifndef LIBURING_VERSION_H
+#define LIBURING_VERSION_H
+
+#define IO_URING_VERSION_MAJOR $VERSION_MAJOR
+#define IO_URING_VERSION_MINOR $VERSION_MINOR
+
+#endif
+EOF
+
 # generate compat.h
 compat_h="src/include/liburing/compat.h"
 cat > $compat_h << EOF

--- a/man/IO_URING_CHECK_VERSION.3
+++ b/man/IO_URING_CHECK_VERSION.3
@@ -1,0 +1,1 @@
+io_uring_check_version.3

--- a/man/IO_URING_VERSION_MAJOR.3
+++ b/man/IO_URING_VERSION_MAJOR.3
@@ -1,0 +1,1 @@
+io_uring_check_version.3

--- a/man/IO_URING_VERSION_MINOR.3
+++ b/man/IO_URING_VERSION_MINOR.3
@@ -1,0 +1,1 @@
+io_uring_check_version.3

--- a/man/io_uring_check_version.3
+++ b/man/io_uring_check_version.3
@@ -1,0 +1,72 @@
+.\" Copyright (C) 2022 Christian Hergert <chergert@redhat.com>
+.\"
+.\" SPDX-License-Identifier: LGPL-2.0-or-later
+.\"
+.TH io_uring_check_version 3 "December 1, 2022" "liburing-2.4" "liburing Manual"
+.SH NAME
+io_uring_check_version \- functions and macros to check the liburing version
+.SH SYNOPSIS
+.nf
+.B #include <liburing.h>
+.PP
+.BI "bool io_uring_check_version(int " major ", int " minor ");"
+.BI "IO_URING_CHECK_VERSION(" major ", " minor ");"
+.PP
+.BI "int io_uring_major_version(void);"
+.BI "IO_URING_VERSION_MAJOR;"
+.PP
+.BI "int io_uring_minor_version(void);"
+.BI "IO_URING_VERSION_MINOR;"
+.fi
+.SH DESCRIPTION
+.PP
+The
+.BR io_uring_check_version (3)
+function returns
+.I true
+if the liburing library loaded by the dynamic linker is greater-than
+or equal-to the
+.I major
+and
+.I minor
+numbers provided.
+
+.PP
+The
+.BR IO_URING_CHECK_VERSION (3)
+macro returns
+.I 1
+if the liburing library being compiled against is greater-than or equal-to the
+.I major
+and
+.I minor
+numbers provided.
+
+.PP
+The
+.BR io_uring_major_version (3)
+function returns the
+.I major
+version number of the liburing library loaded by the dynamic linker.
+
+.PP
+The
+.BR IO_URING_VERSION_MAJOR (3)
+macro returns the
+.I major
+version number of the liburing library being compiled against.
+
+.PP
+The
+.BR io_uring_minor_version (3)
+function returns the
+.I minor
+version number of the liburing library loaded by the dynamic linker.
+
+.PP
+The
+.BR IO_URING_VERSION_MINOR (3)
+macro returns the
+.I minor
+version number of the liburing library being compiled against.
+

--- a/man/io_uring_major_version.3
+++ b/man/io_uring_major_version.3
@@ -1,0 +1,1 @@
+io_uring_check_version.3

--- a/man/io_uring_minor_version.3
+++ b/man/io_uring_minor_version.3
@@ -1,0 +1,1 @@
+io_uring_check_version.3

--- a/src/Makefile
+++ b/src/Makefile
@@ -35,7 +35,7 @@ endif
 
 all: $(all_targets)
 
-liburing_srcs := setup.c queue.c register.c syscall.c
+liburing_srcs := setup.c queue.c register.c syscall.c version.c
 
 ifeq ($(CONFIG_NOLIBC),y)
 	liburing_srcs += nolibc.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -73,6 +73,7 @@ install: $(all_targets)
 	install -D -m 644 include/liburing.h $(includedir)/liburing.h
 	install -D -m 644 include/liburing/compat.h $(includedir)/liburing/compat.h
 	install -D -m 644 include/liburing/barrier.h $(includedir)/liburing/barrier.h
+	install -D -m 644 include/liburing/io_uring_version.h $(includedir)/liburing/io_uring_version.h
 	install -D -m 644 liburing.a $(libdevdir)/liburing.a
 ifeq ($(ENABLE_SHARED),1)
 	install -D -m 755 $(libname) $(libdir)/$(libname)
@@ -84,6 +85,7 @@ clean:
 	@rm -f $(all_targets) $(liburing_objs) $(liburing_sobjs) $(soname).new
 	@rm -f *.so* *.a *.o *.d
 	@rm -f include/liburing/compat.h
+	@rm -f include/liburing/io_uring_version.h
 
 	@# When cleaning, we don't include ../config-host.mak,
 	@# so the nolibc objects are always skipped, clean them up!

--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -1348,6 +1348,24 @@ struct io_uring_sqe *io_uring_get_sqe(struct io_uring *ring);
 ssize_t io_uring_mlock_size(unsigned entries, unsigned flags);
 ssize_t io_uring_mlock_size_params(unsigned entries, struct io_uring_params *p);
 
+/*
+ * Versioning information for liburing.
+ *
+ * Use IO_URING_CHECK_VERSION() for compile time checks including from
+ * preprocessor directives.
+ *
+ * Use io_uring_check_version() for runtime checks of the version of
+ * liburing that was loaded by the dynamic linker.
+ */
+int io_uring_major_version(void);
+int io_uring_minor_version(void);
+bool io_uring_check_version(int major, int minor);
+
+#define IO_URING_CHECK_VERSION(major,minor) \
+  (major > IO_URING_VERSION_MAJOR ||        \
+   (major == IO_URING_VERSION_MAJOR &&      \
+    minor >= IO_URING_VERSION_MINOR))
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -23,6 +23,7 @@
 #include <linux/swab.h>
 #include "liburing/compat.h"
 #include "liburing/io_uring.h"
+#include "liburing/io_uring_version.h"
 #include "liburing/barrier.h"
 
 #ifndef uring_unlikely

--- a/src/liburing.map
+++ b/src/liburing.map
@@ -67,3 +67,10 @@ LIBURING_2.3 {
 		io_uring_get_events;
 		io_uring_submit_and_get_events;
 } LIBURING_2.2;
+
+LIBURING_2.4 {
+	global:
+		io_uring_major_version;
+		io_uring_minor_version;
+		io_uring_check_version;
+} LIBURING_2.3;

--- a/src/version.c
+++ b/src/version.c
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: MIT */
+
+#include "liburing.h"
+#include "liburing/io_uring_version.h"
+
+int io_uring_major_version(void)
+{
+	return IO_URING_VERSION_MAJOR;
+}
+
+int io_uring_minor_version(void)
+{
+	return IO_URING_VERSION_MINOR;
+}
+
+bool io_uring_check_version(int major, int minor)
+{
+	return major > io_uring_major_version() ||
+		(major == io_uring_major_version() &&
+		 minor >= io_uring_minor_version());
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -181,6 +181,7 @@ test_srcs := \
 	timeout-overflow.c \
 	tty-write-dpoll.c \
 	unlink.c \
+	version.c \
 	wakeup-hang.c \
 	xattr.c \
 	# EOL

--- a/test/version.c
+++ b/test/version.c
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Description: check version macros and runtime checks work
+ *
+ */
+#include "liburing.h"
+#include "helpers.h"
+
+int main(int argc, char *argv[])
+{
+	if (!IO_URING_CHECK_VERSION(io_uring_major_version(), io_uring_minor_version()))
+		return T_EXIT_FAIL;
+
+	if (io_uring_major_version() != IO_URING_VERSION_MAJOR)
+		return T_EXIT_FAIL;
+
+	if (io_uring_minor_version() != IO_URING_VERSION_MINOR)
+		return T_EXIT_FAIL;
+
+#if !IO_URING_CHECK_VERSION(IO_URING_VERSION_MAJOR, IO_URING_VERSION_MINOR)
+	return T_EXIT_FAIL;
+#endif
+
+	return T_EXIT_PASS;
+}


### PR DESCRIPTION
Pretty standard API additions for shared library version checking at both compile-time and run-time.

Adds the following to the ABI for runtime checks:

```
int io_uring_major_version (void);
int io_uring_minor_verison (void);
bool io_uring_check_version(int major, int minor);
```

Adds the following to the API for compile time checks:

```
#define IO_URING_CHECK_VERSION(major,minor) ...
#define IO_URING_VERSION_MAJOR ...
#define IO_URING_VERSION_MINOR ...
```

A new `io_uring_version.h` header is installed next to `compat.h` and generated similarly in `configure`.

Includes some basic tests as well.

The only sort of "wizardry" here is that we use a not-so-common trick to parse `Makefile.common` with `make` to extract the values of `$VERSION_MAJOR` and `$VERSION_MINOR`. (I've been doing this in the GNOME Builder IDE to extract compiler flags for a very, very long time).

Fixes #736

----
## git request-pull output:
```
The following changes since commit 919755a7d0096fda08fb6d65ac54ad8d0fe027cd:

  Add test cases for eventfd and epoll loops (2022-11-30 10:53:09 -0700)

are available in the Git repository at:

  git@github.com:chergert/liburing.git master

for you to fetch changes up to 537107c807e9d307e337cc9495a0efb051b8e350:

  version: add runtime and compile time version checks (2022-11-30 15:52:55 -0800)

----------------------------------------------------------------
Christian Hergert (3):
      Makefile.common: include VERSION_MINOR from specfile
      version: generate io_uring_version.h from Makefile.common
      version: add runtime and compile time version checks

 .gitignore             |  1 +
 Makefile.common        |  1 +
 configure              | 16 ++++++++++++++++
 src/Makefile           |  4 +++-
 src/include/liburing.h | 19 +++++++++++++++++++
 src/version.c          | 21 +++++++++++++++++++++
 test/Makefile          |  1 +
 test/version.c         | 25 +++++++++++++++++++++++++
 8 files changed, 87 insertions(+), 1 deletion(-)
 create mode 100644 src/version.c
 create mode 100644 test/version.c

```
----
## By submitting this pull request, I acknowledge that:
* [x] I have followed the above pull request guidelines.
* [x] I have the rights to submit this work under the same license.
* [x] I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
