### PR TITLE
[GIT PULL] man: Fix typos

### DIFF
--- a/man/io_uring_prep_accept.3
+++ b/man/io_uring_prep_accept.3
@@ -92,7 +92,7 @@ will have an unused table index dynamically chosen and returned for each connect
 If both forms of direct selection will be employed, specific and dynamic, see
 .BR io_uring_register_file_alloc_range (3)
 for setting up the table so dynamically chosen entries are made against
-a different range than that targetted by specific requests.
+a different range than that targeted by specific requests.
 
 Note that old kernels don't check the SQE
 .I file_index

--- a/man/io_uring_setup.2
+++ b/man/io_uring_setup.2
@@ -13,7 +13,7 @@ io_uring_setup \- setup a context for performing asynchronous I/O
 .PP
 .BI "int io_uring_setup(u32 " entries ", struct io_uring_params *" p );
 .fi
-.PPAA
+.PP
 .SH DESCRIPTION
 .PP
 The


### PR DESCRIPTION
Fix one typo in wording and another in a troff macro.

Warned-by: lintian
Signed-off-by: Guillem Jover <guillem@hadrons.org>

----
## git request-pull output:
```
The following changes since commit 849f5ba89b0d1ccf9d825160bf8560ad9901c48b:

  tests: lazy pollwq activation for disabled rings (2023-01-16 10:48:45 -0700)

are available in the Git repository at:

  https://github.com/guillemj/liburing pu/man-fixes

for you to fetch changes up to 4215200cf419f7d85cefa04b11a8258d4c8f4974:

  man: Fix typos (2023-01-18 02:53:30 +0100)

----------------------------------------------------------------
Guillem Jover (1):
      man: Fix typos

 man/io_uring_prep_accept.3 | 2 +-
 man/io_uring_setup.2       | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
