### PR TITLE
[GIT PULL] Minor proxy example fixes

### DIFF
--- a/examples/proxy.c
+++ b/examples/proxy.c
@@ -269,7 +269,7 @@ static int setup_recv_ring(struct io_uring *ring, struct conn *c)
 
 	ptr = cbr->buf;
 	for (i = 0; i < nr_bufs; i++) {
-		vlog("%d: add bid %d, data 0x%p\n", c->tid, i, ptr);
+		vlog("%d: add bid %d, data %p\n", c->tid, i, ptr);
 		io_uring_buf_ring_add(cbr->br, ptr, buf_size, i, br_mask, i);
 		ptr += buf_size;
 	}

--- a/examples/proxy.c
+++ b/examples/proxy.c
@@ -1555,8 +1555,8 @@ int main(int argc, char *argv[])
 		if (send_ring == 1) {
 			fprintf(stderr, "Kernel doesn't support ring provided "
 				"buffers for sends, disabled\n");
-			send_ring = 0;
 		}
+		send_ring = 0;
 	}
 
 	if (fixed_files) {


### PR DESCRIPTION
Couple of minor proxy example fixes:
- if `IORING_FEAT_SEND_BUFS` is unavailable, the proxy still tries to use it by default,
- format fix for the verbose log when initially populating the recv buffer ring.

----
## git request-pull output:
```
The following changes since commit af77bf2a82d2e71ffd1c353114ec24634c6e6d25:

  examples/proxy: set 'len' for ring provided send buffers (2024-02-19 14:53:37 -0700)

are available in the Git repository at:

  https://github.com/wlukowicz/liburing.git proxy-fixes

for you to fetch changes up to e00c84cf052e73cdb88c0ced5bd2ee75d6f682f3:

  examples/proxy: fix verbose log format (2024-02-20 22:20:15 +0000)

----------------------------------------------------------------
Wojciech Lukowicz (2):
      examples/proxy: fix send ring default when unavailable
      examples/proxy: fix verbose log format

 examples/proxy.c | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
