### PR TITLE
[GIT PULL] Typo fixes and CI addition

### DIFF
--- a/.github/actions/codespell/stopwords
+++ b/.github/actions/codespell/stopwords
@@ -1,0 +1,7 @@
+bu
+cancelation
+cancelations
+cant
+pring
+sring
+wont

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+name: Codespell
+
+on:
+  # Trigger the workflow on push or pull requests.
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v3
+
+    - name: Install codespell
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y codespell
+
+    - name: Display codespell version
+      run: codespell --version
+
+    - name: Execute codespell
+      run: codespell --ignore-words=.github/actions/codespell/stopwords .

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: userspace library for using io_uring
  io_uring is kernel feature to improve development
  The newese Linux IO interface, io_uring could improve
- system performance a lot. liburing is the userpace
+ system performance a lot. liburing is the userspace
  library to use io_uring feature.
  .
  This package contains the shared library.
@@ -33,7 +33,7 @@ Depends:
 Description: userspace library for using io_uring
  io_uring is kernel feature to improve development
  The newese Linux IO interface, io_uring could improve
- system performance a lot. liburing is the userpace
+ system performance a lot. liburing is the userspace
  library to use io_uring feature.
  .
  This package contains the static library and the header files.

--- a/examples/proxy.c
+++ b/examples/proxy.c
@@ -132,7 +132,7 @@ struct io_msg {
 
 /*
  * Per socket stats per connection. For bi-directional, we'll have both
- * sends and receives on each socket, this helps track them seperately.
+ * sends and receives on each socket, this helps track them separately.
  * For sink or one directional, each of the two stats will be only sends
  * or receives, not both.
  */
@@ -298,7 +298,7 @@ static int default_error(struct error_handler *err,
 }
 
 /*
- * Move error handling out of the normal handling path, cleanly seperating
+ * Move error handling out of the normal handling path, cleanly separating
  * them. If an opcode doesn't need any error handling, set it to NULL. If
  * it wants to stop the connection at that point and not do anything else,
  * then the default handler can be used. Only receive has proper error
@@ -1684,7 +1684,7 @@ static int handle_shutdown(struct io_uring *ring, struct io_uring_cqe *cqe)
 	struct io_uring_sqe *sqe;
 	int fd = cqe_to_fd(cqe);
 
-	fprintf(stderr, "Got shutdown notication on fd %d\n", fd);
+	fprintf(stderr, "Got shutdown notification on fd %d\n", fd);
 
 	if (!cqe->res)
 		fprintf(stderr, "Unexpected success shutdown CQE\n");

--- a/man/io_uring_buf_ring_available.3
+++ b/man/io_uring_buf_ring_available.3
@@ -27,7 +27,7 @@ and identified by the buffer group ID
 Since the head of the provided buffer ring is only visible to the kernel, it's
 impossible to otherwise know how many unconsumed entries exist in the given
 provided buffer ring. This function query the kernel to return that number.
-Availabe since kernel 6.8.
+Available since kernel 6.8.
 
 .SH NOTES
 The returned number of entries reflect the amount of unconsumed entries at the

--- a/man/io_uring_prep_recv.3
+++ b/man/io_uring_prep_recv.3
@@ -97,7 +97,7 @@ field indicates the first buffer in the receive operation. The application must
 iterate from the indicated initial buffer ID and until all
 .I res
 bytes have been seen to know which is the last buffer in the receive operation.
-The buffer IDs consumed will be contigious from the starting ID, in the order
+The buffer IDs consumed will be contiguous from the starting ID, in the order
 in which they were added to the buffer ring used. Receiving in bundles can
 improve performance when more than one chunk of data is available to receive,
 by eliminating redundant round trips through the networking stack. Receive

--- a/man/io_uring_prep_send.3
+++ b/man/io_uring_prep_send.3
@@ -111,7 +111,7 @@ to limit the transfer size. A single CQE is posted for the send, with the result
 being how many bytes were sent, on success. When used with provided buffers,
 send or send bundle will contain the starting buffer group ID in the CQE
 .I flags
-field. The number of bytes sent starts from there, and will be in contigious
+field. The number of bytes sent starts from there, and will be in contiguous
 buffer IDs after that. Send bundle, and send with provided buffers in general,
 are available since kernel 6.10, and can be further identified by checking for
 the

--- a/man/io_uring_prep_symlinkat.3
+++ b/man/io_uring_prep_symlinkat.3
@@ -41,7 +41,7 @@ is setup to symlink the target path pointed to by
 .I target
 to the new destination indicated by
 .I linkpath
-relative to the the current working directory. This function prepares an async
+relative to the current working directory. This function prepares an async
 .BR symlink (2)
 request. See that man page for details.
 

--- a/man/io_uring_register_eventfd.3
+++ b/man/io_uring_register_eventfd.3
@@ -44,7 +44,6 @@ eventfd notifications posted. An eventfd notification must thus only be treated
 as a hint to check the CQ ring for completions.
 .SH RETURN VALUE
 Returns 0 on success, or
-or
 .BR -errno
 on error.
 .SH SEE ALSO

--- a/man/io_uring_submit.3
+++ b/man/io_uring_submit.3
@@ -28,7 +28,7 @@ On success
 .BR io_uring_submit (3)
 returns the number of submitted submission queue entries, if SQPOLL is not used.
 If SQPOLL is used, the return value may report a higher number of submitted
-entries than actually submitted. If the the user requires accurate information
+entries than actually submitted. If the user requires accurate information
 about how many submission queue entries have been successfully submitted, while
 using SQPOLL, the user must fall back to repeatedly submitting a single submission
 queue entry. On failure it returns

--- a/src/include/liburing/io_uring.h
+++ b/src/include/liburing/io_uring.h
@@ -361,7 +361,7 @@ enum io_uring_op {
  *				result 	will be the number of buffers send, with
  *				the starting buffer ID in cqe->flags as per
  *				usual for provided buffer usage. The buffers
- *				will be	contigious from the starting buffer ID.
+ *				will be contiguous from the starting buffer ID.
  */
 #define IORING_RECVSEND_POLL_FIRST	(1U << 0)
 #define IORING_RECV_MULTISHOT		(1U << 1)

--- a/test/ignore-single-mmap.c
+++ b/test/ignore-single-mmap.c
@@ -2,7 +2,7 @@
 /*
  * 6.10-rc merge window had a bug where the rewritten mmap support caused
  * rings allocated with > 1 page, but asking for smaller mappings, would
- * cause -EFAULT to be returned rather than a succesful map. This hit
+ * cause -EFAULT to be returned rather than a successful map. This hit
  * applications either using an ancient liburing with IORING_FEAT_SINGLE_MMAP
  * support, or application just ignoring that feature flag and still doing
  * 3 mmap operations to map the ring.


### PR DESCRIPTION
This series include a couple of commits for typo fixes, and another one introducing a new GitHub workflow to run codespell over the source tree, to catch regressions.

The typo fixes modify the header which is usually imported from Linux, but otherwise we'd need to mark that typo as a stopword. The workflow uses a more recent Ubuntu release than the other workflows, otherwise the older codespell  generates more false positives.

----
## git request-pull output:
```
The following changes since commit 27758779626a28d416a58a824f85fb118a63a4d5:

  test/recvsend_bundle: don't fail on short receives (2024-08-26 19:26:15 -0600)

are available in the Git repository at:

  https://github.com/guillemj/liburing.git pu/typos

for you to fetch changes up to bb1d03aeb6c7bb64770f70dd453e9c241d96450f:

  .github: Add new codespell CI test (2024-08-27 10:16:06 +0200)

----------------------------------------------------------------
Guillem Jover (3):
      Fix typos
      Fix typos
      .github: Add new codespell CI test

 .github/actions/codespell/stopwords |  7 +++++++
 .github/workflows/codespell.yml     | 25 +++++++++++++++++++++++++
 debian/control                      |  4 ++--
 examples/proxy.c                    |  6 +++---
 man/io_uring_buf_ring_available.3   |  2 +-
 man/io_uring_prep_recv.3            |  2 +-
 man/io_uring_prep_send.3            |  2 +-
 man/io_uring_prep_symlinkat.3       |  2 +-
 man/io_uring_register_eventfd.3     |  1 -
 man/io_uring_submit.3               |  2 +-
 src/include/liburing/io_uring.h     |  2 +-
 test/ignore-single-mmap.c           |  2 +-
 12 files changed, 44 insertions(+), 13 deletions(-)
 create mode 100644 .github/actions/codespell/stopwords
 create mode 100644 .github/workflows/codespell.yml
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
