### PR TITLE
Add prep functions man pages

### DIFF
--- a/man/io_uring_prep_fgetxattr.3
+++ b/man/io_uring_prep_fgetxattr.3
@@ -1,0 +1,1 @@
+io_uring_prep_getxattr.3

--- a/man/io_uring_prep_fsetxattr.3
+++ b/man/io_uring_prep_fsetxattr.3
@@ -1,0 +1,1 @@
+io_uring_prep_setxattr.3

--- a/man/io_uring_prep_getxattr.3
+++ b/man/io_uring_prep_getxattr.3
@@ -1,0 +1,61 @@
+.\" Copyright (C) 2023 Rutvik Patel <heyrutvik@gmail.com>
+.\"
+.\" SPDX-License-Identifier: LGPL-2.0-or-later
+.\"
+.TH io_uring_prep_getxattr 3 "January 23, 2023" "liburing-2.4" "liburing Manual"
+.SH NAME
+io_uring_prep_getxattr, io_uring_prep_fgetxattr \- prepare a request to get an 
+extended attribute value
+.SH SYNOPSIS
+.nf
+.B #include <liburing.h>
+.PP
+.BI "void io_uring_prep_getxattr(struct io_uring_sqe *" sqe ","
+.BI "                            const char *" name ","
+.BI "                            char *" value ","
+.BI "                            const char *" path ","
+.BI "                            unsigned int " len ");"
+.PP
+.BI "void io_uring_prep_fgetxattr(struct io_uring_sqe *" sqe ","
+.BI "                             int " fd ","
+.BI "                             const char *" name ","
+.BI "                             char *" value ","
+.BI "                             unsigned int " len ");"
+.fi
+.SH DESCRIPTION
+.PP
+The
+.BR io_uring_prep_getxattr (3)
+function prepares a request to get an extended attribute value. The submission 
+queue entry
+.I sqe
+is setup to get the
+.I value
+of the extended attribute identified by
+.I name
+and associated with the given
+.I path
+in the filesystem.
+The
+.I len
+argument specifies the size (in bytes) of
+.IR value .
+
+.BR io_uring_prep_fgetxattr (3)
+is identical to 
+.BR io_uring_prep_getxattr (3),
+only the open file referred to by
+.I fd
+is interrogated in place of
+.IR path .
+
+This function prepares an async 
+.BR getxattr (2)
+request. See that man page for details.
+
+.SH RETURN VALUE
+None
+
+.SH SEE ALSO
+.BR io_uring_get_sqe (3),
+.BR getxattr (2)

--- a/man/io_uring_prep_link_timeout.3
+++ b/man/io_uring_prep_link_timeout.3
@@ -1,0 +1,94 @@
+.\" Copyright (C) 2023 Rutvik Patel <heyrutvik@gmail.com>
+.\"
+.\" SPDX-License-Identifier: LGPL-2.0-or-later
+.\"
+.TH io_uring_prep_link_timeout 3 "January 23, 2023" "liburing-2.4" "liburing Manual"
+.SH NAME
+io_uring_prep_link_timeout \- a timeout request for linked sqes
+.SH SYNOPSIS
+.nf
+.B #include <liburing.h>
+.PP
+.BI "void io_uring_prep_link_timeout(struct io_uring_sqe *" sqe ","
+.BI "                                struct __kernel_timespec *" ts ","
+.BI "                                unsigned " flags ");"
+.fi
+.SH DESCRIPTION
+.PP
+The 
+.BR io_uring_prep_link_timeout (3)
+function prepares a timeout request for linked sqes. The submission queue entry 
+.I sqe
+is setup a timeout specified by
+.IR ts .
+The flags argument holds modifier
+.I flags
+for the timeout behaviour of the request.
+
+The
+.I ts
+argument must be filled in with the appropriate information for the timeout. It looks as follows:
+.PP
+.in +4n
+.EX
+struct __kernel_timespec {
+    __kernel_time64_t tv_sec;
+    long long tv_nsec;
+};
+.EE
+.in
+.PP
+
+The
+.I flags
+argument may contain:
+.TP
+.B IORING_TIMEOUT_ABS
+The value specified in
+.I ts
+is an absolute value rather than a relative one.
+.TP
+.B IORING_TIMEOUT_BOOTTIME
+The boottime clock source should be used.
+.TP
+.B IORING_TIMEOUT_REALTIME
+The realtime clock source should be used.
+.TP
+.B IORING_TIMEOUT_ETIME_SUCCESS
+Consider an expired timeout a success in terms of the posted completion.
+.PP
+
+It is invalid to create a chain (linked sqes) consisting only of a link timeout 
+request. If all the requests in the chain are completed before timeout, then the 
+link timeout request gets cancelled. Upon timeout, all the uncompleted requests 
+in the chain get cancelled.
+
+.SH RETURN VALUE
+None
+
+.SH ERRORS
+.PP
+These are the errors that are reported in the CQE
+.I res
+field. On success,
+.B 0
+is returned.
+.TP
+.B -ETIME
+The specified timeout occurred and triggered the completion event.
+.TP
+.B -EINVAL
+One of the fields set in the SQE was invalid. For example, two clock sources 
+where given, or the specified timeout seconds or nanoseconds where < 0.
+.TP
+.B -EFAULT
+io_uring was unable to access the data specified by ts.
+.TP
+.B -ECANCELED
+The timeout was canceled because all submitted requests were completed successfully 
+or one of the requests resulted in failure.
+
+
+.SH SEE ALSO
+.BR io_uring_get_sqe (3),
+.BR io_uring_prep_timeout (3)

--- a/man/io_uring_prep_send_set_addr.3
+++ b/man/io_uring_prep_send_set_addr.3
@@ -1,0 +1,38 @@
+.\" Copyright (C) 2023 Rutvik Patel <heyrutvik@gmail.com>
+.\"
+.\" SPDX-License-Identifier: LGPL-2.0-or-later
+.\"
+.TH io_uring_prep_send_set_addr 3 "January 23, 2023" "liburing-2.4" "liburing Manual"
+.SH NAME
+io_uring_prep_send_set_addr \- set address details for send requests
+.SH SYNOPSIS
+.nf
+.B #include <liburing.h>
+.PP
+.BI "void io_uring_prep_send_set_addr(struct io_uring_sqe *" sqe ","
+.BI "                                 const struct sockaddr *" dest_addr ","
+.BI "                                 __u16 " addr_len ");"
+.fi
+.SH DESCRIPTION
+.PP
+The
+.BR io_uring_prep_send_set_addr (3)
+function sets a socket destination address specified by
+.I dest_addr
+and its length using
+.I addr_len
+parameters. It can be used once 
+.I sqe
+is prepared using any of the
+.BR send (2)
+io_uring helpers. See man pages of
+.BR io_uring_prep_send (3)
+or
+.BR io_uring_prep_send_zc (3).
+.SH RETURN VALUE
+None
+.SH SEE ALSO
+.BR io_uring_get_sqe (3),
+.BR io_uring_prep_send (3),
+.BR io_uring_prep_send_zc (3),
+.BR send (2)

--- a/man/io_uring_prep_send_zc.3
+++ b/man/io_uring_prep_send_zc.3
@@ -10,11 +10,19 @@ io_uring_prep_send_zc \- prepare a zerocopy send request
 .B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_send_zc(struct io_uring_sqe *" sqe ","
-.BI "                        int " sockfd ","
-.BI "                        const void *" buf ","
-.BI "                        size_t " len ","
-.BI "                        int " flags ","
-.BI "                        int " zc_flags ");"
+.BI "                           int " sockfd ","
+.BI "                           const void *" buf ","
+.BI "                           size_t " len ","
+.BI "                           int " flags ","
+.BI "                           unsigned " zc_flags ");"
+.PP
+.BI "void io_uring_prep_send_zc_fixed(struct io_uring_sqe *" sqe ","
+.BI "                                 int " sockfd ","
+.BI "                                 const void *" buf ","
+.BI "                                 size_t " len ","
+.BI "                                 int " flags ","
+.BI "                                 unsigned " zc_flags ");"
+.BI "                                 unsigned " buf_index ");"
 .fi
 .SH DESCRIPTION
 .PP
@@ -29,20 +37,35 @@ to start sending the data from
 of size
 .I len
 bytes with send modifier flags
-.IR flags
+.I flags
 and zerocopy modifier flags
 .IR zc_flags .
+
+The 
+.BR io_uring_prep_send_zc_fixed (3)
+works just like
+.BR io_uring_prep_send_zc (3)
+except it requires the use of buffers that have been registered with 
+.BR io_uring_register_buffers (3).
+The
+.I buf
+and
+.I len
+arguments must fall within a region specified by
+.I buf_index
+in the previously registered buffer. The buffer need not be aligned with the 
+start of the registered buffer.
 
 Note that using
 .B IOSQE_IO_LINK
 with this request type requires the setting of
 .B MSG_WAITALL
 in the
-.IR flags
-argument, as a short send isn't a considered an error condition without
+.I flags
+argument, as a short send isn't considered an error condition without
 that being set.
 
-This function prepares an async zerocopy
+These functions prepare an async zerocopy
 .BR send (2)
 request. See that man page for details. For details on the zerocopy nature
 of it, see

--- a/man/io_uring_prep_send_zc_fixed.3
+++ b/man/io_uring_prep_send_zc_fixed.3
@@ -1,0 +1,1 @@
+io_uring_prep_send_zc.3

--- a/man/io_uring_prep_sendmsg.3
+++ b/man/io_uring_prep_sendmsg.3
@@ -15,6 +15,11 @@ io_uring_prep_sendmsg \- prepare a sendmsg request
 .BI "                           int " fd ","
 .BI "                           const struct msghdr *" msg ","
 .BI "                           unsigned " flags ");"
+.PP
+.BI "void io_uring_prep_sendmsg_zc(struct io_uring_sqe *" sqe ","
+.BI "                              int " fd ","
+.BI "                              const struct msghdr *" msg ","
+.BI "                              unsigned " flags ");"
 .fi
 .SH DESCRIPTION
 .PP
@@ -32,13 +37,19 @@ defined flags in the
 .I flags
 argument.
 
+The
+.BR io_uring_prep_sendmsg_zc (3)
+accepts the same parameters as 
+.BR io_uring_prep_sendmsg (3)
+but prepares a zerocopy sendmsg request.
+
 Note that using
 .B IOSQE_IO_LINK
 with this request type requires the setting of
 .B MSG_WAITALL
 in the
-.IR flags
-argument, as a short send isn't a considered an error condition without
+.I flags
+argument, as a short send isn't considered an error condition without
 that being set.
 
 This function prepares an async

--- a/man/io_uring_prep_sendmsg_zc.3
+++ b/man/io_uring_prep_sendmsg_zc.3
@@ -1,0 +1,1 @@
+io_uring_prep_sendmsg.3

--- a/man/io_uring_prep_setxattr.3
+++ b/man/io_uring_prep_setxattr.3
@@ -1,0 +1,64 @@
+.\" Copyright (C) 2023 Rutvik Patel <heyrutvik@gmail.com>
+.\"
+.\" SPDX-License-Identifier: LGPL-2.0-or-later
+.\"
+.TH io_uring_prep_setxattr 3 "January 23, 2023" "liburing-2.4" "liburing Manual"
+.SH NAME
+io_uring_prep_setxattr, io_uring_prep_fsetxattr \- prepare a request to set an 
+extended attribute value
+.SH SYNOPSIS
+.nf
+.B #include <liburing.h>
+.PP
+.BI "void io_uring_prep_setxattr(struct io_uring_sqe *" sqe ","
+.BI "                            const char *" name ","
+.BI "                            const char *" value ","
+.BI "                            const char *" path ","
+.BI "                            int " flags ","
+.BI "                            unsigned int " len ");"
+.PP
+.BI "void io_uring_prep_fsetxattr(struct io_uring_sqe *" sqe ","
+.BI "                             int " fd ","
+.BI "                             const char *" name ","
+.BI "                             const char *" value ","
+.BI "                             int " flags ","
+.BI "                             unsigned int " len ");"
+.fi
+.SH DESCRIPTION
+.PP
+The
+.BR io_uring_prep_setxattr (3)
+function prepares a request to set an extended attribute value. The submission 
+queue entry 
+.I sqe
+is setup to set the
+.I value
+of the extended attribute identified by
+.I name
+and associated with the given
+.I path
+in the filesystem with modifier flags
+.IR flags .
+The
+.I len
+argument specifies the size (in bytes) of
+.IR value .
+
+.BR io_uring_prep_fsetxattr (3)
+is identical to 
+.BR io_uring_prep_setxattr (3),
+only the extended attribute is set on the open file referred to by
+.I fd
+in place of
+.IR path .
+
+This function prepares an async 
+.BR setxattr (2)
+request. See that man page for details.
+
+.SH RETURN VALUE
+None
+
+.SH SEE ALSO
+.BR io_uring_get_sqe (3),
+.BR setxattr (2)


### PR DESCRIPTION
Adds man pages for following prep functions (part of https://github.com/axboe/liburing/issues/777):

-  io_uring_prep_link_timeout
-  io_uring_prep_send_zc_fixed
-  io_uring_prep_sendmsg_zc
-  io_uring_prep_send_set_addr
-  io_uring_prep_getxattr
-  io_uring_prep_setxattr
-  io_uring_prep_fgetxattr
-  io_uring_prep_fsetxattr