### PR TITLE
Add register functions man pages (buffers and files)

### DIFF
--- a/man/io_uring_register_buffers.3
+++ b/man/io_uring_register_buffers.3
@@ -9,12 +9,23 @@ io_uring_register_buffers \- register buffers for fixed buffer operations
 .nf
 .B #include <liburing.h>
 .PP
-.BI "int io_uring_register_buffers(struct io_uring *" ring ",
-.BI "                              const struct iovec *" iovecs ",
+.BI "int io_uring_register_buffers(struct io_uring *" ring ","
+.BI "                              const struct iovec *" iovecs ","
 .BI "                              unsigned " nr_iovecs ");"
 .PP
-.BI "int io_uring_register_buffers_sparse(struct io_uring *" ring ",
-.BI "                              unsigned " nr_iovecs ");"
+.BI "int io_uring_register_buffers_tags(struct io_uring *" ring ","
+.BI "                                   const struct iovec *" iovecs ","
+.BI "                                   const __u64 *" tags ","
+.BI "                                   unsigned " nr ");"
+.PP
+.BI "int io_uring_register_buffers_sparse(struct io_uring *" ring ","
+.BI "                                     unsigned " nr_iovecs ");"
+.PP
+.BI "int io_uring_register_buffers_update_tag(struct io_uring *" ring ","
+.BI "                                         unsigned " off ","
+.BI "                                         const struct iovec *" iovecs ","
+.BI "                                         const __u64 *" tags ","
+.BI "                                         unsigned " nr ");"
 .fi
 .SH DESCRIPTION
 .PP
@@ -26,6 +37,16 @@ number of buffers defined by the array
 .I iovecs
 belonging to the
 .IR ring .
+
+The
+.BR io_uring_register_buffers_tags (3)
+function behaves the same as 
+.BR io_uring_register_buffers (3)
+function but additionally takes 
+.I tags
+parameter. See
+.B IORING_REGISTER_BUFFERS2
+for the resource tagging description.
 
 The
 .BR io_uring_register_buffers_sparse (3)
@@ -46,14 +67,36 @@ the buffer is registered rather than doing a map and unmap for each IO
 every time IO is performed to that region. Additionally, it also avoids
 manipulating the page reference counts for each IO.
 
+The
+.BR io_uring_register_buffers_update_tag (3)
+function updates registered buffers with new ones, either turning a sparse 
+entry into a real one, or replacing an existing entry. The 
+.I off
+is offset on which to start the update
+.I nr
+number of buffers defined by the array
+.I iovecs
+belonging to the
+.IR ring .
+The
+.I tags
+points to an array of tags. See
+.B IORING_REGISTER_BUFFERS2
+for the resource tagging description.
+
 .SH RETURN VALUE
 On success
-.BR io_uring_register_buffers (3)
+.BR io_uring_register_buffers (3),
+.BR io_uring_register_buffers_tags (3)
 and
 .BR io_uring_register_buffers_sparse (3)
-return 0. On failure they return
+return 0. 
+.BR io_uring_register_buffers_update_tag (3)
+return number of buffers updated.
+On failure they return
 .BR -errno .
 .SH SEE ALSO
+.BR io_uring_register (2),
 .BR io_uring_get_sqe (3),
 .BR io_uring_unregister_buffers (3),
 .BR io_uring_register_buf_ring (3),

--- a/man/io_uring_register_buffers_sparse.3
+++ b/man/io_uring_register_buffers_sparse.3
@@ -1,0 +1,1 @@
+io_uring_register_buffers.3

--- a/man/io_uring_register_buffers_tags.3
+++ b/man/io_uring_register_buffers_tags.3
@@ -1,0 +1,1 @@
+io_uring_register_buffers.3

--- a/man/io_uring_register_buffers_update_tag.3
+++ b/man/io_uring_register_buffers_update_tag.3
@@ -1,0 +1,1 @@
+io_uring_register_buffers.3

--- a/man/io_uring_register_files.3
+++ b/man/io_uring_register_files.3
@@ -13,8 +13,24 @@ io_uring_register_files \- register file descriptors
 .BI "                            const int *" files ","
 .BI "                            unsigned " nr_files ");"
 .PP
+.BI "int io_uring_register_files_tags(struct io_uring *" ring ","
+.BI "                                 const int *" files ","
+.BI "                                 const __u64 *" tags ","
+.BI "                                 unsigned " nr ");"
+.PP
 .BI "int io_uring_register_files_sparse(struct io_uring *" ring ","
-.BI "                            unsigned " nr_files ");"
+.BI "                                   unsigned " nr_files ");"
+.PP
+.BI "int io_uring_register_files_update(struct io_uring *" ring ","
+.BI "                                   unsigned " off ","
+.BI "                                   const int *" files ","
+.BI "                                   unsigned " nr_files ");"
+.PP
+.BI "int io_uring_register_files_update_tag(struct io_uring *" ring ","
+.BI "                                   unsigned " off ","
+.BI "                                   const int *" files ","
+.BI "                                   const __u64 *" tags ","
+.BI "                                   unsigned " nr_files ");"
 .fi
 .SH DESCRIPTION
 .PP
@@ -29,11 +45,22 @@ belonging to the
 for subsequent operations.
 
 The
+.BR io_uring_register_files_tags (3)
+function behaves the same as 
+.BR io_uring_register_files (3)
+function but additionally takes 
+.I tags
+parameter. See
+.B IORING_REGISTER_BUFFERS2
+for the resource tagging description.
+
+The
 .BR io_uring_register_files_sparse (3)
 function registers an empty file table of
 .I nr_files
-number of file descriptors. The sparse variant is available in kernels 5.19
-and later.
+number of file descriptors. These files must be updated before use, using eg
+.BR io_uring_register_files_update_tag (3).
+The sparse variant is available in kernels 5.19 and later.
 
 Registering a file table is a prerequisite for using any request that uses
 direct descriptors.
@@ -45,13 +72,41 @@ shared, for example if the process has ever created any threads, then this
 cost goes up even more. Using registered files reduces the overhead of
 file reference management across requests that operate on a file.
 
+The 
+.BR io_uring_register_files_update (3) 
+function updates existing registered files. The 
+.I off
+is offset on which to start the update
+.I nr_files
+number of files defined by the array
+.I files
+belonging to the
+.IR ring .
+
+The 
+.BR io_uring_register_files_update_tag (3)
+function behaves the same as 
+.BR io_uring_register_files_update (3) 
+function but additionally takes 
+.I tags
+parameter. See 
+.B IORING_REGISTER_BUFFERS2
+for the resource tagging description.
+
 .SH RETURN VALUE
 On success
-.BR io_uring_register_files (3)
+.BR io_uring_register_files (3),
+.BR io_uring_register_files_tags (3)
 and
 .BR io_uring_register_files_sparse (3)
-return 0. On failure they return
+return 0. 
+.BR io_uring_register_files_update (3)
+and
+.BR io_uring_register_files_update_tag (3)
+return number of files updated.
+On failure they return
 .BR -errno .
 .SH SEE ALSO
+.BR io_uring_register (2),
 .BR io_uring_get_sqe (3),
 .BR io_uring_unregister_files (3)

--- a/man/io_uring_register_files_tags.3
+++ b/man/io_uring_register_files_tags.3
@@ -1,0 +1,1 @@
+io_uring_register_files.3

--- a/man/io_uring_register_files_update.3
+++ b/man/io_uring_register_files_update.3
@@ -1,0 +1,1 @@
+io_uring_register_files.3

--- a/man/io_uring_register_files_update_tag.3
+++ b/man/io_uring_register_files_update_tag.3
@@ -1,0 +1,1 @@
+io_uring_register_files.3


### PR DESCRIPTION
Adds man pages for following register functions (part of https://github.com/axboe/liburing/issues/777):

- io_uring_register_buffers_sparse
- io_uring_register_buffers_update_tag
- io_uring_register_buffers_tags
- io_uring_register_files_tags
- io_uring_register_files_update
- io_uring_register_files_update_tag