### PR TITLE
[GIT PULL] man/io_uring_prep_msg_ring.3: Remove an extra char

### DIFF
--- a/man/io_uring_prep_msg_ring.3
+++ b/man/io_uring_prep_msg_ring.3
@@ -18,7 +18,7 @@ io_uring_prep_msg_ring \- send a message to another ring
 .SH DESCRIPTION
 .PP
 .BR io_uring_prep_msg_ring (3)
-prepares a to send a CQE to an io_uring file descriptor. The submission queue
+prepares to send a CQE to an io_uring file descriptor. The submission queue
 entry
 .I sqe
 is setup to use the file descriptor


### PR DESCRIPTION
The current message for io_uring_prep_msg_ring(3) is a bit confusing. Removing the additional 'a' char makes the reading smoother.

Signed-off-by: Breno Leitao <leitao@debian.org>


<!-- Explain your changes here... -->

----
## git request-pull output:
```
The following changes since commit f6d880f0c9be588cc71007d9c36d1160fe8ab54e:

  test: always use local liburing.h header (2023-01-03 15:24:03 -0700)

are available in the Git repository at:

  git@github.com:leitao/liburing.git upstream

for you to fetch changes up to 66a61b526fd7a1a76bdfa9a906b06d88f0fe6246:

  man/io_uring_prep_msg_ring.3: Remove an extra char (2023-01-04 03:16:19 -0800)

----------------------------------------------------------------
Breno Leitao (1):
      man/io_uring_prep_msg_ring.3: Remove an extra char

 man/io_uring_prep_msg_ring.3 | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
 ```
