### PR TITLE
use make --no-print-directory to generate version string

### DIFF
--- a/configure
+++ b/configure
@@ -460,8 +460,8 @@ print_config "CXX" "$cxx"
 
 # generate io_uring_version.h
 MAKE_PRINT_VARS="include Makefile.common\nprint-%: ; @echo \$(\$*)\n"
-VERSION_MAJOR=$(env echo -e "$MAKE_PRINT_VARS" | make -s -f - print-VERSION_MAJOR)
-VERSION_MINOR=$(env echo -e "$MAKE_PRINT_VARS" | make -s -f - print-VERSION_MINOR)
+VERSION_MAJOR=$(env echo -e "$MAKE_PRINT_VARS" | make -s --no-print-directory -f - print-VERSION_MAJOR)
+VERSION_MINOR=$(env echo -e "$MAKE_PRINT_VARS" | make -s --no-print-directory -f - print-VERSION_MINOR)
 io_uring_version_h="src/include/liburing/io_uring_version.h"
 cat > $io_uring_version_h << EOF
 /* SPDX-License-Identifier: MIT */


### PR DESCRIPTION
When I ran `build-debs.sh` on my Debian 11 system, I got a bunch of errors because the generated `io_uring_version.h` contained:

```
/* SPDX-License-Identifier: MIT */
#ifndef LIBURING_VERSION_H
#define LIBURING_VERSION_H

#define IO_URING_VERSION_MAJOR make[2]: Entering directory '/tmp/release/Debian/liburing/liburing-2.3'
2
make[2]: Leaving directory '/tmp/release/Debian/liburing/liburing-2.3'
#define IO_URING_VERSION_MINOR make[2]: Entering directory '/tmp/release/Debian/liburing/liburing-2.3'
4
make[2]: Leaving directory '/tmp/release/Debian/liburing/liburing-2.3'

#endif
```

The "Entering directory" and "Leaving directory" are generated by make called by configure with these 3 lines:
```
MAKE_PRINT_VARS="include Makefile.common\nprint-%: ; @echo \$(\$*)\n"
VERSION_MAJOR=$(env echo -e "$MAKE_PRINT_VARS" | make -s -f - print-VERSION_MAJOR)
VERSION_MINOR=$(env echo -e "$MAKE_PRINT_VARS" | make -s -f - print-VERSION_MINOR)
```

The fix for this was to add `--no-print-directory` to the `make` parameters.