### PR TITLE
[GIT PULL] liburing-ffi.map: Add comments for symbols added in wrong version node

### DIFF
--- a/src/liburing-ffi.map
+++ b/src/liburing-ffi.map
@@ -172,8 +172,8 @@ LIBURING_2.4 {
 		io_uring_prep_msg_ring_fd;
 		io_uring_prep_msg_ring_fd_alloc;
 		io_uring_prep_sendto;
-		io_uring_register_napi;
-		io_uring_unregister_napi;
+		io_uring_register_napi;		/* Added in 2.6. */
+		io_uring_unregister_napi;	/* Added in 2.6. */
 	local:
 		*;
 };
@@ -181,12 +181,13 @@ LIBURING_2.4 {
 LIBURING_2.5 {
 	global:
 		io_uring_queue_init_mem;
-		io_uring_prep_cmd_sock;
-		io_uring_prep_read_multishot;
-		io_uring_prep_waitid;
-		io_uring_prep_futex_wake;
-		io_uring_prep_futex_wait;
-		io_uring_prep_futex_waitv;
+		io_uring_prep_cmd_sock;		/* Added in 2.5,
+						   exported in 2.6. */
+		io_uring_prep_read_multishot;	/* Added in 2.6. */
+		io_uring_prep_waitid;		/* Added in 2.6. */
+		io_uring_prep_futex_wake;	/* Added in 2.6. */
+		io_uring_prep_futex_wait;	/* Added in 2.6. */
+		io_uring_prep_futex_waitv;	/* Added in 2.6. */
 } LIBURING_2.4;
 
 LIBURING_2.6 {


### PR DESCRIPTION
These symbols all appeared in the 2.6 version. One was added in 2.5, but the symbol name in the map file was wrong so it was not exported. The rest were all added in 2.6 but in the wrong nodes, either 2.4 or 2.5.

We cannot fix these now because the version is now attached to the symbols, so the best we can do w/o breaking ABI is to document this in the map file so that other people do not get confused.

Signed-off-by: Guillem Jover <guillem@hadrons.org>

----
## git request-pull output:
```
The following changes since commit eb267a661a1636e69969d210654d90513fe81c2f:

  man: fix IORING_REGISTER_RING_FDS docs (2024-05-03 16:17:41 -0600)

are available in the Git repository at:

  https://github.com/guillemj/liburing pu/libffi-symbols

for you to fetch changes up to 222b46ddc07109ba9232fb0140bbdec38b742607:

  liburing-ffi.map: Add comments for symbols added in wrong version node (2024-05-05 16:40:12 +0200)

----------------------------------------------------------------
Guillem Jover (1):
      liburing-ffi.map: Add comments for symbols added in wrong version node

 src/liburing-ffi.map | 17 +++++++++--------
 1 file changed, 9 insertions(+), 8 deletions(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
