### PR TITLE
[GIT PULL] Support IORING_SETUP_REGISTERED_FD_ONLY

### DIFF
--- a/man/io_uring_setup.2
+++ b/man/io_uring_setup.2
@@ -300,6 +300,23 @@ Note that if this flag is set then it is the application's responsibility to per
 trigger work (for example via any of the CQE waiting functions) or else completions may
 not be delivered.
 Available since 6.1.
+.TP
+.B IORING_SETUP_NO_MMAP
+By default, io_uring allocates kernel memory that callers must subsequently
+.BR mmap (2).
+If this flag is set, io_uring instead uses caller-allocated buffers;
+.I p->cq_off.user_data
+must point to the memory for the sq/cq rings, and
+.I p->sq_off.user_data
+must point to the memory for the sqes.
+Each allocation must be contiguous memory.
+Typically, callers should allocate this memory by using
+.BR mmap (2)
+to allocate a huge page.
+If this flag is set, a subsequent attempt to
+.BR mmap (2)
+the io_uring file descriptor will fail.
+
 .PP
 If no flags are specified, the io_uring instance is setup for
 interrupt driven I/O.  I/O may be submitted using

--- a/man/io_uring_setup.2
+++ b/man/io_uring_setup.2
@@ -316,6 +316,14 @@ to allocate a huge page.
 If this flag is set, a subsequent attempt to
 .BR mmap (2)
 the io_uring file descriptor will fail.
+.TP
+.B IORING_SETUP_REGISTERED_FD_ONLY
+If this flag is set, io_uring will register the ring file descriptor, and
+return the registered descriptor index, without ever allocating an unregistered
+file descriptor. The caller will need to use
+.B IORING_REGISTER_USE_REGISTERED_RING
+when calling
+.BR io_uring_register (2).
 
 .PP
 If no flags are specified, the io_uring instance is setup for

--- a/src/include/liburing/io_uring.h
+++ b/src/include/liburing/io_uring.h
@@ -178,6 +178,13 @@ enum {
  */
 #define IORING_SETUP_NO_MMAP		(1U << 14)
 
+/*
+ * Register the ring fd in itself for use with
+ * IORING_REGISTER_USE_REGISTERED_RING; return a registered fd index rather
+ * than an fd.
+ */
+#define IORING_SETUP_REGISTERED_FD_ONLY	(1U << 15)
+
 enum io_uring_op {
 	IORING_OP_NOP,
 	IORING_OP_READV,

--- a/test/Makefile
+++ b/test/Makefile
@@ -142,6 +142,7 @@ test_srcs := \
 	recv-msgall.c \
 	recv-msgall-stream.c \
 	recv-multishot.c \
+	reg-fd-only.c \
 	reg-hint.c \
 	reg-reg-ring.c \
 	regbuf-merge.c \

--- a/test/reg-fd-only.c
+++ b/test/reg-fd-only.c
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Test io_uring_setup with IORING_SETUP_REGISTERED_FD_ONLY
+ *
+ */
+#include <stdio.h>
+
+#include "helpers.h"
+
+int main(int argc, char *argv[])
+{
+	struct io_uring ring;
+	unsigned values[2];
+	int ret;
+
+	if (argc > 1)
+		return T_EXIT_SKIP;
+
+	ret = io_uring_queue_init(8, &ring, IORING_SETUP_REGISTERED_FD_ONLY | IORING_SETUP_NO_MMAP);
+	if (ret) {
+		fprintf(stderr, "ring setup failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	ret = io_uring_register_ring_fd(&ring);
+	if (ret != -EEXIST) {
+		fprintf(stderr, "registering already-registered ring fd should fail\n");
+		goto err;
+	}
+
+	ret = io_uring_close_ring_fd(&ring);
+	if (ret != -EBADF) {
+		fprintf(stderr, "closing already-closed ring fd should fail\n");
+		goto err;
+	}
+
+	/* Test a simple io_uring_register operation expected to work.
+	 * io_uring_register_iowq_max_workers is arbitrary.
+	 */
+	values[0] = values[1] = 0;
+	ret = io_uring_register_iowq_max_workers(&ring, values);
+	if (ret || (values[0] == 0 && values[1] == 0)) {
+		fprintf(stderr, "io_uring_register operation failed after closing ring fd\n");
+		goto err;
+	}
+
+	io_uring_queue_exit(&ring);
+	return T_EXIT_PASS;
+
+err:
+	io_uring_queue_exit(&ring);
+	return T_EXIT_FAIL;
+}


### PR DESCRIPTION
This adds support for passing
`IORING_SETUP_REGISTERED_FD_ONLY | IORING_SETUP_NO_MMAP`
to any of the queue init functions.

----
## git request-pull output:
```
The following changes since commit d39530a3f4b52ff2fab653eb3b2314e0aedc2d92:

  Merge branch 'huge.2' (2023-06-09 11:29:05 -0600)

are available in the Git repository at:

  https://github.com/joshtriplett/liburing setup-registered-fd-only

for you to fetch changes up to 08e261a7f56a1d22f9e36c97ff33ea56c5e6f288:

  Add test for IORING_SETUP_REGISTERED_FD_ONLY (2023-06-09 18:16:25 -0700)

----------------------------------------------------------------
Josh Triplett (5):
      io_uring.h: Update to include IORING_SETUP_REGISTERED_FD_ONLY
      man/io_uring_setup.2: Document IORING_SETUP_NO_MMAP
      man/io_uring_setup.2: Document IORING_SETUP_REGISTERED_FD_ONLY
      setup: Support IORING_SETUP_REGISTERED_FD_ONLY
      Add test for IORING_SETUP_REGISTERED_FD_ONLY

 man/io_uring_setup.2            | 25 +++++++++++++++++++++++++
 src/include/liburing/io_uring.h |  7 +++++++
 src/setup.c                     | 17 ++++++++++++++++-
 test/Makefile                   |  1 +
 test/reg-fd-only.c              | 53 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 5 files changed, 102 insertions(+), 1 deletion(-)
 create mode 100644 test/reg-fd-only.c
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
