### PR TITLE
[GIT PULL] Minor Fix for make -n

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -225,7 +225,9 @@ all: $(test_targets)
 helpers.o: helpers.c
 	$(QUIET_CC)$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ -c $<
 
-%.t: %.c $(helpers) helpers.h ../src/liburing.a
+LIBURING := $(shell if [ -e ../src/liburing.a ]; then echo ../src/liburing.a; fi)
+
+%.t: %.c $(helpers) helpers.h $(LIBURING)
 	$(QUIET_CC)$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ $< $(helpers) $(LDFLAGS)
 
 #
@@ -234,7 +236,7 @@ helpers.o: helpers.c
 #   cc1plus: warning: command-line option '-Wmissing-prototypes' \
 #   is valid for C/ObjC but not for C++
 #
-%.t: %.cc $(helpers) helpers.h ../src/liburing.a
+%.t: %.cc $(helpers) helpers.h $(LIBURING)
 	$(QUIET_CXX)$(CXX) \
 	$(patsubst -Wmissing-prototypes,,$(CPPFLAGS)) \
 	$(patsubst -Wmissing-prototypes,,$(CXXFLAGS)) \


### PR DESCRIPTION
make -n i.e no-operation fails.


<!-- Explain your changes here... -->
This is fixed by setting a conditional variable called LIBURING to ../src/liburing.a iff ../src/liburing.a exists in test/Makefile

----
## git request-pull output:
```
The following changes since commit 33a326b64769c01dd5ff0e11e510641055c9354d:

  Merge branch 'master' of https://github.com/stonebrakert6/liburing (2023-07-03 08:17:33 -0600)

are available in the Git repository at:

  https://github.com/stonebrakert6/liburing master

for you to fetch changes up to 1138f50b231538716795929c65d9e341532c70fc:

  build: Fixed make -n (2023-07-05 12:01:32 +0530)

----------------------------------------------------------------
Kartik Mahajan (1):
      build: Fixed make -n

 test/Makefile | 6 ++++--
 1 file changed, 4 insertions(+), 2 deletions(-)

```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
