### PR TITLE
uapi: Sync with the kernel and adjust the way to avoid linux/time_typ…

### DIFF
--- a/configure
+++ b/configure
@@ -468,10 +468,15 @@ struct __kernel_timespec {
 	long long	tv_nsec;
 };
 
+/* <linux/time_types.h> is not available, so it can't be included */
+#define UAPI_LINUX_IO_URING_H_SKIP_LINUX_TIME_TYPES_H 1
+
 EOF
 else
 cat >> $compat_h << EOF
 #include <linux/time_types.h>
+/* <linux/time_types.h> is included above and not needed again */
+#define UAPI_LINUX_IO_URING_H_SKIP_LINUX_TIME_TYPES_H 1
 
 EOF
 fi

--- a/src/include/liburing/io_uring.h
+++ b/src/include/liburing/io_uring.h
@@ -12,12 +12,11 @@
 #include <linux/types.h>
 /*
  * this file is shared with liburing and that has to autodetect
- * if linux/time_types.h is available
+ * if linux/time_types.h is available or not, it can
+ * define UAPI_LINUX_IO_URING_H_SKIP_LINUX_TIME_TYPES_H
+ * if linux/time_types.h is not available
  */
-#ifdef __KERNEL__
-#define HAVE_LINUX_TIME_TYPES_H 1
-#endif
-#ifdef HAVE_LINUX_TIME_TYPES_H
+#ifndef UAPI_LINUX_IO_URING_H_SKIP_LINUX_TIME_TYPES_H
 #include <linux/time_types.h>
 #endif
 
@@ -231,7 +230,7 @@ enum io_uring_op {
 
 /*
  * sqe->uring_cmd_flags
- * IORING_URING_CMD_FIXED	use registered buffer; pass thig flag
+ * IORING_URING_CMD_FIXED	use registered buffer; pass this flag
  *				along with setting sqe->buf_index.
  */
 #define IORING_URING_CMD_FIXED	(1U << 0)
@@ -305,10 +304,28 @@ enum io_uring_op {
  *
  * IORING_RECVSEND_FIXED_BUF	Use registered buffers, the index is stored in
  *				the buf_index field.
+ *
+ * IORING_SEND_ZC_REPORT_USAGE
+ *				If set, SEND[MSG]_ZC should report
+ *				the zerocopy usage in cqe.res
+ *				for the IORING_CQE_F_NOTIF cqe.
+ *				0 is reported if zerocopy was actually possible.
+ *				IORING_NOTIF_USAGE_ZC_COPIED if data was copied
+ *				(at least partially).
  */
 #define IORING_RECVSEND_POLL_FIRST	(1U << 0)
 #define IORING_RECV_MULTISHOT		(1U << 1)
 #define IORING_RECVSEND_FIXED_BUF	(1U << 2)
+#define IORING_SEND_ZC_REPORT_USAGE	(1U << 3)
+
+/*
+ * cqe.res for IORING_CQE_F_NOTIF if
+ * IORING_SEND_ZC_REPORT_USAGE was requested
+ *
+ * It should be treated as a flag, all other
+ * bits of cqe.res should be treated as reserved!
+ */
+#define IORING_NOTIF_USAGE_ZC_COPIED    (1U << 31)
 
 /*
  * accept flags stored in sqe->ioprio


### PR DESCRIPTION
…es.h

This is similar to commit 4189c79a8dd1004fb119badaf823647b0cb20541, "uapi: Sync with the kernel in order to build systems without linux/time_types.h"

Now we opt-in and define UAPI_LINUX_IO_URING_H_SKIP_LINUX_TIME_TYPES_H if there's no linux/time_types.h in the system and we provide replacements for the required types.

Fixes: https://github.com/axboe/liburing/issues/708
Fixes: 4189c79a8dd1004fb119badaf823647b0cb20541 ("uapi: Sync with the kernel in order to build systems without linux/time_types.h")
Link: https://lore.kernel.org/io-uring/167215158915.44294.15174860895720844240.b4-ty@kernel.dk/T/#t
Signed-off-by: Stefan Metzmacher <metze@samba.org>


<!-- Explain your changes here... -->

----
## git request-pull output:
```
<!-- START REPLACE ME -->

Generate your PR shortlog and diffstat with these commands:
   git remote add axboe-tree https://github.com/axboe/liburing
   git fetch axboe-tree
   git request-pull axboe-tree/master your_fork_URL your_branch_name

Then replace this with the output of `git request-pull` command.

<!-- END REPLACE ME -->
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
