### PR TITLE
[GIT PULL] Minor Build Failure Fixes

### DIFF
--- a/configure
+++ b/configure
@@ -468,6 +468,8 @@ echo "CXX=$cxx" >> $config_host_mak
 print_config "CXX" "$cxx"
 
 # generate io_uring_version.h
+# Reset MAKEFLAGS
+MAKEFLAGS=
 MAKE_PRINT_VARS="include Makefile.common\nprint-%: ; @echo \$(\$*)\n"
 VERSION_MAJOR=$(env echo -e "$MAKE_PRINT_VARS" | make -s --no-print-directory -f - print-VERSION_MAJOR)
 VERSION_MINOR=$(env echo -e "$MAKE_PRINT_VARS" | make -s --no-print-directory -f - print-VERSION_MINOR)

--- a/src/Makefile
+++ b/src/Makefile
@@ -81,7 +81,7 @@ liburing-ffi.a: $(liburing_objs) $(liburing_ffi_objs)
 $(libname): $(liburing_sobjs) liburing.map
 	$(QUIET_CC)$(CC) $(SO_CFLAGS) -shared -Wl,--version-script=liburing.map -Wl,-soname=$(soname) -o $@ $(liburing_sobjs) $(LINK_FLAGS)
 
-$(ffi_libname): $(liburing_ffi_objs) $(liburing_ffi_sobjs) liburing-ffi.map
+$(ffi_libname): $(liburing_ffi_objs) $(liburing_ffi_sobjs) $(liburing_sobjs) liburing-ffi.map
 	$(QUIET_CC)$(CC) $(SO_CFLAGS) -shared -Wl,--version-script=liburing-ffi.map -Wl,-soname=$(ffi_soname) -o $@ $(liburing_sobjs) $(liburing_ffi_sobjs) $(LINK_FLAGS)
 
 install: $(all_targets)


### PR DESCRIPTION
Noticed 2 minor independent build failures
1.  Run `make --trace` without the configure step.
    This causes make to build the target `config-host.mak` which
    in turn invokes configure which generates an incorrect
    `io_uring_version.h` file.
    Fixed by setting `MAKEFLAGS=`
    before generating `io_uring_version.h` file in the configure script

 2. `/configure && make --shuffle=2836571325`
     fails.
    The build fails on parallel builds for me and the above command reproduces it.
    Note that `--shuffle`options is available on make version >= 4.4
    Target `ffi_libname` in `src/Makefile` should have an additional dependency
    upon `$(liburing_sobjs)`
    
`make -n` also breaks but don't want to clutter this patch. If you give a go ahead, will fix that too.

----
## git request-pull output:
```
The following changes since commit 2d3368b73b478a737b2247ef5630be56c3b176b5:

  test/io_uring_register: fix errno confusion and new error (2023-06-28 19:43:02 -0600)

are available in the Git repository at:

  https://github.com/stonebrakert6/liburing master

for you to fetch changes up to b5f3dcfe210b83700566cf68484913f8c62c9be7:

  Fixes build failure on ./configure && make --shuffle=2836571325 ./configure && make --shuffle=2836571325 fails. The build fails on parallel builds for me and above command reproduces it. Note that --shuffle options is available on make version >= 4.4 Target ffi_libname in src/Makefile should have a additional dependency upon $(liburing_sobjs) (2023-06-30 11:34:07 +0530)

----------------------------------------------------------------
stonebrakert6 (2):
      Fixes make --trace
      Fixes build failure on ./configure && make --shuffle=2836571325 ./configure && make --shuffle=2836571325 fails. The build fails on parallel builds for me and above command reproduces it. Note that --shuffle options is available on make version >= 4.4 Target ffi_libname in src/Makefile should have a additional dependency upon $(liburing_sobjs)

 configure    | 2 ++
 src/Makefile | 2 +-
 2 files changed, 3 insertions(+), 1 deletion(-)

```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
