### PR TITLE
test/buf-ring-nommap: zero the ringbuf memory

### DIFF
--- a/test/buf-ring-nommap.c
+++ b/test/buf-ring-nommap.c
@@ -41,6 +41,8 @@ int main(int argc, char *argv[])
 	if (posix_memalign(&ring_mem, 16384, 16384))
 		return T_EXIT_FAIL;
 
+	memset(ring_mem, 0, 16384);
+
 	p.flags = IORING_SETUP_NO_MMAP;
 	ret = io_uring_queue_init_mem(1, &ring, &p, ring_mem, 16384);
 	if (ret < 0) {


### PR DESCRIPTION
The test crashes when run under the openSUSE build system. It sets `MALLOC_PERTURB_=69` in the environment, so the allocated memory is initialized to `0xba`.

Later in `io_uring_get_sqe()` -> `_io_uring_get_sqe()`:
```
1424           if (next - head <= sq->ring_entries) {
(gdb) p *sq
$2 = {khead = 0x55555555d000, ktail = 0x55555555d004,
 kring_mask = 0x55555555d010, kring_entries = 0x55555555d018,
 kflags = 0x55555555d024, kdropped = 0x55555555d020, array = 0x0,
 sqes = 0x55555555c000, sqe_head = 0, sqe_tail = 0, ring_sz = 0,
 ring_ptr = 0x55555555d000, ring_mask = 0, ring_entries = 1, pad = {0, 0}}
(gdb) p sq->ring_entries
$3 = 1
(gdb) p next
$4 = 1
(gdb) p/x head
$6 = 0xbabababa
```
And that causes a crash, of course.

Fix that by zeroing the memory after `posix_memalign()`.