### PR TITLE
[GIT PULL] Fix build system issues with undefined symbols

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@ override CFLAGS += -Wno-unused-parameter \
 	$(LIBURING_CFLAGS)
 SO_CFLAGS=-fPIC $(CFLAGS)
 L_CFLAGS=$(CFLAGS)
-LINK_FLAGS=
+LINK_FLAGS=-Wl,-z,defs
 LINK_FLAGS+=$(LDFLAGS)
 ENABLE_SHARED ?= 1
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,8 +10,9 @@ CPPFLAGS ?=
 override CPPFLAGS += -D_GNU_SOURCE \
 	-Iinclude/ -include ../config-host.h \
 	-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
-CFLAGS ?= -g -O3 -Wall -Wextra -fno-stack-protector
+CFLAGS ?= -g -O3 -Wall -Wextra
 override CFLAGS += -Wno-unused-parameter \
+	-fno-stack-protector \
 	-DLIBURING_INTERNAL \
 	$(LIBURING_CFLAGS)
 SO_CFLAGS=-fPIC $(CFLAGS)


### PR DESCRIPTION
This fixes the build system to avoid undefined symbols that can appear due to compiler injecting calls to libc or compiler support functions (even though in principle we are disabling these in the build system). In particular this was an issue with the stack protection support.

----
## git request-pull output:
```
The following changes since commit 76ce6f509e76df7547f051d59b8f883ea01c8cab:

  Revert "setup: unify queue exit path" (2023-06-12 12:30:41 -0600)

are available in the Git repository at:

  https://github.com/guillemj/liburing pu/build-undef-syms

for you to fetch changes up to 9a127c05dd3b9fd0e4967c8d59d549706e89607f:

  build: Fail the build if we have undefined symbols (2023-06-13 01:28:26 +0200)

----------------------------------------------------------------
Guillem Jover (2):
      build: Disable stack protector unconditionally
      build: Fail the build if we have undefined symbols

 src/Makefile | 5 +++--
 1 file changed, 3 insertions(+), 2 deletions(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
