### PR TITLE
[GIT PULL] test/reg-fd-only: skip on older kernels

### DIFF
--- a/test/reg-fd-only.c
+++ b/test/reg-fd-only.c
@@ -17,7 +17,9 @@ int main(int argc, char *argv[])
 		return T_EXIT_SKIP;
 
 	ret = io_uring_queue_init(8, &ring, IORING_SETUP_REGISTERED_FD_ONLY | IORING_SETUP_NO_MMAP);
-	if (ret) {
+	if (ret == -EINVAL)
+		return T_EXIT_SKIP;
+	else if (ret) {
 		fprintf(stderr, "ring setup failed\n");
 		return T_EXIT_FAIL;
 	}


### PR DESCRIPTION
The reg-fd-only test fails on older kernels without IORING_SETUP_REGISTERED_FD_ONLY defined.

This change skips the test if io_uring_queue_init returns EINVAL.

----
## git request-pull output:
```
The following changes since commit b3abdd798db6b6bfee6acac7ba1ee6698cc503ae:

  Merge branch 'pu/build-undef-syms' of https://github.com/guillemj/liburing (2023-06-12 18:41:25 -0600)

are available in the Git repository at:

  https://github.com/spikeh/liburing fix_reg_fd_only_test

for you to fetch changes up to 75642b285a06a5715a62d0f7d62dd732ca0e9dfa:

  test/reg-fd-only: skip on older kernels (2023-06-13 15:08:55 -0700)

----------------------------------------------------------------
David Wei (1):
      test/reg-fd-only: skip on older kernels

 test/reg-fd-only.c | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
