### PR TITLE
[GIT PULL] Bugfixes for pre-allocated ring support

### DIFF
--- a/man/io_uring_queue_init.3
+++ b/man/io_uring_queue_init.3
@@ -17,6 +17,11 @@ io_uring_queue_init \- setup io_uring submission and completion queues
 .BI "int io_uring_queue_init_params(unsigned " entries ","
 .BI "                               struct io_uring *" ring ","
 .BI "                               struct io_uring_params *" params ");"
+.PP
+.BI "int io_uring_queue_init_mem(unsigned " entries ","
+.BI "                            struct io_uring *" ring ","
+.BI "                            struct io_uring_params *" params ","
+.BI "                            void *" buf ", size_t " buf_size ");"
 .fi
 .SH DESCRIPTION
 .PP
@@ -65,13 +70,34 @@ is returned.
 will be passed through to the io_uring_setup syscall (see
 .BR io_uring_setup (2)).
 
-If the
+The
 .BR io_uring_queue_init_params (3)
-variant is used, then the parameters indicated by
+and
+.BR io_uring_queue_init_mem (3)
+variants will pass the parameters indicated by
 .I params
-will be passed straight through to the
+straight through to the
 .BR io_uring_setup (2)
 system call.
+
+The
+.BR io_uring_queue_init_mem (3)
+variant uses the provided
+.I buf
+with associated size
+.I buf_size
+as the memory for the ring, using the
+.B IORING_SETUP_NO_MMAP
+flag to
+.BR io_uring_setup (2).
+.BR io_uring_queue_init_mem (3)
+zeroes the memory it uses.
+Typically, the caller should allocate a huge page and pass that in to
+.BR io_uring_queue_init_mem (3).
+.BR io_uring_queue_init_mem (3)
+returns the number of bytes used from the provided buffer, so that the app can
+reuse the buffer with the returned offset to put more rings in the same huge
+page.
 
 On success, the resources held by
 .I ring
@@ -79,7 +105,14 @@ should be released via a corresponding call to
 .BR io_uring_queue_exit (3).
 .SH RETURN VALUE
 .BR io_uring_queue_init (3)
-returns 0 on success and
+and
+.BR io_uring_queue_init_params (3)
+return 0 on success and
+.BR -errno
+on failure.
+
+.BR io_uring_queue_init_mem (3)
+returns the number of bytes used from the provided buffer on success, and
 .BR -errno
 on failure.
 .SH SEE ALSO

--- a/man/io_uring_queue_init.3
+++ b/man/io_uring_queue_init.3
@@ -90,10 +90,12 @@ as the memory for the ring, using the
 .B IORING_SETUP_NO_MMAP
 flag to
 .BR io_uring_setup (2).
+The buffer passed to
 .BR io_uring_queue_init_mem (3)
-zeroes the memory it uses.
+must already be zeroed.
 Typically, the caller should allocate a huge page and pass that in to
 .BR io_uring_queue_init_mem (3).
+Pages allocated by mmap are already zeroed.
 .BR io_uring_queue_init_mem (3)
 returns the number of bytes used from the provided buffer, so that the app can
 reuse the buffer with the returned offset to put more rings in the same huge

--- a/man/io_uring_queue_init_mem.3
+++ b/man/io_uring_queue_init_mem.3
@@ -1,0 +1,1 @@
+io_uring_queue_init.3

--- a/src/setup.c
+++ b/src/setup.c
@@ -218,6 +218,8 @@ static int io_uring_alloc_huge(unsigned entries, struct io_uring_params *p,
 	sqes_mem = sq_entries * sizeof(struct io_uring_sqe);
 	sqes_mem = (sqes_mem + page_size - 1) & ~(page_size - 1);
 	ring_mem = cq_entries * sizeof(struct io_uring_cqe);
+	if (p->flags & IORING_SETUP_CQE32)
+		ring_mem *= 2;
 	ring_mem += sq_entries * sizeof(unsigned);
 	mem_used = sqes_mem + ring_mem;
 	mem_used = (mem_used + page_size - 1) & ~(page_size - 1);

--- a/src/setup.c
+++ b/src/setup.c
@@ -227,6 +227,7 @@ static int io_uring_alloc_huge(unsigned entries, struct io_uring_params *p,
 	if (buf) {
 		if (mem_used > buf_size)
 			return -ENOMEM;
+		memset(buf, 0, mem_used);
 		ptr = buf;
 	} else {
 		ptr = __sys_mmap(NULL, huge_page_size, PROT_READ|PROT_WRITE,
@@ -239,7 +240,6 @@ static int io_uring_alloc_huge(unsigned entries, struct io_uring_params *p,
 	}
 
 	sq->sqes = ptr;
-	memset(ptr, 0, buf_size);
 	if (mem_used <= buf_size) {
 		sq->ring_ptr = (void *) sq->sqes + sqes_mem;
 		/* clear ring sizes, we have just one mmap() to undo */
@@ -253,7 +253,6 @@ static int io_uring_alloc_huge(unsigned entries, struct io_uring_params *p,
 			__sys_munmap(sq->sqes, buf_size);
 			return PTR_ERR(ptr);
 		}
-		memset(ptr, 0, buf_size);
 		sq->ring_ptr = ptr;
 		sq->ring_sz = buf_size;
 		cq->ring_sz = 0;

--- a/src/setup.c
+++ b/src/setup.c
@@ -237,7 +237,6 @@ static int io_uring_alloc_huge(unsigned entries, struct io_uring_params *p,
 	if (buf) {
 		if (mem_used > buf_size)
 			return -ENOMEM;
-		memset(buf, 0, mem_used);
 		ptr = buf;
 	} else {
 		int map_hugetlb = 0;


### PR DESCRIPTION
The new preallocated ring support calculated the memory it needed in two
places, and the two calculations didn't match. Unify the two calculations to
prevent this.

The size calculation also didn't take `IORING_SETUP_CQE32` into account.
(This calculation should probably get unified across the various setup functions.)

In the `IORING_SETUP_CQE32` case, it was also possible to overrun a 2MB huge page;
detect and handle that case.

Use a normal-sized page if that suffices for the queue sizes, to save memory
and to work automatically on systems that don't have huge pages configured
(e.g. where `nr_hugepages` and `nr_overcommit_hugepages` still have their
default value of 0). For 4096-byte pages, this allows a queue size of 64 to fit
within two normal page allocations, and a queue size of 32 to fit within one normal
page allocation. This should allow many users of io_uring to avoid requiring huge
pages.

The preallocated ring support also zeroed memory freshly allocated from mmap,
which is redundant; memory allocated by mmap is already zeroed.

The last commit also changes `io_uring_queue_init_mem` to avoid zeroing the
caller-provided buffer, since that function recommends that the user allocate
memory by `mmap`ing a huge page. I'm making the assumption that nobody has
started using `io_uring_queue_init_mem` yet, so it's safe to change that aspect
of the API. If that's not the case, leave out the last commit.

----
```
The following changes since commit d39530a3f4b52ff2fab653eb3b2314e0aedc2d92:

  Merge branch 'huge.2' (2023-06-09 11:29:05 -0600)

are available in the Git repository at:

  https://github.com/joshtriplett/liburing setup-preallocated-cleanup

for you to fetch changes up to 6a1ca1dd9f0a2745f110d3605b3ca6b02bac2844:

  setup: Expect pre-zeroed memory in io_uring_queue_init_mem (2023-06-09 20:37:47 -0700)

----------------------------------------------------------------
Josh Triplett (7):
      setup: Fix and unify ring size calculation for preallocated ring
      setup: Account for IORING_SETUP_CQE32 for the preallocated ring case
      setup: Avoid zeroing a freshly mapped MAP_ANONYMOUS page
      setup: Avoid overrunning the CQ/SQ huge page
      man: Add documentation for io_uring_queue_init_mem
      setup: Use non-huge pages if sufficient for the queue sizes
      setup: Expect pre-zeroed memory in io_uring_queue_init_mem

 man/io_uring_queue_init.3     | 43 +++++++++++++++++++++++++++++++++++++++----
 man/io_uring_queue_init_mem.3 |  1 +
 src/setup.c                   | 55 ++++++++++++++++++++++++++++++++++++-------------------
 3 files changed, 76 insertions(+), 23 deletions(-)
 create mode 120000 man/io_uring_queue_init_mem.3
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
