### PR TITLE
[GIT PULL] man/io_uring_enter: fix IORING_OP_EPOLL_CTL documentation

### DIFF
--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -349,13 +349,13 @@ See
 for details of the system call.
 .I fd
 holds the file descriptor that represents the epoll instance,
-.I addr
+.I off
 holds the file descriptor to add, remove or modify,
 .I len
 holds the operation (EPOLL_CTL_ADD, EPOLL_CTL_DEL, EPOLL_CTL_MOD) to perform and,
-.I off
+.I addr
 holds a pointer to the
-.I epoll_events
+.I epoll_event
 structure. Available since 5.6.
 
 .TP


### PR DESCRIPTION
Correct IORING_OP_EPOLL_CTL documentation for 'off' and 'addr' parameters and fix typo.


<!-- Explain your changes here... -->

----
## git request-pull output:
```
The following changes since commit b68cf47a120d6b117a81ed9f7617aad13314258c:

  man/io_uring_enter: correct struct type referenced for timeouts (2024-06-03 13:01:56 -0600)

are available in the Git repository at:

  https://github.com/Andreas-Bur/liburing

for you to fetch changes up to 98a52fe8d350ac92834896d8be0853690159c46f:

  man/io_uring_enter: fix IORING_OP_EPOLL_CTL documentation (2024-06-16 21:02:27 +0200)

----------------------------------------------------------------
Andreas Bur (1):
      man/io_uring_enter: fix IORING_OP_EPOLL_CTL documentation

 man/io_uring_enter.2 | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
