### PR TITLE
[GIT PULL] src/arch/aarch64: fix uclibc build

### DIFF
--- a/src/arch/aarch64/lib.h
+++ b/src/arch/aarch64/lib.h
@@ -4,7 +4,6 @@
 #define LIBURING_ARCH_AARCH64_LIB_H
 
 #include <elf.h>
-#include <sys/auxv.h>
 #include "../../syscall.h"
 
 static inline long __get_page_size(void)


### PR DESCRIPTION
Fix the following build failure with uclibc-ng raised since version 2.3 and
https://github.com/axboe/liburing/commit/c6bc86e2125bcd6fa10ff2b128cd86486acadff6:

```
In file included from lib.h:12,
                 from setup.c:4:
arch/aarch64/lib.h:7:10: fatal error: sys/auxv.h: No such file or directory
    7 | #include <sys/auxv.h>
      |          ^~~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/cc44d714c9267dd7a98debeb8c81c4ee1efe4ebb