### PR TITLE
read-mshot.t: test with differing buffer size

### DIFF
--- a/test/read-mshot.c
+++ b/test/read-mshot.c
@@ -15,6 +15,7 @@
 #include "helpers.h"
 
 #define BUF_SIZE	32
+#define BUF_SIZE_FIRST	17
 #define NR_BUFS		64
 #define BUF_BGID	1
 
@@ -33,8 +34,7 @@ static int test(int first_good, int async, int overflow)
 	struct io_uring ring;
 	int ret, fds[2], i;
 	char tmp[32];
-	char *buf;
-	void *ptr;
+	void *ptr[NR_BUFS];
 
 	p.flags = IORING_SETUP_CQSIZE;
 	if (!overflow)
@@ -52,9 +52,6 @@ static int test(int first_good, int async, int overflow)
 		return 1;
 	}
 
-	if (posix_memalign((void **) &buf, 4096, NR_BUFS * BUF_SIZE))
-		return 1;
-
 	br = io_uring_setup_buf_ring(&ring, NR_BUFS, BUF_BGID, 0, &ret);
 	if (!br) {
 		if (ret == -EINVAL) {
@@ -65,10 +62,12 @@ static int test(int first_good, int async, int overflow)
 		return 1;
 	}
 
-	ptr = buf;
 	for (i = 0; i < NR_BUFS; i++) {
-		io_uring_buf_ring_add(br, buf, BUF_SIZE, i + 1, BR_MASK, i);
-		buf += BUF_SIZE;
+		unsigned size = i <= 1 ? BUF_SIZE_FIRST : BUF_SIZE;
+		ptr[i] = malloc(size);
+		if (!ptr[i])
+			return 1;
+		io_uring_buf_ring_add(br, ptr[i], size, i + 1, BR_MASK, i);
 	}
 	io_uring_buf_ring_advance(br, NR_BUFS);
 
@@ -96,7 +95,7 @@ static int test(int first_good, int async, int overflow)
 		sprintf(tmp, "this is buffer %d\n", i + 1);
 		ret = write(fds[1], tmp, strlen(tmp));
 		if (ret != strlen(tmp)) {
-			printf("write ret %d\n", ret);
+			fprintf(stderr, "write ret %d\n", ret);
 			return 1;
 		}
 	}
@@ -117,7 +116,11 @@ static int test(int first_good, int async, int overflow)
 			}
 			fprintf(stderr, "%d: cqe res %d\n", i, cqe->res);
 			return 1;
+		} else if (i > 9 && cqe->res <= 17) {
+			fprintf(stderr, "truncated message %d %d\n", i, cqe->res);
+			return 1;
 		}
+
 		if (!(cqe->flags & IORING_CQE_F_BUFFER)) {
 			fprintf(stderr, "no buffer selected\n");
 			return 1;
@@ -138,7 +141,8 @@ static int test(int first_good, int async, int overflow)
 	}
 
 	io_uring_queue_exit(&ring);
-	free(ptr);
+	for (i = 0; i < NR_BUFS; i++)
+		free(ptr[i]);
 	return 0;
 }
 


### PR DESCRIPTION
This patch adds a check for differing buffer sizes, and amkes sure that the returned size is correct.

This fails currently, but should work with https://lore.kernel.org/io-uring/20231105223008.125563-1-dyudaken@gmail.com/T/#t


----
## git request-pull output:
```

The following changes since commit 78eef455c9538cbc145d7c658367f7662aeba39a:

  liburing.spec: move to minor 6 (2023-11-04 15:15:11 -0600)

are available in the Git repository at:

  https://github.com/dylanZA/liburing fix1

for you to fetch changes up to 3df9b683d12e1c6bb68e48bfccaf9befddc86be9:

  read-mshot.t: test with differing buffer size (2023-11-05 22:33:16 +0000)

----------------------------------------------------------------
Dylan Yudaken (1):
      read-mshot.t: test with differing buffer size

 test/read-mshot.c | 24 ++++++++++++++----------
 1 file changed, 14 insertions(+), 10 deletions(-)

```
----
