### PR TITLE
[GIT PULL] Fix io_uring_free_buf_ring return value documentation

### DIFF
--- a/man/io_uring_free_buf_ring.3
+++ b/man/io_uring_free_buf_ring.3
@@ -47,7 +47,7 @@ Available since 5.19.
 .SH RETURN VALUE
 On success
 .BR io_uring_free_buf_ring (3)
-returns a pointer to the buffe ring. On failure it returns
+zero. On failure it returns
 .BR -errno .
 .SH SEE ALSO
 .BR io_uring_setup_buf_ring (3)


### PR DESCRIPTION
Trivial documentation fix: The function returns zero or `-errno`, not a pointer. Also, this removes the "buffe ring" typo, which I am probably the only person to find funny.

----
## git request-pull output:
```
The following changes since commit b0cf23de76df798833f271579b31bdd70cb50863:

  test: return skipped if we don't have permission to open file (2024-09-03 10:52:32 -0600)

are available in the Git repository at:

  git@github.com:nigoroll/liburing.git buffe_ring

for you to fetch changes up to 9448db157751a3a5b8618ff6c0fb81fc73443e8e:

  man/io_uring_free_buf_ring.3: Fix return value documentation (2024-09-03 19:13:04 +0200)

----------------------------------------------------------------
Nils Goroll (1):
      man/io_uring_free_buf_ring.3: Fix return value documentation

 man/io_uring_free_buf_ring.3 | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```
----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
