### PR TITLE
Introduce make uninstall in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,19 @@ install: $(NAME).pc $(NAME)-ffi.pc
 	$(INSTALL) -m 755 -d $(DESTDIR)$(mandir)/man7
 	$(INSTALL) -m 644 man/*.7 $(DESTDIR)$(mandir)/man7
 
+uninstall:
+	@$(MAKE) -C src uninstall prefix=$(DESTDIR)$(prefix) datadir=$(DESTDIR)$(datadir)
+	@rm -f $(DESTDIR)$(libdevdir)/pkgconfig/$(NAME).pc
+	@rm -f $(DESTDIR)$(libdevdir)/pkgconfig/$(NAME)-ffi.pc
+	@rm -rf $(DESTDIR)$(mandir)/man2/io_uring*.2
+	@rm -rf $(DESTDIR)$(mandir)/man3/io_uring*.3
+	@rm -rf $(DESTDIR)$(mandir)/man7/io_uring*.7
+
 install-tests:
 	@$(MAKE) -C test install prefix=$(DESTDIR)$(prefix) datadir=$(DESTDIR)$(datadir)
+
+uninstall-tests:
+	@$(MAKE) -C test uninstall prefix=$(DESTDIR)$(prefix) datadir=$(DESTDIR)$(datadir)
 
 clean:
 	@rm -f config-host.mak config-host.h cscope.out $(NAME).pc $(NAME)-ffi.pc test/*.dmesg

--- a/src/Makefile
+++ b/src/Makefile
@@ -101,6 +101,23 @@ ifeq ($(ENABLE_SHARED),1)
 	ln -sf $(relativelibdir)$(ffi_libname) $(libdevdir)/liburing-ffi.so
 endif
 
+uninstall:
+	@rm -f $(includedir)/liburing/io_uring.h
+	@rm -f $(includedir)/liburing.h
+	@rm -f $(includedir)/liburing/compat.h
+	@rm -f $(includedir)/liburing/barrier.h
+	@rm -f $(includedir)/liburing/io_uring_version.h
+	@rm -f $(libdevdir)/liburing.a
+	@rm -f $(libdevdir)/liburing-ffi.a
+ifeq ($(ENABLE_SHARED),1)
+	@rm -f $(libdir)/$(libname)
+	@rm -f $(libdir)/$(ffi_libname)
+	@rm -f $(libdir)/$(soname)
+	@rm -f $(libdevdir)/liburing.so
+	@rm -f $(libdir)/$(ffi_soname)
+	@rm -f $(libdevdir)/liburing-ffi.so
+endif
+
 clean:
 	@rm -f $(all_targets) $(liburing_objs) $(liburing_sobjs) $(liburing_ffi_objs) $(liburing_ffi_sobjs) $(soname).new
 	@rm -f *.so* *.a *.o *.d

--- a/test/Makefile
+++ b/test/Makefile
@@ -261,6 +261,9 @@ install: $(test_targets) runtests.sh runtests-loop.sh
 	$(INSTALL) -D -m 755 runtests.sh  $(datadir)/liburing-test/
 	$(INSTALL) -D -m 755 runtests-loop.sh  $(datadir)/liburing-test/
 
+uninstall:
+	@rm -rf $(datadir)/liburing-test/
+
 clean:
 	@rm -f $(all_targets) helpers.o output/*
 	@rm -rf output/


### PR DESCRIPTION
Introduce make uninstall in Makefile

Previously there was no uninstall feature, which was not user-friendly.
So now this commit adds the uninstall feature to the Makefile.
Following the installation funciton, we add two uninstallations target:
  1-'uninstall': for src dir uninstallation
  2-'uninstall-tests': for test dir uninstallation

In order to make sure that the path variables are valid, we also
include the 'config-host.mak' when performing the uninstall function.

Signed-off-by: Xinghui Li <korantli@tencent.com>