### PR TITLE
[GIT PULL] io_uring_enter2.2: add EEXIST to errors

### DIFF
--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -1541,6 +1541,9 @@ occur if the application tries to queue more requests than we have room for in
 the CQ ring, or if the application attempts to wait for more events without
 having reaped the ones already present in the CQ ring.
 .TP
+.B EEXIST
+The thread submitting the work is invalid.
+.TP
 .B EINVAL
 Some bits in the
 .I flags

--- a/man/io_uring_register.2
+++ b/man/io_uring_register.2
@@ -758,6 +758,9 @@ or
 was specified, but there were already buffers, files, or restrictions
 registered.
 .TP
+.B EEXIST
+The thread performing the registration is invalid.
+.TP
 .B EFAULT
 buffer is outside of the process' accessible address space, or
 .I iov_len


### PR DESCRIPTION
EEXIST can arise in io_run_local_work, io_iopoll_check(), and io_cqring_wait(). In all cases, it seems due to the wrong thread being involved.

It looks like this can happen for io_uring_register() as well, so add it there, too.


## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).


----
## git request-pull output:
```
The following changes since commit 1e81a9a5943ba20dc68ef2b3269dc286d00f7c13:

  test/coredump: make it explicit that the child is not returning (2023-06-15 14:10:18 -0600)

are available in the Git repository at:

  https://github.com/dankamongmen/liburing/ dankamongmen/enter-eexist

for you to fetch changes up to 0a5ef60967efa8d3d1f4eb70b69bc27cf3020a54:

  io_uring_enter2.2: add EEXIST to errors (2023-06-18 00:07:57 -0400)

----------------------------------------------------------------
nick black (1):
      io_uring_enter2.2: add EEXIST to errors

 man/io_uring_enter.2    | 3 +++
 man/io_uring_register.2 | 3 +++
 2 files changed, 6 insertions(+)
----
