### PR TITLE
[GIT PULL] liburing.pc.in: add -D_GNU_SOuRCE to Cflags

### DIFF
--- a/liburing.pc.in
+++ b/liburing.pc.in
@@ -9,4 +9,4 @@ Description: io_uring library
 URL: https://git.kernel.dk/cgit/liburing/
 
 Libs: -L${libdir} -luring
-Cflags: -I${includedir}
+Cflags: -I${includedir} -D_GNU_SOURCE


### PR DESCRIPTION
Add `-D_GNU_SOURCE` to Cflags to avoid the following musl build failure with applications using liburing (e.g. libdex) raised since version 2.6 and c427ed678f39fd144d784f2e970bd8c52f425e14 which reverted c34070e08199491fe9653617364f4aea9b9b22be:

```
In file included from ../src/dex-uring-aio-backend.c:29: /home/autobuild/autobuild/instance-7/output-1/host/mips-buildroot-linux-musl/sysroot/usr/include/liburing.h:224:39: error: unknown type name 'cpu_set_t'
  224 |                                 const cpu_set_t *mask);
      |                                       ^~~~~~~~~
/home/autobuild/autobuild/instance-7/output-1/host/mips-buildroot-linux-musl/sysroot/usr/include/liburing.h:1212:48: error: unknown type name 'loff_t'; did you mean 'off_t'?
 1212 |                                        int fd, loff_t len)
      |                                                ^~~~~~
      |                                                off_t
```