### PR TITLE
[GIT PULL] man/io_uring_free_buf_ring.3: Add back a lost word

### DIFF
--- a/man/io_uring_free_buf_ring.3
+++ b/man/io_uring_free_buf_ring.3
@@ -47,7 +47,7 @@ Available since 5.19.
 .SH RETURN VALUE
 On success
 .BR io_uring_free_buf_ring (3)
-zero. On failure it returns
+returns zero. On failure it returns
 .BR -errno .
 .SH SEE ALSO
 .BR io_uring_setup_buf_ring (3)


### PR DESCRIPTION
I am sorry: a word got lost in #1219 and I only noticed after opening the PR. And being on a train with a slow connection, Jens was faster merging than I could correct my mistake. This caused way too much effort for what it is, sorry again.

----
## git request-pull output:
```
The following changes since commit b277fced7257720734b863f14833c88be6d4b6b9:

  Merge branch 'buffe_ring' of https://github.com/nigoroll/liburing (2024-09-03 11:17:32 -0600)

are available in the Git repository at:

  git@github.com:nigoroll/liburing.git buffe_ring2

for you to fetch changes up to 06a4cc6bf5a2ac70d6bd21f2f1862be41e09bc49:

  man/io_uring_free_buf_ring.3: Add back a lost word (2024-09-03 19:26:23 +0200)

----------------------------------------------------------------
Nils Goroll (1):
      man/io_uring_free_buf_ring.3: Add back a lost word

 man/io_uring_free_buf_ring.3 | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```
----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
