### PR TITLE
[GIT PULL] document that shutdown processing may run asynchronously

### DIFF
--- a/man/io_uring_register.2
+++ b/man/io_uring_register.2
@@ -101,7 +101,9 @@ If the application currently has requests in-flight, the registration will
 wait for those to finish before proceeding.
 
 An application need not unregister buffers explicitly before shutting
-down the io_uring instance. Available since 5.1.
+down the io_uring instance. Note, however, that shutdown processing may run
+asynchronously within the kernel. As a result, it is not guaranteed that
+pages are immediately unpinned in this case. Available since 5.1.
 
 .TP
 .B IORING_REGISTER_BUFFERS2
@@ -201,7 +203,7 @@ Available since 5.13.
 This operation takes no argument, and
 .I arg
 must be passed as NULL.  All previously registered buffers associated
-with the io_uring instance will be released. Available since 5.1.
+with the io_uring instance will be released synchronously. Available since 5.1.
 
 .TP
 .B IORING_REGISTER_FILES

--- a/man/io_uring_setup.2
+++ b/man/io_uring_setup.2
@@ -610,7 +610,9 @@ ptr = mmap(0, cq_off.cqes + cq_entries * sizeof(struct io_uring_cqe),
 .PP
 Closing the file descriptor returned by
 .BR io_uring_setup (2)
-will free all resources associated with the io_uring context.
+will free all resources associated with the io_uring context. Note that this
+may happen asynchronously within the kernel, so it is not guaranteed that
+resources are freed immediately.
 .PP
 .SH RETURN VALUE
 .BR io_uring_setup (2)


### PR DESCRIPTION
This PR adds some documentation that shutdown processing after closing the io_uring file descriptor runs asynchronously.

This does not matter in most cases, but can lead to unexpected behavior if users previously registered some buffers that they did not explicitly unregister. In this case the pinned pages have not necessarily been unpinned yet when the close call returns, and subsequently setting up another io_uring instance with registered buffers may fail when running with a tight RLIMIT_MEMLOCK limit.

----
## git request-pull output:
```
The following changes since commit 0c020c66a413980e237a22f8620fa8e22150a6b5:

  man/io_uring_prep_timeout_update: add note that remove doesn't take flags (2023-03-25 07:55:37 -0600)

are available in the Git repository at:

  git@github.com:freitmi/liburing.git 

for you to fetch changes up to 0ba9f4d8d9d768c197ace81665251dbff520f19e:

  man: document that shutdown processing may run asynchronously (2023-03-28 09:42:42 +0200)

----------------------------------------------------------------
Michael Freitag (1):
      man: document that shutdown processing may run asynchronously

 man/io_uring_register.2 | 6 ++++--
 man/io_uring_setup.2    | 4 +++-
 2 files changed, 7 insertions(+), 3 deletions(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
