### PR TITLE
[GIT PULL] test/socket-getsetsock-cmd: remove fprintfs

### DIFF
--- a/test/socket-getsetsock-cmd.c
+++ b/test/socket-getsetsock-cmd.c
@@ -178,12 +178,10 @@ static int run_getsockopt_test(struct io_uring *ring, struct fds *sockfds)
 {
 	int err;
 
-	fprintf(stderr, "Testing getsockopt SO_PEERNAME\n");
 	err = run_get_peername(ring, sockfds);
 	if (err)
 		return err;
 
-	fprintf(stderr, "Testing getsockopt SO_RCVBUF\n");
 	return run_get_rcvbuf(ring, sockfds);
 }
 
@@ -262,14 +260,12 @@ static int run_setsockopt_test(struct io_uring *ring, struct fds *sockfds)
 {
 	int err, i;
 
-	fprintf(stderr, "Testing setsockopt SOL_SOCKET/SO_REUSEPORT\n");
 	for (i = 0; i <= 1; i++) {
 		err = run_setsockopt_reuseport(ring, sockfds, i);
 		if (err)
 			return err;
 	}
 
-	fprintf(stderr, "Testing setsockopt IPPROTO_TCP/TCP_FASTOPEN\n");
 	for (i = 1; i <= 10; i++) {
 		err = run_setsockopt_usertimeout(ring, sockfds, i);
 		if (err)


### PR DESCRIPTION

Make the socket-getsetsock-cmd run
----
## git request-pull output:

```
he following changes since commit 2d80864dfb83c158b2f1b273ee3d9be21b1729e5:

  test/msg-ring: use local ring for remote waiter (2024-05-29 11:07:22 -0600)

are available in the Git repository at:

  https://github.com/axboe/liburing.git master

for you to fetch changes up to 013f87d498a8038890e55dda7665f0c3707205d5:

  test/socket-getsetsock-cmd: remove fprintfs (2024-05-30 06:26:17 -0700)

----------------------------------------------------------------
Breno Leitao (1):
      test/socket-getsetsock-cmd: remove fprintfs

 test/socket-getsetsock-cmd.c | 4 ----
 1 file changed, 4 deletions(-)
```


----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
