### PR TITLE
[GIT PULL] man/io_uring_setup.2: fix memory ordering

### DIFF
--- a/man/io_uring_setup.2
+++ b/man/io_uring_setup.2
@@ -109,11 +109,11 @@ call with the following code sequence:
 .EX
 /*
  * Ensure that the wakeup flag is read after the tail pointer
- * has been written. It's important to use memory load acquire
- * semantics for the flags read, as otherwise the application
- * and the kernel might not agree on the consistency of the
- * wakeup flag.
+ * has been written. A full memory barrier is required because
+ * this is a read-after-write (which cannot be synchronized
+ * using acquire/release memory ordering).
  */
+smp_mb();
 unsigned flags = atomic_load_relaxed(sq_ring->flags);
 if (flags & IORING_SQ_NEED_WAKEUP)
     io_uring_enter(fd, 0, 0, IORING_ENTER_SQ_WAKEUP);


### PR DESCRIPTION
See https://github.com/axboe/liburing/pull/542

----
## git request-pull output:
```
The following changes since commit b58921e0b0ae84b6f1cd22b87c66a6e91a540ec8:

  Merge branch 'uring_sysctl' of https://github.com/matrizzo/liburing (2023-09-13 08:11:53 -0600)

are available in the Git repository at:

  git@github.com:haslersn/liburing.git fix-man-memory-barrier

for you to fetch changes up to 0f1d7741284754ce42e129dc91918f85c2e87fa4:

  man/io_uring_setup.2: fix memory ordering (2023-09-15 02:47:35 +0200)

----------------------------------------------------------------
Sebastian Hasler (1):
      man/io_uring_setup.2: fix memory ordering

 man/io_uring_setup.2 | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)
```
----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
