### PR TITLE
[GIT PULL] Add support for io_uring_prep_msg_ring_cqe_flags(3)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ liburing-2.4 release
 - Add io_uring_{major,minor,check}_version() functions.
 - Add IO_URING_{MAJOR,MINOR,CHECK}_VERSION() macros.
 - FFI support (for non-C/C++ languages integration).
+- Add io_uring_prep_msg_ring_cqe_flags() function.
 
 liburing-2.3 release
 

--- a/man/io_uring_prep_msg_ring.3
+++ b/man/io_uring_prep_msg_ring.3
@@ -14,6 +14,13 @@ io_uring_prep_msg_ring \- send a message to another ring
 .BI "                        unsigned int " len ","
 .BI "                        __u64 " data ","
 .BI "                        unsigned int " flags ");"
+.PP
+.BI "void io_uring_prep_msg_ring_cqe_flags(struct io_uring_sqe *" sqe ","
+.BI "                        int " fd ","
+.BI "                        unsigned int " len ","
+.BI "                        __u64 " data ","
+.BI "                        unsigned int " flags ","
+.BI "                        unsigned int " cqe_flags ");"
 .fi
 .SH DESCRIPTION
 .PP
@@ -46,6 +53,18 @@ and
 fields. The use case may be anything from simply waking up someone waiting
 on the targeted ring, or it can be used to pass messages between the two
 rings.
+
+.BR io_uring_prep_msg_ring_cqe_flags (3)
+is similar to
+.BR io_uring_prep_msg_ring (3) .
+But has an addition
+.I cqe_flags
+parameter, which is used to set
+.I flags
+field on CQE side. That way, you can set the CQE flags field
+.I cqe->flags
+when sending a message. Be aware that io_uring could potentially set additional
+bits into this field.
 
 .SH RETURN VALUE
 None

--- a/man/io_uring_prep_msg_ring_cqe_flags.3
+++ b/man/io_uring_prep_msg_ring_cqe_flags.3
@@ -1,0 +1,1 @@
+io_uring_prep_msg_ring.3

--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -987,6 +987,15 @@ IOURINGINLINE void io_uring_prep_link(struct io_uring_sqe *sqe,
 	io_uring_prep_linkat(sqe, AT_FDCWD, oldpath, AT_FDCWD, newpath, flags);
 }
 
+IOURINGINLINE void io_uring_prep_msg_ring_cqe_flags(struct io_uring_sqe *sqe,
+					  int fd, unsigned int len, __u64 data,
+					  unsigned int flags, unsigned int cqe_flags)
+{
+	io_uring_prep_rw(IORING_OP_MSG_RING, sqe, fd, NULL, len, data);
+	sqe->msg_ring_flags = IORING_MSG_RING_FLAGS_PASS | flags;
+	sqe->file_index = cqe_flags;
+}
+
 IOURINGINLINE void io_uring_prep_msg_ring(struct io_uring_sqe *sqe, int fd,
 					  unsigned int len, __u64 data,
 					  unsigned int flags)

--- a/src/include/liburing/io_uring.h
+++ b/src/include/liburing/io_uring.h
@@ -347,6 +347,8 @@ enum {
  *				applicable for IORING_MSG_DATA, obviously.
  */
 #define IORING_MSG_RING_CQE_SKIP	(1U << 0)
+/* Pass through the flags from sqe->file_index to cqe->flags */
+#define IORING_MSG_RING_FLAGS_PASS	(1U << 1)
 
 /*
  * IO completion data structure (Completion Queue Entry)

--- a/test/Makefile
+++ b/test/Makefile
@@ -107,6 +107,7 @@ test_srcs := \
 	madvise.c \
 	mkdir.c \
 	msg-ring.c \
+	msg-ring-flags.c \
 	multicqes_drain.c \
 	nolibc.c \
 	nop-all-sizes.c \

--- a/test/msg-ring-flags.c
+++ b/test/msg-ring-flags.c
@@ -1,0 +1,131 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Description: test ring messaging with flags command
+ *
+ */
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <pthread.h>
+
+#include "liburing.h"
+#include "helpers.h"
+
+#define CUSTOM_FLAG 0x42
+#define USER_DATA 0x5aa5
+#define LEN 0x20
+#define ID 0x1
+
+static int recv_msg(struct io_uring *ring)
+{
+	struct io_uring_cqe *cqe;
+	int ret;
+
+	ret = io_uring_wait_cqe(ring, &cqe);
+	if (ret) {
+		fprintf(stderr, "wait cqe %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+	if (cqe->user_data != USER_DATA) {
+		fprintf(stderr, "user_data %llx\n", (long long) cqe->user_data);
+		return T_EXIT_FAIL;
+	}
+	if (cqe->res != LEN) {
+		fprintf(stderr, "len %x\n", cqe->res);
+		return T_EXIT_FAIL;
+	}
+	if (cqe->flags != CUSTOM_FLAG) {
+		fprintf(stderr, "flags %x\n", cqe->flags);
+		return T_EXIT_FAIL;
+	}
+
+	return T_EXIT_PASS;
+}
+
+static int send_msg(struct io_uring *ring, struct io_uring *target)
+{
+	struct io_uring_cqe *cqe;
+	struct io_uring_sqe *sqe;
+	int ret;
+
+	sqe = io_uring_get_sqe(ring);
+	if (!sqe) {
+		fprintf(stderr, "get sqe failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	io_uring_prep_msg_ring_cqe_flags(sqe, target->ring_fd, LEN, USER_DATA,
+					 0, CUSTOM_FLAG);
+	sqe->user_data = ID;
+
+	ret = io_uring_submit(ring);
+	if (ret <= 0) {
+		if (ret == -EINVAL)
+			return T_EXIT_SKIP;
+
+		fprintf(stderr, "sqe submit failed: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	ret = io_uring_wait_cqe(ring, &cqe);
+	if (ret < 0) {
+		fprintf(stderr, "wait completion %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+	if (cqe->res != 0) {
+		if (cqe->res == -EINVAL)
+			return T_EXIT_SKIP;
+		fprintf(stderr, "cqe res %d\n", cqe->res);
+		return T_EXIT_FAIL;
+	}
+	if (cqe->user_data != ID) {
+		fprintf(stderr, "user_data %llx\n", (long long) cqe->user_data);
+		return T_EXIT_FAIL;
+	}
+
+	io_uring_cqe_seen(ring, cqe);
+
+	return T_EXIT_PASS;
+}
+
+
+int main(int argc, char *argv[])
+{
+	struct io_uring ring, ring2;
+	int ret;
+
+	if (argc > 1)
+		return T_EXIT_SKIP;
+
+	ret = io_uring_queue_init(8, &ring, 0);
+	if (ret) {
+		fprintf(stderr, "io_uring_queue_init failed for ring1: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	ret = io_uring_queue_init(8, &ring2, 0);
+	if (ret) {
+		fprintf(stderr, "io_uring_queue_init failed for ring2: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	ret = send_msg(&ring, &ring2);
+	if (ret) {
+		if (ret == T_EXIT_SKIP)
+			fprintf(stderr, "test skipped\n");
+		else
+			fprintf(stderr, "send_msg failed: %d\n", ret);
+		return ret;
+	}
+
+	ret = recv_msg(&ring2);
+	if (ret) {
+		fprintf(stderr, "recv_msg failed: %d\n", ret);
+		return ret;
+	}
+
+	return T_EXIT_PASS;
+}


### PR DESCRIPTION
This PR adds support for a new flag to pass through flags from SQE to CQE. 

Basically, you specify the flags you want to see in `cqe->flags` by setting `sqe->file_index`, and toggling the new flag `IORING_MSG_RING_FLAGS_PASS` 

Kernel patch: https://lore.kernel.org/io-uring/20230103160507.617416-1-leitao@debian.org/T/#u

----
## git request-pull output:
```
The following changes since commit 052c2e03e4b64e07f9d4e43ed816cd8e5721b9d8:

  Merge branch 'io_uring_uapi' of https://github.com/metze-samba/liburing (2022-12-28 10:04:10 -0700)

are available in the Git repository at:

  git@github.com:leitao/liburing.git master

for you to fetch changes up to f08da78a3b0ff6c175bbaeb8ddd35cb11a1635d8:

  test/io_uring_prep_msg_ring_cqe_flags new test (2023-01-03 06:51:17 -0800)

----------------------------------------------------------------
Breno Leitao (4):
      uapi: Sync with the kernel in order to see IORING_MSG_RING_FLAGS_PASS
      Add io_uring_prep_msg_ring_cqe_flags function
      man/io_uring_prep_msg_ring: Add additional function
      test/io_uring_prep_msg_ring_cqe_flags new test

 man/io_uring_prep_msg_ring.3           |  18 +++++++++++
 man/io_uring_prep_msg_ring_cqe_flags.3 |   1 +
 src/include/liburing.h                 |   9 ++++++
 src/include/liburing/io_uring.h        |   2 ++
 test/Makefile                          |   1 +
 test/msg-ring-flags.c                  | 120 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 6 files changed, 151 insertions(+)
 create mode 120000 man/io_uring_prep_msg_ring_cqe_flags.3
 create mode 100644 test/msg-ring-flags.c
```

