### PR TITLE
[GIT PULL] man/io_uring_enter: Add missing Op codes and some minor other additions

### DIFF
--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -1258,6 +1258,22 @@ for details on how to setup a context for fixed buffer I/O.
 .PP
 
 .TP
+.B IORING_OP_SENDMSG_ZC
+Issue the zerocopy equivalent of a
+.BR sendmsg (2)
+system call.
+Works just like
+.IR IORING_OP_SENDMSG ,
+but like
+.I IORING_OP_SEND_ZC
+supports
+.IR IORING_RECVSEND_FIXED_BUF .
+For additional notes regarding zero copy see
+.IR IORING_OP_SEND_ZC .
+
+Available since 6.1
+
+.TP
 .B IORING_OP_WAITID
 Issue the equivalent of a
 .BR waitid(2)

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -1370,6 +1370,23 @@ must contain the length to which the file will be truncated.
 
 Available since 6.9.
 
+.TP
+.B IORING_OP_READ_MULTISHOT
+Like
+.IR IORING_OP_READ ,
+but similar to requests prepared with
+.IR io_uring_prep_multishoot_accept (3)
+additional reads and thus CQEs will be performed based on this single SQE once
+there is more data available.
+Is restricted to pollable files and will fall back to single shoot if the file
+does not support
+.IR NOWAIT .
+Like other multishot type requests, the application should look at the CQE
+flags and see if
+.I IORING_CQE_F_MORE
+is set on completion as an indication of whether or not the read request will
+generate further CQEs.
+
 .PP
 The
 .I flags

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -1329,31 +1329,6 @@ must contain the length of the address.
 
 Available since 6.11.
 
-.TP
-.B IORING_OP_LISTEN
-Issues the equivalent of the
-.IR listen(2)
-system call.
-.I fd
-must contain the file descriptor of the socket and
-.I addr
-must contain the backlog parameter, i.e. the maximum amount of pending
-queued connections.
-
-Available since 6.11.
-
-.TP
-.B IORING_OP_FTRUNCATE
-Issues the equivalent of the
-.IR ftruncate(2)
-system call.
-.I fd
-must contain the file descriptor of the file to truncate and
-.I off
-must contain the length to which to file will be truncated.
-
-Available since 6.9.
-
 .PP
 The
 .I flags

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -1412,6 +1412,26 @@ must contain additional flags passed in.
 
 Available since 6.7.
 
+.TP
+.B IORING_OP_FUTEX_WAKE
+Issues the equivalent of the
+.IR futex_wake (2)
+system call.
+.I addr
+must hold a pointer to the futex,
+.I addr2
+must hold the maximum number of waiters waiting on this futex to wake,
+.I addr3
+must hold the bitmask of this
+.IR futex_wake (2)
+call.
+To wake a waiter additionally the bitmask of the waiter and waker must have
+at least one set bit in common.
+.IR fd
+must contain additional flags passed in.
+
+Available since 6.7.
+
 .PP
 The
 .I flags

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -1342,6 +1342,18 @@ queued connections.
 
 Available since 6.11.
 
+.TP
+.B IORING_OP_FTRUNCATE
+Issues the equivalent of the
+.IR ftruncate (2)
+system call.
+.I fd
+must contain the file descriptor of the file to truncate and
+.I off
+must contain the length to which the file will be truncated.
+
+Available since 6.9.
+
 .PP
 The
 .I flags

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -1329,6 +1329,19 @@ must contain the length of the address.
 
 Available since 6.11.
 
+.TP
+.B IORING_OP_LISTEN
+Issues the equivalent of the
+.IR listen(2)
+system call.
+.I fd
+must contain the file descriptor of the socket and
+.I addr
+must contain the backlog parameter, i.e. the maximum amount of pending
+queued connections.
+
+Available since 6.11.
+
 .PP
 The
 .I flags

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -1273,6 +1273,87 @@ is a pointer to siginfo_t, if any, being filled in. See also
 .BR waitid(2)
 for the general description of the related system call. Available since 6.5.
 
+.TP
+.B IORING_OP_SETXATTR
+.TP
+.B IORING_OP_GETXATTR
+.TP
+.B IORING_OP_FSETXATTR
+.TP
+.B IORING_OP_FGETXATTR
+Issue the equivalent of a
+.BR setxattr(2)
+or
+.BR getxattr(2)
+or
+.BR fsetxattr(2)
+or
+.BR fgetxattr(2)
+system call.
+.I addr
+must contain a pointer to a buffer containing the name of the extended
+attribute.
+.I addr2
+must contain a pointer to a buffer of maximum length
+.IR len ,
+in which the value of the extended attribute is to be placed or is read from.
+Additional flags maybe provided in
+.IR xattr_flags .
+For
+.IR setxattr(2)
+or
+.IR getxattr(2)
+.I addr3
+must contain a pointer to the path of the file.
+For
+.IR fsetxattr(2)
+or
+.IR fgetxattr(2)
+.I fd
+must contain the file descriptor of the file.
+
+Available since 5.19.
+
+.TP
+.B IORING_OP_BIND
+Issues the equivalent of the
+.IR bind (2)
+system call.
+.I fd
+must contain the file descriptor of the socket,
+.I addr
+must contain a pointer to the sockaddr struct containing the address to assign
+and
+.I addr2
+must contain the length of the address.
+
+Available since 6.11.
+
+.TP
+.B IORING_OP_LISTEN
+Issues the equivalent of the
+.IR listen(2)
+system call.
+.I fd
+must contain the file descriptor of the socket and
+.I addr
+must contain the backlog parameter, i.e. the maximum amount of pending
+queued connections.
+
+Available since 6.11.
+
+.TP
+.B IORING_OP_FTRUNCATE
+Issues the equivalent of the
+.IR ftruncate(2)
+system call.
+.I fd
+must contain the file descriptor of the file to truncate and
+.I off
+must contain the length to which to file will be truncated.
+
+Available since 6.9.
+
 .PP
 The
 .I flags

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -1187,6 +1187,15 @@ and
 Available since 5.19.
 
 .TP
+.B IORING_OP_URING_CMD
+Issues an asynchronous, per-file private operation, similar to
+.BR ioctl (2).
+Further information may be found in the dedicated man page of
+.BR IORING_OP_URING_CMD .
+
+Available since 5.19.
+
+.TP
 .B IORING_OP_SEND_ZC
 Issue the zerocopy equivalent of a
 .BR send(2)

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -1387,6 +1387,31 @@ flags and see if
 is set on completion as an indication of whether or not the read request will
 generate further CQEs.
 
+.TP
+.B IORING_OP_FUTEX_WAIT
+Issues the equivalent of the
+.IR futex_wait (2)
+system call.
+.I addr
+must hold a pointer to the futex,
+.I addr2
+must hold the value to which the futex has to be changed so this caller to
+.IR futex_wait (2)
+can be woken by a call to
+.IR futex_wake (2),
+.I addr3
+must hold the bitmask of this
+.IR futex_wait (2)
+caller.
+For a caller of
+.IR futex_wake (2)
+to wake a waiter additionally the bitmask of the waiter and waker must have
+at least one set bit in common.
+.IR fd
+must contain additional flags passed in.
+
+Available since 6.7.
+
 .PP
 The
 .I flags

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -290,6 +290,12 @@ for details on how to setup a context for fixed reads and writes.
 .B IORING_OP_FSYNC
 File sync.  See also
 .BR fsync (2).
+Optionally
+.I off
+and
+.I len
+can be used to specify a range within the file to be synced rather than
+syncing the entire file, which is the default behavior.
 Note that, while I/O is initiated in the order in which it appears in
 the submission queue, completions are unordered.  For example, an
 application which places a write I/O followed by an fsync in the

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -297,6 +297,10 @@ submission queue cannot expect the fsync to apply to the write.  The
 two operations execute in parallel, so the fsync may complete before
 the write is issued to the storage.  The same is also true for
 previously issued writes that have not completed prior to the fsync.
+To enforce ordering one may utilize linked SQEs,
+.I IOSQE_IO_DRAIN
+or wait for the arrival of CQEs of requests which have to be ordered
+before a given request before submitting its SQE.
 
 .TP
 .B IORING_OP_POLL_ADD

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -1455,6 +1455,25 @@ smaller than FUTEX_WAITV_MAX (as of 6.11 == 128).
 
 Available since 6.7.
 
+.TP
+.B IORING_OP_FIXED_FD_INSTALL
+This operation is used to insert a registered file into the regular process
+file table.
+Consequently
+.I fd
+must contain the file index and
+.B IOSQE_FIXED_FILE
+must be set.
+Additional flags may be passed in via
+.IR install_fd_flags .
+Currently supported flags are:
+.BR IORING_FIXED_FD_NO_CLOEXEC ,
+which overrides a potentially set
+.B O_CLOEXEC
+flag set on the initial file.
+
+Available since 6.8.
+
 .PP
 The
 .I flags

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -339,6 +339,17 @@ This command works like
 an async
 .BR poll(2)
 and the completion event result is the returned mask of events.
+
+Without
+.B IORING_POLL_ADD_MULTI
+and the initial poll operation with
+.B IORING_POLL_ADD_MULTI
+the operation is level triggered, i.e. if there is data ready or events
+pending etc. at the time of submission a corresponding CQE will be posted.
+Potential further completions beyond the first caused by a
+.B IORING_POLL_ADD_MULTI
+are edge triggered.
+
 .TP
 .B IORING_OP_POLL_REMOVE
 Remove or update an existing poll request.  If found, the

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -1432,6 +1432,19 @@ must contain additional flags passed in.
 
 Available since 6.7.
 
+.TP
+.B IORING_OP_FUTEX_WAITV
+Issues the equivalent of the
+.IR futex_waitv (2)
+system call.
+.I addr
+must hold a pointer to the futexv struct,
+.I len
+must hold the length of the futexv struct, which may not be 0 and must be
+smaller than FUTEX_WAITV_MAX (as of 6.11 == 128).
+
+Available since 6.7.
+
 .PP
 The
 .I flags


### PR DESCRIPTION
<!-- Explain your changes here... -->
This adds documentation for the following missing Op codes:

1. IORING_OP_GETXATTR
2. IORING_OP_SETXATTR
3. IORING_OP_FGETXATTR
4. IORING_OP_FSETXATTR
5. IORING_OP_BIND
6. IORING_OP_LISTEN
7. IORING_OP_FTRUNCATE
8. IORING_OP_SENDMSG_ZC
9. IORING_OP_READ_MULTISHOT
10. IORING_OP_FUTEX_WAIT
11. IORING_OP_FUTEX_WAITV
12. IORING_OP_FUTEX_WAKE

It also adds documentation about:
1. the undocumented ability to sync file ranges rather than the whole file with IORING_OP_FSYNC see #990
2. the "level" and "edge triggered" behavior of IORING_OP_POLL_ADD see #1014
3. how to enforce ordering between requests after the remark in IORING_OP_FSYNC how one can not rely on ordering per default

As it seems there are no man pages for the new futex syscalls yet (they are normally done by glibc right?) I'm not very sure that I got everything right regarding these syscalls.

Two Ops that are still missing now are IORING_OP_FIXED_FD_INSTALL and IORING_OP_URING_CMD.
IORING_OP_URING_CMD should maybe have its own man page? Currently it is only nvme that is using it, but i supposed the description of it could grow large over time. (As a side note liburing helper functions for nvme cmds would be neat :) )
Regarding IORING_OP_FIXED_FD_INSTALL I wasn't entirely sure how it works. It is apparently used to take "ownership" (installing it in the reg file table and dealing with the file refcount)  of a registered file of another ring, but I wasn't sure how the passing of the file struct is actually happening. Does that have smth to do with MSG rings?

On another side note:
IORING_OP_FIXED_FD_INSTALL, IORING_OP_FTRUNCATE, IORING_OP_BIND, IORING_OP_LISTEN seem to be missing in the enum in tools/include/uapi/linux/io_uring.h, right? 

----
## git request-pull output:
```
The following changes since commit 0fe5c09195c0918f89582dd6ff098a58a0bdf62a:

  configure: fix ublk_cmd header check (2024-09-06 15:54:04 -0600)

are available in the Git repository at:

  https://github.com/CPestka/liburing io_uring_enter_man

for you to fetch changes up to c6a303d012bf453cf2dc5f593ed80814715d511b:

  man/io_uring_enter: Adds docs about the capability to fsync file ranges (2024-09-07 16:28:49 +0200)

----------------------------------------------------------------
CPestka (11):
      man/io_uring_enter: Add Docs for missing xattr related OP codes
      man/io_uring_enter: Add docs for io_uring Op code for bind(2)
      man/io_uring_enter: Adds doc for io_uring OP code of listen(2)
      man/io_uring_enter: Adds docs for io_uring op for ftruncate(2)
      man/io_uring_enter: Add docs for zero copy version of sendmsg op
      man/io_uring_enter: Add docs for multishoot variant of read OP
      man/io_uring_enter: Add doc for io_uring version of futex_wait(2)
      man/io_uring_enter: Adds docs for io_uring version of futex_wake(2)
      man/io_uring_enter: Add docs for the io_uring version of futex_waitv(2)
      man/io_uring_enter: Added remark about ordering of SQE/CQEs
      man/io_uring_enter: Adds docs about the capability to fsync file ranges

 man/io_uring_enter.2 | 182 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 182 insertions(+)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
13. Follow the commit message format rules below.
14. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
5. Then an empty line.
6. Then a description (may be omitted for truly trivial changes).
15. Then an empty line again (if it has a description).
16. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
