### PR TITLE
[GIT PULL] Add ftruncate

### DIFF
--- a/man/io_uring_prep_ftruncate.3
+++ b/man/io_uring_prep_ftruncate.3
@@ -1,0 +1,48 @@
+.\" Copyright (C) 2024 Tony Solomonik <tony.solomonik@gmail.com>
+.\"
+.\" SPDX-License-Identifier: LGPL-2.0-or-later
+.\"
+.TH io_uring_prep_ftruncate 3 "January 23, 2024" "liburing-2.6" "liburing Manual"
+.SH NAME
+io_uring_prep_ftruncate \- prepare an ftruncate request
+.SH SYNOPSIS
+.nf
+.B #include <liburing.h>
+.PP
+.BI "void io_uring_prep_ftruncate(struct io_uring_sqe *" sqe ","
+.BI "                             int " fd ","
+.BI "                             loff_t " len ");"
+.fi
+.SH DESCRIPTION
+.PP
+The
+.BR io_uring_prep_ftruncate (3)
+function prepares an ftruncate request. The submission queue entry
+.I sqe
+is setup to use the file descriptor
+.I fd
+that should get truncated to the length indicated by the
+.I len
+argument.
+
+.SH RETURN VALUE
+None
+.SH ERRORS
+The CQE
+.I res
+field will contain the result of the operation. See the related man page for
+details on possible values. Note that where synchronous system calls will return
+.B -1
+on failure and set
+.I errno
+to the actual error value, io_uring never uses
+.IR errno .
+Instead it returns the negated
+.I errno
+directly in the CQE
+.I res
+field.
+.SH SEE ALSO
+.BR io_uring_get_sqe (3),
+.BR io_uring_submit (3),
+.BR ftruncate (2),

--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -1202,6 +1202,12 @@ IOURINGINLINE void io_uring_prep_fixed_fd_install(struct io_uring_sqe *sqe,
 	sqe->install_fd_flags = flags;
 }
 
+IOURINGINLINE void io_uring_prep_ftruncate(struct io_uring_sqe *sqe,
+				       int fd, loff_t len)
+{
+	io_uring_prep_rw(IORING_OP_FTRUNCATE, sqe, fd, 0, 0, len);
+}
+
 /*
  * Returns number of unconsumed (if SQPOLL) or unsubmitted entries exist in
  * the SQ ring

--- a/src/include/liburing/io_uring.h
+++ b/src/include/liburing/io_uring.h
@@ -255,6 +255,7 @@ enum io_uring_op {
 	IORING_OP_FUTEX_WAKE,
 	IORING_OP_FUTEX_WAITV,
 	IORING_OP_FIXED_FD_INSTALL,
+	IORING_OP_FTRUNCATE,
 
 	/* this goes last, obviously */
 	IORING_OP_LAST,

--- a/src/liburing-ffi.map
+++ b/src/liburing-ffi.map
@@ -191,4 +191,5 @@ LIBURING_2.6 {
 	global:
 		io_uring_prep_fixed_fd_install;
 		io_uring_buf_ring_available;
+		io_uring_prep_ftruncate;
 } LIBURING_2.5;

--- a/test/Makefile
+++ b/test/Makefile
@@ -198,6 +198,7 @@ test_srcs := \
 	thread-exit.c \
 	timeout.c \
 	timeout-new.c \
+	truncate.c \
 	tty-write-dpoll.c \
 	unlink.c \
 	version.c \

--- a/test/truncate.c
+++ b/test/truncate.c
@@ -1,0 +1,135 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Description: run various truncate tests
+ *
+ */
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+
+#include "liburing.h"
+#include "helpers.h"
+
+#define TWO_GIG_SIZE ((loff_t)2 * 1024 * 1024 * 1024)
+#define ONE_GIG_SIZE ((loff_t)1024 * 1024 * 1024)
+#define HALF_GIG_SIZE ((loff_t)512 * 1024 * 1024)
+
+static int test_ftruncate(struct io_uring *ring, int fd, loff_t len)
+{
+	struct io_uring_cqe *cqe;
+	struct io_uring_sqe *sqe;
+	int ret;
+
+	sqe = io_uring_get_sqe(ring);
+	if (!sqe) {
+		fprintf(stderr, "get sqe failed\n");
+		goto err;
+	}
+
+	memset(sqe, 0, sizeof(*sqe));
+
+	io_uring_prep_ftruncate(sqe, fd, len);
+
+	ret = io_uring_submit(ring);
+	if (ret <= 0) {
+		fprintf(stderr, "sqe submit failed: %d\n", ret);
+		goto err;
+	}
+
+	ret = io_uring_wait_cqe(ring, &cqe);
+	if (ret < 0) {
+		fprintf(stderr, "wait completion %d\n", ret);
+		goto err;
+	}
+	ret = cqe->res;
+	io_uring_cqe_seen(ring, cqe);
+	return ret;
+err:
+	return 1;
+}
+
+static int get_file_size(int fd, loff_t *size)
+{
+	struct stat st;
+
+	if (fstat(fd, &st) < 0)
+		return -1;
+	if (S_ISREG(st.st_mode)) {
+		*size = st.st_size;
+		return 0;
+	} else if (S_ISBLK(st.st_mode)) {
+		unsigned long long bytes;
+
+		if (ioctl(fd, BLKGETSIZE64, &bytes) != 0)
+			return -1;
+
+		*size = bytes;
+		return 0;
+	}
+
+	return -1;
+}
+
+int main(int argc, char *argv[])
+{
+	struct io_uring ring;
+	char path[32] = "./XXXXXX";
+	int ret;
+	int fd;
+	int i;
+	loff_t size;
+	loff_t test_sizes[3];
+
+	if (argc > 1)
+		return T_EXIT_SKIP;
+
+	ret = io_uring_queue_init(1, &ring, 0);
+	if (ret) {
+		fprintf(stderr, "ring setup failed: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	fd = mkostemp(path, O_WRONLY | O_CREAT | O_TRUNC);
+	if (fd < 0) {
+		perror("mkostemp");
+		return T_EXIT_FAIL;
+	}
+
+	test_sizes[0] = TWO_GIG_SIZE;
+	test_sizes[1] = ONE_GIG_SIZE;
+	test_sizes[2] = HALF_GIG_SIZE;
+
+	for (i = 0; i < 3; i++) {
+		ret = test_ftruncate(&ring, fd, test_sizes[i]);
+		if (ret < 0) {
+			if (ret == -EBADF || ret == -EINVAL) {
+				if (i == 0) {
+					fprintf(stdout, "Ftruncate not supported, skipping\n");
+					ret = T_EXIT_SKIP;
+					goto out;
+				}
+				goto err;
+			}
+			fprintf(stderr, "ftruncate: %s\n", strerror(-ret));
+			goto err;
+		} else if (ret)
+			goto err;
+
+		if (get_file_size(fd, &size) || size != test_sizes[i]) {
+			fprintf(stderr, "size not %lu\n", size);
+			goto err;
+		}
+	}
+
+out:
+	close(fd);
+	return T_EXIT_PASS;
+err:
+	close(fd);
+	return T_EXIT_FAIL;
+}


### PR DESCRIPTION
To accompany the patches I sent for adding ftruncate, here are the changes for usermode.

----
## git request-pull output:
```
The following changes since commit 63342497bec87b72d4b415c8bed930c15ff83b0d:

  test/read-mshot: check that IORING_CQE_F_MORE isn't set on error (2024-01-22 14:56:08 -0700)

are available in the Git repository at:

  git@github.com:tontinton/liburing.git truncate

for you to fetch changes up to c023393f3a3b960e3df77e5bcfd1b2e93e3b5e0f:

  man/io_uring_prep_ftruncate: Add the new ftruncate command (2024-01-31 17:52:13 +0200)

----------------------------------------------------------------
Tony Solomonik (4):
      Add ftruncate helpers
      test/truncate: Add test for ftruncate
      test/truncate: Add test for failure on truncate path
      man/io_uring_prep_ftruncate: Add the new ftruncate command

 man/io_uring_prep_ftruncate.3   |  48 ++++++++++++++++++++++++++++++++
 src/include/liburing.h          |   6 ++++
 src/include/liburing/io_uring.h |   1 +
 src/liburing-ffi.map            |   1 +
 test/Makefile                   |   1 +
 test/truncate.c                 | 179 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 6 files changed, 236 insertions(+)
 create mode 100644 man/io_uring_prep_ftruncate.3
 create mode 100644 test/truncate.c
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
