### PR TITLE
[GIT PULL] fix: documentation for readv, readv2 and setup

### DIFF
--- a/man/io_uring_prep_readv.3
+++ b/man/io_uring_prep_readv.3
@@ -43,7 +43,7 @@ possible to provide the desired IO offset from the application or library.
 
 On files that are not capable of seeking, the offset must be 0 or -1.
 
-After the write has been prepared it can be submitted with one of the submit
+After the read has been prepared it can be submitted with one of the submit
 functions.
 
 .SH RETURN VALUE

--- a/man/io_uring_prep_readv2.3
+++ b/man/io_uring_prep_readv2.3
@@ -69,7 +69,7 @@ possible to provide the desired IO offset from the application or library.
 
 On files that are not capable of seeking, the offset must be 0 or -1.
 
-After the write has been prepared, it can be submitted with one of the submit
+After the read has been prepared, it can be submitted with one of the submit
 functions.
 
 .SH RETURN VALUE

--- a/man/io_uring_setup.2
+++ b/man/io_uring_setup.2
@@ -119,6 +119,18 @@ is a submission queue ring setup using the
 described below.
 .TP
 .BR
+Note that, when using a ring setup with
+.B IORING_SETUP_SQPOLL,
+you never directly call the
+.I io_uring_enter()
+system call. That is usually taken care of by liburing’s
+.I io_uring_submit()
+function. It automatically determines if you are using
+polling mode or not and deals with when your program needs to call
+.I io_uring_enter()
+without you having to bother about it.
+.TP
+.BR
 Before version 5.11 of the Linux kernel, to successfully use this feature, the
 application must register a set of files to be used for IO through
 .BR io_uring_register (2)


### PR DESCRIPTION
The readv and readv2 man pages have a typo that probably came from the write man page.
I also want to update the example for handling IORING_SQ_NEED_WAKEUP in the io_uring_setup man page.


These changes fixes 2 small typos on io_uring_prep_readv, io_uring_prep_readv2 man pages and tries to clarify the polling example in the io_uring_setup man page.

----
## git request-pull output:
```
The following changes since commit 5772879454421e82ae153c60853cf378a314e8f9:

  Merge branch 'provide-buffers-man-fixes' of https://github.com/wlukowicz/liburing (2022-12-03 09:27:37 -0700)

are available in the Git repository at:

  git@github.com:bignacio/liburing.git issue_746_man-page-fixes-improvements

for you to fetch changes up to 0228709ca2ea662c85a154e646c16f869fadbc50:

  fix documentation for readv, readv2 and setup (2022-12-04 21:46:24 -0500)

----------------------------------------------------------------
Bira Ignacio (1):
      fix documentation for readv, readv2 and setup

 man/io_uring_prep_readv.3  |  2 +-
 man/io_uring_prep_readv2.3 |  2 +-
 man/io_uring_setup.2       | 14 ++++++++++++--
 3 files changed, 14 insertions(+), 4 deletions(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
