### PR TITLE
Remove calls to error() from error.h.

### DIFF
--- a/examples/send-zerocopy.c
+++ b/examples/send-zerocopy.c
@@ -5,11 +5,11 @@
 #include <stdint.h>
 #include <assert.h>
 #include <errno.h>
-#include <error.h>
 #include <limits.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdbool.h>
+#include <stdarg.h>
 #include <string.h>
 
 #include <arpa/inet.h>
@@ -57,6 +57,23 @@ static struct sockaddr_storage cfg_dst_addr;
 
 static char payload[IP_MAXPACKET] __attribute__((aligned(4096)));
 
+/*
+ * Implementation of error(3), prints an error message and exits.
+ */
+static void t_error(int status, int errnum, const char *format, ...)
+{
+	va_list args;
+	va_start(args, format);
+
+	vfprintf(stderr, format, args);
+	if (errnum)
+		fprintf(stderr, ": %s", strerror(errnum));
+
+	fprintf(stderr, "\n");
+	va_end(args);
+	exit(status);
+}
+
 static unsigned long gettimeofday_ms(void)
 {
 	struct timeval tv;
@@ -68,7 +85,7 @@ static unsigned long gettimeofday_ms(void)
 static void do_setsockopt(int fd, int level, int optname, int val)
 {
 	if (setsockopt(fd, level, optname, &val, sizeof(val)))
-		error(1, errno, "setsockopt %d.%d: %d", level, optname, val);
+		t_error(1, errno, "setsockopt %d.%d: %d", level, optname, val);
 }
 
 static void setup_sockaddr(int domain, const char *str_addr,
@@ -84,7 +101,7 @@ static void setup_sockaddr(int domain, const char *str_addr,
 		addr4->sin_port = htons(cfg_port);
 		if (str_addr &&
 		    inet_pton(AF_INET, str_addr, &(addr4->sin_addr)) != 1)
-			error(1, 0, "ipv4 parse error: %s", str_addr);
+			t_error(1, 0, "ipv4 parse error: %s", str_addr);
 		break;
 	case PF_INET6:
 		memset(addr6, 0, sizeof(*addr6));
@@ -92,10 +109,10 @@ static void setup_sockaddr(int domain, const char *str_addr,
 		addr6->sin6_port = htons(cfg_port);
 		if (str_addr &&
 		    inet_pton(AF_INET6, str_addr, &(addr6->sin6_addr)) != 1)
-			error(1, 0, "ipv6 parse error: %s", str_addr);
+			t_error(1, 0, "ipv6 parse error: %s", str_addr);
 		break;
 	default:
-		error(1, 0, "illegal domain");
+		t_error(1, 0, "illegal domain");
 	}
 }
 
@@ -105,12 +122,12 @@ static int do_setup_tx(int domain, int type, int protocol)
 
 	fd = socket(domain, type, protocol);
 	if (fd == -1)
-		error(1, errno, "socket t");
+		t_error(1, errno, "socket t");
 
 	do_setsockopt(fd, SOL_SOCKET, SO_SNDBUF, 1 << 21);
 
 	if (connect(fd, (void *) &cfg_dst_addr, cfg_alen))
-		error(1, errno, "connect");
+		t_error(1, errno, "connect");
 	return fd;
 }
 
@@ -125,7 +142,7 @@ static inline struct io_uring_cqe *wait_cqe_fast(struct io_uring *ring)
 
 	ret = io_uring_wait_cqe(ring, &cqe);
 	if (ret)
-		error(1, ret, "wait cqe");
+		t_error(1, ret, "wait cqe");
 	return cqe;
 }
 
@@ -143,17 +160,17 @@ static void do_tx(int domain, int type, int protocol)
 
 	ret = io_uring_queue_init(512, &ring, IORING_SETUP_COOP_TASKRUN);
 	if (ret)
-		error(1, ret, "io_uring: queue init");
+		t_error(1, ret, "io_uring: queue init");
 
 	if (cfg_fixed_files) {
 		ret = io_uring_register_files(&ring, &fd, 1);
 		if (ret < 0)
-			error(1, ret, "io_uring: files registration");
+			t_error(1, ret, "io_uring: files registration");
 	}
 	if (cfg_reg_ringfd) {
 		ret = io_uring_register_ring_fd(&ring);
 		if (ret < 0)
-			error(1, ret, "io_uring: io_uring_register_ring_fd");
+			t_error(1, ret, "io_uring: io_uring_register_ring_fd");
 	}
 
 	iov.iov_base = payload;
@@ -161,7 +178,7 @@ static void do_tx(int domain, int type, int protocol)
 
 	ret = io_uring_register_buffers(&ring, &iov, 1);
 	if (ret)
-		error(1, ret, "io_uring: buffer registration");
+		t_error(1, ret, "io_uring: buffer registration");
 
 	tstop = gettimeofday_ms() + cfg_runtime_ms;
 	do {
@@ -193,14 +210,14 @@ static void do_tx(int domain, int type, int protocol)
 
 		ret = io_uring_submit(&ring);
 		if (ret != cfg_nr_reqs)
-			error(1, ret, "submit");
+			t_error(1, ret, "submit");
 
 		for (i = 0; i < cfg_nr_reqs; i++) {
 			cqe = wait_cqe_fast(&ring);
 
 			if (cqe->flags & IORING_CQE_F_NOTIF) {
 				if (cqe->flags & IORING_CQE_F_MORE)
-					error(1, -EINVAL, "F_MORE notif");
+					t_error(1, -EINVAL, "F_MORE notif");
 				compl_cqes--;
 				i--;
 				io_uring_cqe_seen(&ring, cqe);
@@ -217,7 +234,7 @@ static void do_tx(int domain, int type, int protocol)
 				fprintf(stderr, "Connection failure");
 				goto out_fail;
 			} else if (cqe->res != -EAGAIN) {
-				error(1, cqe->res, "send failed");
+				t_error(1, cqe->res, "send failed");
 			}
 			io_uring_cqe_seen(&ring, cqe);
 		}
@@ -226,7 +243,7 @@ static void do_tx(int domain, int type, int protocol)
 out_fail:
 	shutdown(fd, SHUT_RDWR);
 	if (close(fd))
-		error(1, errno, "close");
+		t_error(1, errno, "close");
 
 	fprintf(stderr, "tx=%lu (MB=%lu), tx/s=%lu (MB/s=%lu)\n",
 			packets, bytes >> 20,
@@ -254,7 +271,7 @@ static void do_test(int domain, int type, int protocol)
 
 static void usage(const char *filepath)
 {
-	error(1, 0, "Usage: %s [-n<N>] [-z<val>] [-s<payload size>] "
+	t_error(1, 0, "Usage: %s [-n<N>] [-z<val>] [-s<payload size>] "
 		    "(-4|-6) [-t<time s>] -D<dst_ip> udp", filepath);
 }
 
@@ -276,13 +293,13 @@ static void parse_opts(int argc, char **argv)
 		switch (c) {
 		case '4':
 			if (cfg_family != PF_UNSPEC)
-				error(1, 0, "Pass one of -4 or -6");
+				t_error(1, 0, "Pass one of -4 or -6");
 			cfg_family = PF_INET;
 			cfg_alen = sizeof(struct sockaddr_in);
 			break;
 		case '6':
 			if (cfg_family != PF_UNSPEC)
-				error(1, 0, "Pass one of -4 or -6");
+				t_error(1, 0, "Pass one of -4 or -6");
 			cfg_family = PF_INET6;
 			cfg_alen = sizeof(struct sockaddr_in6);
 			break;
@@ -311,9 +328,9 @@ static void parse_opts(int argc, char **argv)
 	}
 
 	if (cfg_nr_reqs > MAX_SUBMIT_NR)
-		error(1, 0, "-n: submit batch nr exceeds max (%d)", MAX_SUBMIT_NR);
+		t_error(1, 0, "-n: submit batch nr exceeds max (%d)", MAX_SUBMIT_NR);
 	if (cfg_payload_len > max_payload_len)
-		error(1, 0, "-s: payload exceeds max (%d)", max_payload_len);
+		t_error(1, 0, "-s: payload exceeds max (%d)", max_payload_len);
 
 	setup_sockaddr(cfg_family, daddr, &cfg_dst_addr);
 
@@ -333,7 +350,7 @@ int main(int argc, char **argv)
 	else if (!strcmp(cfg_test, "udp"))
 		do_test(cfg_family, SOCK_DGRAM, 0);
 	else
-		error(1, 0, "unknown cfg_test %s", cfg_test);
+		t_error(1, 0, "unknown cfg_test %s", cfg_test);
 
 	return 0;
 }

--- a/test/defer-taskrun.c
+++ b/test/defer-taskrun.c
@@ -4,7 +4,6 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
-#include <error.h>
 #include <sys/eventfd.h>
 #include <signal.h>
 #include <poll.h>

--- a/test/helpers.c
+++ b/test/helpers.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <stdarg.h>
 #include <sys/types.h>
 
 #include <arpa/inet.h>
@@ -299,4 +300,21 @@ unsigned __io_uring_flush_sq(struct io_uring *ring)
 	 * situation regardless of any perceived atomicity.
 	 */
 	return tail - *sq->khead;
+}
+
+/*
+ * Implementation of error(3), prints an error message and exits.
+ */
+void t_error(int status, int errnum, const char *format, ...)
+{
+	va_list args;
+    	va_start(args, format);
+
+	vfprintf(stderr, format, args);
+    	if (errnum)
+        	fprintf(stderr, ": %s", strerror(errnum));
+
+	fprintf(stderr, "\n");
+	va_end(args);
+    	exit(status);
 }

--- a/test/helpers.h
+++ b/test/helpers.h
@@ -89,6 +89,8 @@ unsigned __io_uring_flush_sq(struct io_uring *ring);
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 
+void t_error(int status, int errnum, const char *format, ...);
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/poll.c
+++ b/test/poll.c
@@ -11,7 +11,6 @@
 #include <signal.h>
 #include <poll.h>
 #include <sys/wait.h>
-#include <error.h>
 #include <assert.h>
 
 #include "helpers.h"
@@ -20,7 +19,7 @@
 static void do_setsockopt(int fd, int level, int optname, int val)
 {
 	if (setsockopt(fd, level, optname, &val, sizeof(val)))
-		error(1, errno, "setsockopt %d.%d: %d", level, optname, val);
+		t_error(1, errno, "setsockopt %d.%d: %d", level, optname, val);
 }
 
 static bool check_cq_empty(struct io_uring *ring)

--- a/test/send-zerocopy.c
+++ b/test/send-zerocopy.c
@@ -4,7 +4,6 @@
 #include <stdint.h>
 #include <assert.h>
 #include <errno.h>
-#include <error.h>
 #include <limits.h>
 #include <fcntl.h>
 #include <unistd.h>

--- a/test/single-issuer.c
+++ b/test/single-issuer.c
@@ -5,7 +5,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
-#include <error.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 
@@ -56,13 +55,13 @@ static int try_submit(struct io_uring *ring)
 		return ret;
 
 	if (ret != 1)
-		error(1, ret, "submit %i", ret);
+		t_error(1, ret, "submit %i", ret);
 	ret = io_uring_wait_cqe(ring, &cqe);
 	if (ret)
-		error(1, ret, "wait fail %i", ret);
+		t_error(1, ret, "wait fail %i", ret);
 
 	if (cqe->res || cqe->user_data != 42)
-		error(1, ret, "invalid cqe");
+		t_error(1, ret, "invalid cqe");
 
 	io_uring_cqe_seen(ring, cqe);
 	return 0;
@@ -105,7 +104,7 @@ int main(int argc, char *argv[])
 	ret = io_uring_queue_init(8, &ring, IORING_SETUP_SINGLE_ISSUER |
 					    IORING_SETUP_R_DISABLED);
 	if (ret)
-		error(1, ret, "ring init (2) %i", ret);
+		t_error(1, ret, "ring init (2) %i", ret);
 
 	if (!fork_t()) {
 		io_uring_enable_rings(&ring);
@@ -121,7 +120,7 @@ int main(int argc, char *argv[])
 	ret = io_uring_queue_init(8, &ring, IORING_SETUP_SINGLE_ISSUER |
 					    IORING_SETUP_R_DISABLED);
 	if (ret)
-		error(1, ret, "ring init (3) %i", ret);
+		t_error(1, ret, "ring init (3) %i", ret);
 
 	io_uring_enable_rings(&ring);
 	if (!fork_t()) {
@@ -136,7 +135,7 @@ int main(int argc, char *argv[])
 	/* test that anyone can submit to a SQPOLL|SINGLE_ISSUER ring */
 	ret = io_uring_queue_init(8, &ring, IORING_SETUP_SINGLE_ISSUER|IORING_SETUP_SQPOLL);
 	if (ret)
-		error(1, ret, "ring init (4) %i", ret);
+		t_error(1, ret, "ring init (4) %i", ret);
 
 	ret = try_submit(&ring);
 	if (ret) {
@@ -156,7 +155,7 @@ int main(int argc, char *argv[])
 	/* test that IORING_ENTER_REGISTERED_RING doesn't break anything */
 	ret = io_uring_queue_init(8, &ring, IORING_SETUP_SINGLE_ISSUER);
 	if (ret)
-		error(1, ret, "ring init (5) %i", ret);
+		t_error(1, ret, "ring init (5) %i", ret);
 
 	if (!fork_t()) {
 		ret = try_submit(&ring);


### PR DESCRIPTION
On musl systems, liburing cannot build examples and tests due to it's usage of error.h. Replace all calls to error() with fprintf(stderr, ...) and exit(1).

Closes: #786

Signed-off-by: Steffen Winter <steffen.winter@proton.me>

