### PR TITLE
liburing.h: Use proper sqe flags

### DIFF
--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -992,7 +992,7 @@ IOURINGINLINE void io_uring_prep_msg_ring(struct io_uring_sqe *sqe, int fd,
 					  unsigned int flags)
 {
 	io_uring_prep_rw(IORING_OP_MSG_RING, sqe, fd, NULL, len, data);
-	sqe->rw_flags = flags;
+	sqe->msg_ring_flags = flags;
 }
 
 IOURINGINLINE void io_uring_prep_getxattr(struct io_uring_sqe *sqe,


### PR DESCRIPTION
io_uring_prep_msg_ring(3) is setting sqe->rw_flags for the flags. Since this is a message ring operation, let's use the proper field, msg_ring_flags.

Discussion at https://github.com/axboe/liburing/pull/765#discussion_r1061346797

Signed-off-by: Breno Leitao <leitao@debian.org>

----
## git request-pull output:
```
The following changes since commit f5a48392c4ea33f222cbebeb2e2fc31620162949:

  Merge branch 'man-fixes' of https://github.com/wlukowicz/liburing (2023-01-08 09:45:24 -0700)

are available in the Git repository at:

  git@github.com:leitao/liburing.git upstream

for you to fetch changes up to 59bb5b8660186589c15104ab78626d14656dde4a:

  liburing.h: Use proper sqe flags (2023-01-09 09:34:55 -0800)

----------------------------------------------------------------
Breno Leitao (1):
      liburing.h: Use proper sqe flags

 src/include/liburing.h | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
