### PR TITLE
[GIT PULL] Add new reason for returning EPERM from io_uring_setup

### DIFF
--- a/man/io_uring_setup.2
+++ b/man/io_uring_setup.2
@@ -691,6 +691,13 @@ Insufficient kernel resources are available.
 .B IORING_SETUP_SQPOLL
 was specified, but the effective user ID of the caller did not have sufficient
 privileges.
+.TP
+.B EPERM
+.I /proc/sys/kernel/io_uring_disabled
+has the value 2, or it has the value 1 and the calling process does not hold the
+.B CAP_SYS_ADMIN
+capability or is not a member of
+.I /proc/sys/kernel/io_uring_group.
 .SH SEE ALSO
 .BR io_uring_register (2),
 .BR io_uring_enter (2)


### PR DESCRIPTION
The new io_uring_disabled sysctl can make io_uring_setup return -EPERM if it's set to disable io_uring, document this in the man pages.

Link: https://lore.kernel.org/all/x49y1i42j1z.fsf@segfault.boston.devel.redhat.com/

----

## git request-pull output:
```
The following changes since commit 091e0931b3e54759b7e2ae66c2850a79768c8c23:

  Remove old sendmsg lookup test case (2023-09-11 20:41:02 -0600)

are available in the Git repository at:

  https://github.com/matrizzo/liburing.git uring_sysctl

for you to fetch changes up to f26bc4261d9cea77aa826e6e1f2a2b8bf532c3b1:

  man/io_uring_setup.2: add new reason for returning EPERM. (2023-09-13 08:11:53 +0000)

----------------------------------------------------------------
Matteo Rizzo (1):
      man/io_uring_setup.2: add new reason for returning EPERM.

 man/io_uring_setup.2 | 7 +++++++
 1 file changed, 7 insertions(+)
```

----

## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
