### PR TITLE
[GIT PULL] man/io_uring_enter: add missing and clarify another return value

### DIFF
--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -44,12 +44,17 @@ number of events in
 before returning. This flag can be set along with
 .I to_submit
 to both submit and complete events in a single system call.
-If this flag is set the thread issuing the syscall must either be the
-thread that created the io_uring associated with
-.I fd
-or must not have the flag
+If this flag is set either the flag
 .B IORING_SETUP_DEFER_TASKRUN
-set.
+must not be set or the thread issuing the syscall must be the thread that
+created the io_uring associated with
+.I fd,
+or be the thread that enabled the ring originally created with
+.B IORING_SETUP_R_DISABLED
+via
+.BR io_uring_register (2)
+or
+.BR io_uring_enable_rings (3).
 .TP
 .B IORING_ENTER_SQ_WAKEUP
 If the ring has been created with
@@ -1572,8 +1577,8 @@ The thread submitting the work is invalid. This may occur if
 .B IORING_ENTER_GETEVENTS
 and
 .B IORING_SETUP_DEFER_TASKRUN
-is set, but the submitting thread is not the thread that initially created the
-io_uring associated with
+is set, but the submitting thread is not the thread that initially created or
+enabled the io_uring associated with
 .I fd.
 .TP
 .B EINVAL

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -44,6 +44,12 @@ number of events in
 before returning. This flag can be set along with
 .I to_submit
 to both submit and complete events in a single system call.
+If this flag is set the thread issuing the syscall must either be the
+thread that created the io_uring associated with
+.I fd
+or must not have the flag
+.B IORING_SETUP_DEFER_TASKRUN
+set.
 .TP
 .B IORING_ENTER_SQ_WAKEUP
 If the ring has been created with
@@ -1562,7 +1568,13 @@ the CQ ring, or if the application attempts to wait for more events without
 having reaped the ones already present in the CQ ring.
 .TP
 .B EEXIST
-The thread submitting the work is invalid.
+The thread submitting the work is invalid. This may occur if
+.B IORING_ENTER_GETEVENTS
+and
+.B IORING_SETUP_DEFER_TASKRUN
+is set, but the submitting thread is not the thread that initially created the
+io_uring associated with
+.I fd.
 .TP
 .B EINVAL
 Some bits in the

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -1599,6 +1599,11 @@ complete; see
 .BR signal(7).
 Can happen while waiting for events with
 .B IORING_ENTER_GETEVENTS.
+.TP
+.B EOWNERDEAD
+The ring has been setup with
+.B IORING_SETUP_SQPOLL
+and the sq poll kernel thread has been killed.
 
 .SH CQE ERRORS
 These io_uring-specific errors are returned as a negative value in the

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -56,7 +56,7 @@ If the ring has been created with
 then the application has no real insight into when the SQ kernel thread has
 consumed entries from the SQ ring. This can lead to a situation where the
 application can no longer get a free SQE entry to submit, without knowing
-when it one becomes available as the SQ kernel thread consumes them. If
+when one will become available as the SQ kernel thread consumes them. If
 the system call is used with this flag set, then it will wait until at least
 one entry is free in the SQ ring.
 .TP


### PR DESCRIPTION
<!-- Explain your changes here... -->
This makes three small changes to the man pages of io_uring_enter:
1. Adds documentation for the possible return value EEOWNERDEAD (i.e. ring uses sqpoll and some one killed the sqpoll kthread)
2. Adds a more specific description to when a thread is "invalid" and thus causes a return value of EEXIST. Which as far as i could tell boils down to IORING_ENTER_GETEVENTS && IORING_SETUP_DEFER_TASKRUN && current != ctx->submitter_task
3. Fixes a small grammatical error 

----
## git request-pull output:
```

The following changes since commit cc74667886e92a0a1b3a279ed5f2f527c5d9f3e0:

  Update CHANGELOG (2024-08-31 06:20:06 -0600)

are available in the Git repository at:

  https://github.com/CPestka/liburing man_io_uring_enter

for you to fetch changes up to 6981007646a70326071ca3fa6d0b518ce0213ca4:

  man/io_uring_enter: Add missing return value EOWNERDEAD (2024-09-01 12:47:42 +0200)

----------------------------------------------------------------
CPestka (3):
      man/io_uring_enter: Fix minor grammatical error
      man/io_uring_enter: Clarify when EEXIST can occur
      man/io_uring_enter: Add missing return value EOWNERDEAD

 man/io_uring_enter.2 | 21 +++++++++++++++++++--
 1 file changed, 19 insertions(+), 2 deletions(-)

```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
4. Follow the commit message format rules below.
5. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
6. Then an empty line again (if it has a description).
7. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
