### PR TITLE
[GIT PULL] test/hardlink: add test for `AT_EMPTY_PATH` flag

### DIFF
--- a/test/hardlink.c
+++ b/test/hardlink.c
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
 	static const char linkname[] = "io_uring-linkat-test-link";
 	static const char symlinkname[] = "io_uring-linkat-test-symlink";
 	struct io_uring ring;
-	int ret, exit_status = T_EXIT_FAIL;
+	int ret, fd, exit_status = T_EXIT_FAIL;
 
 	if (argc > 1)
 		return T_EXIT_SKIP;
@@ -82,16 +82,16 @@ int main(int argc, char *argv[])
 		return ret;
 	}
 
-	ret = open(target, O_CREAT | O_RDWR | O_EXCL, 0600);
+	ret = fd = open(target, O_CREAT | O_RDWR | O_EXCL, 0600);
 	if (ret < 0) {
 		perror("open");
 		goto out;
 	}
-	if (write(ret, "linktest", 8) != 8) {
-		close(ret);
+	if (write(fd, "linktest", 8) != 8) {
+		close(fd);
 		goto out;
 	}
-	close(ret);
+	close(fd);
 
 	ret = symlink(target, symlinkname);
 	if (ret < 0) {


### PR DESCRIPTION
This PR adds a test for the issue documented in #995. The new test will only run as root. Since the issue requires an upstream change, the test is not passing currently, but as a sanity check, the following patch can be applied to replace the call to uring's version of linkat with an equivalent call to regular linkat and the test will pass.
```diff
---
 test/hardlink.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

diff --git a/test/hardlink.c b/test/hardlink.c
index cf170d0..2d328d1 100644
--- a/test/hardlink.c
+++ b/test/hardlink.c
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
 	if(geteuid()) {
 		fprintf(stdout, "not root, skipping AT_EMPTY_PATH test\n");
 	} else {
-		ret = do_linkat(&ring, fd, "", emptyname, AT_EMPTY_PATH);
+		ret = linkat(fd, "", AT_FDCWD, emptyname, AT_EMPTY_PATH);
 		if (ret < 0) {
 			if (ret == -EBADF || ret == -EINVAL) {
 				fprintf(stdout, "linkat not supported, skipping\n");
-- 
2.41.0

```
----
## git request-pull output:
```
The following changes since commit 9dc95a03e4a764e42b9e62990bb00feb9307ba63:

  test/no-mmap-inval: 0 return is fine too (2023-11-07 08:05:52 -0700)

are available in the Git repository at:

  https://github.com/charliemirabile/liburing.git at_empty_path

for you to fetch changes up to f0fe0515ca3c162fac545528ffddc45398d7d181:

  test/hardlink: Add test for `AT_EMPTY_PATH` flag (2023-11-20 05:38:35 -0500)

----------------------------------------------------------------
Charles Mirabile (4):
      test/hardlink: Cleanup error handling
      test/hardlink: add parameter for old's dirfd to `do_linkat`
      test/hardlink: introduce `fd` variable to hold the file open file descriptor
      test/hardlink: Add test for `AT_EMPTY_PATH` flag

 test/hardlink.c | 88 ++++++++++++++++++++++++++++++++++++++++++++++++----------------------------------------
 1 file changed, 48 insertions(+), 40 deletions(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
