### PR TITLE
[GIT PULL] man/io_uring_enter: Add doc for timeout flags (multishot, etime_success), update sqe definition, various fmt-ing fixes

### DIFF
--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -205,56 +205,83 @@ structure:
  * IO submission data structure (Submission Queue Entry)
  */
 struct io_uring_sqe {
-    __u8    opcode;         /* type of operation for this sqe */
-    __u8    flags;          /* IOSQE_ flags */
-    __u16   ioprio;         /* ioprio for the request */
-    __s32   fd;             /* file descriptor to do IO on */
-    union {
-        __u64   off;            /* offset into file */
-        __u64   addr2;
-    };
-    union {
-        __u64   addr;       /* pointer to buffer or iovecs */
-        __u64   splice_off_in;
-    }
-    __u32   len;            /* buffer size or number of iovecs */
-    union {
-        __kernel_rwf_t  rw_flags;
-        __u32    fsync_flags;
-        __u16    poll_events;   /* compatibility */
-        __u32    poll32_events; /* word-reversed for BE */
-        __u32    sync_range_flags;
-        __u32    msg_flags;
-        __u32    timeout_flags;
-        __u32    accept_flags;
-        __u32    cancel_flags;
-        __u32    open_flags;
-        __u32    statx_flags;
-        __u32    fadvise_advice;
-        __u32    splice_flags;
-        __u32    rename_flags;
-        __u32    unlink_flags;
-        __u32    hardlink_flags;
-    };
-    __u64    user_data;     /* data to be passed back at completion time */
-    union {
-    struct {
-        /* index into fixed buffers, if used */
-            union {
-                /* index into fixed buffers, if used */
-                __u16    buf_index;
-                /* for grouped buffer selection */
-                __u16    buf_group;
-            }
-        /* personality to use, if used */
-        __u16    personality;
-        union {
-            __s32    splice_fd_in;
-            __u32    file_index;
+	__u8	opcode;		/* type of operation for this sqe */
+	__u8	flags;		/* IOSQE_ flags */
+	__u16	ioprio;		/* ioprio for the request */
+	__s32	fd;		/* file descriptor to do IO on */
+	union {
+		__u64	off;	/* offset into file */
+		__u64	addr2;
+		struct {
+			__u32	cmd_op;
+			__u32	__pad1;
+		};
 	};
-    };
-    __u64    __pad2[3];
-    };
+	union {
+		__u64	addr;	/* pointer to buffer or iovecs */
+		__u64	splice_off_in;
+		struct {
+			__u32	level;
+			__u32	optname;
+		};
+	};
+	__u32	len;		/* buffer size or number of iovecs */
+	union {
+		__kernel_rwf_t	rw_flags;
+		__u32		fsync_flags;
+		__u16		poll_events;	/* compatibility */
+		__u32		poll32_events;	/* word-reversed for BE */
+		__u32		sync_range_flags;
+		__u32		msg_flags;
+		__u32		timeout_flags;
+		__u32		accept_flags;
+		__u32		cancel_flags;
+		__u32		open_flags;
+		__u32		statx_flags;
+		__u32		fadvise_advice;
+		__u32		splice_flags;
+		__u32		rename_flags;
+		__u32		unlink_flags;
+		__u32		hardlink_flags;
+		__u32		xattr_flags;
+		__u32		msg_ring_flags;
+		__u32		uring_cmd_flags;
+		__u32		waitid_flags;
+		__u32		futex_flags;
+		__u32		install_fd_flags;
+		__u32		nop_flags;
+	};
+	__u64	user_data;	/* data to be passed back at completion time */
+	/* pack this to avoid bogus arm OABI complaints */
+	union {
+		/* index into fixed buffers, if used */
+		__u16	buf_index;
+		/* for grouped buffer selection */
+		__u16	buf_group;
+	} __attribute__((packed));
+	/* personality to use, if used */
+	__u16	personality;
+	union {
+		__s32	splice_fd_in;
+		__u32	file_index;
+		__u32	optlen;
+		struct {
+			__u16	addr_len;
+			__u16	__pad3[1];
+		};
+	};
+	union {
+		struct {
+			__u64	addr3;
+			__u64	__pad2[1];
+		};
+		__u64	optval;
+		/*
+		 * If the ring is initialized with IORING_SETUP_SQE128, then
+		 * this field is used for 80 bytes of arbitrary command data
+		 */
+		__u8	cmd[0];
+	};
 };
 .EE
 .in

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -609,6 +609,23 @@ instead of
 
 .PP
 .in +7
+Since 5.16,
+.B IORING_TIMEOUT_ETIME_SUCCESS
+can be set in
+.IR timeout_flags ,
+which will result in the expiration of the timer and subsequent completion
+with
+.B -ETIME
+not being interpreted as an error. This is mostly relevant for linked SQEs, as
+subsequent requests in the chain would not get canceled by the timeout, if
+this flag is set. See
+.B IOSQE_IO_LINK
+for more details on linked SQEs.
+.in
+.PP
+
+.PP
+.in +7
 Since 6.4,
 .B IORING_TIMEOUT_MULTISHOT
 can be set in

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -1544,6 +1544,7 @@ Consequently
 must contain the file index and
 .B IOSQE_FIXED_FILE
 must be set.
+The resulting regular fd is returned via cqe->res.
 Additional flags may be passed in via
 .IR install_fd_flags .
 Currently supported flags are:

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -111,7 +111,7 @@ directly in version 5.11 and newer by using this feature.
 .TP
 .B IORING_ENTER_REGISTERED_RING
 If the ring file descriptor has been registered through use of
-.B IORING_REGISTER_RING_FDS,
+.BR IORING_REGISTER_RING_FDS ,
 then setting this flag will tell the kernel that the
 .I ring_fd
 passed in is the registered ring offset rather than a normal file descriptor.
@@ -123,8 +123,8 @@ When this flag is set, the timeout argument passed in
 .I struct io_uring_getevents_arg
 will be interpreted as an absolute
 time of the registered clock (see
-.B IORING_REGISTER_CLOCK
-) until which the waiting should end.
+.BR IORING_REGISTER_CLOCK)
+until which the waiting should end.
 
 Available since 6.12
 
@@ -304,7 +304,7 @@ two operations execute in parallel, so the fsync may complete before
 the write is issued to the storage.  The same is also true for
 previously issued writes that have not completed prior to the fsync.
 To enforce ordering one may utilize linked SQEs,
-.I IOSQE_IO_DRAIN
+.B IOSQE_IO_DRAIN
 or wait for the arrival of CQEs of requests which have to be ordered
 before a given request before submitting its SQE.
 
@@ -396,7 +396,11 @@ holds the file descriptor that represents the epoll instance,
 .I off
 holds the file descriptor to add, remove or modify,
 .I len
-holds the operation (EPOLL_CTL_ADD, EPOLL_CTL_DEL, EPOLL_CTL_MOD) to perform and,
+holds the operation (
+.BR EPOLL_CTL_ADD ,
+.BR EPOLL_CTL_DEL ,
+.BR EPOLL_CTL_MOD )
+to perform and,
 .I addr
 holds a pointer to the
 .I epoll_event
@@ -534,7 +538,8 @@ field must contain a pointer to a struct __kernel_timespec structure,
 .I len
 must contain 1 to signify one __kernel_timespec structure,
 .I timeout_flags
-may contain IORING_TIMEOUT_ABS
+may contain
+.B IORING_TIMEOUT_ABS
 for an absolute timeout value, or 0 for a relative timeout.
 .I off
 may contain a completion event count. A timeout
@@ -545,12 +550,12 @@ trigger the event. If set to 0, completed events are not counted, which
 effectively acts like a timer. io_uring timeouts use the
 .B CLOCK_MONOTONIC
 clock source. The request will complete with
-.I -ETIME
+.B -ETIME
 if the timeout got completed through expiration of the timer, or
 .I 0
 if the timeout got completed through requests completing on their own. If
 the timeout was canceled before it expired, the request will complete with
-.I -ECANCELED.
+.B -ECANCELED.
 Available since 5.4.
 
 Since 5.15, this command also supports the following modifiers in
@@ -560,17 +565,17 @@ Since 5.15, this command also supports the following modifiers in
 .in +12
 .B IORING_TIMEOUT_BOOTTIME
 If set, then the clocksource used is
-.I CLOCK_BOOTTIME
+.B CLOCK_BOOTTIME
 instead of
-.I CLOCK_MONOTONIC.
+.BR CLOCK_MONOTONIC .
 This clocksource differs in that it includes time elapsed if the system was
 suspend while having a timeout request in-flight.
 
 .B IORING_TIMEOUT_REALTIME
 If set, then the clocksource used is
-.I CLOCK_REALTIME
+.B CLOCK_REALTIME
 instead of
-.I CLOCK_MONOTONIC.
+.BR CLOCK_MONOTONIC .
 .EE
 .in
 .PP
@@ -578,8 +583,8 @@ instead of
 .TP
 .B IORING_OP_TIMEOUT_REMOVE
 If
-.I timeout_flags are zero, then it attempts to remove an existing timeout
-operation.
+.I timeout_flags
+are zero, then it attempts to remove an existing timeout operation.
 .I addr
 must contain the
 .I user_data
@@ -589,16 +594,16 @@ with a result value of
 .I 0
 If the timeout request was found but expiration was already in progress,
 this request will terminate with a result value of
-.I -EBUSY
+.B -EBUSY
 If the timeout request wasn't found, the request will terminate with a result
 value of
-.I -ENOENT
+.B -ENOENT
 Available since 5.5.
 
 If
 .I timeout_flags
 contain
-.I IORING_TIMEOUT_UPDATE,
+.BR IORING_TIMEOUT_UPDATE ,
 instead of removing an existing operation, it updates it.
 .I addr
 and return values are same as before.
@@ -612,7 +617,7 @@ Available since 5.11.
 .TP
 .B IORING_OP_ACCEPT
 Issue the equivalent of an
-.BR accept4(2)
+.BR accept4 (2)
 system call.
 .I fd
 must be set to the socket file descriptor,
@@ -623,14 +628,15 @@ must contain a pointer to the socklen_t addrlen field. Flags can be passed using
 the
 .I accept_flags
 field. See also
-.BR accept4(2)
+.BR accept4 (2)
 for the general description of the related system call. Available since 5.5.
 
 If the
 .I file_index
 field is set to a positive number, the file won't be installed into the
 normal file table as usual but will be placed into the fixed file table at index
-.I file_index - 1.
+.I file_index
+- 1.
 In this case, instead of returning a file descriptor, the result will contain
 either 0 on success or an error. If the index points to a valid empty slot, the
 installation is guaranteed to not fail. If there is already a file in the slot,
@@ -640,7 +646,7 @@ Please note that only io_uring has access to such files and no other syscall
 can use them. See
 .B IOSQE_FIXED_FILE
 and
-.B IORING_REGISTER_FILES.
+.BR IORING_REGISTER_FILES .
 
 Available since 5.5.
 
@@ -655,9 +661,13 @@ complete with one of the following results codes. If found, the
 .I res
 field of the cqe will contain 0. If not found,
 .I res
-will contain -ENOENT. If found and attempted canceled, the
+will contain
+.BR -ENOENT .
+If found and attempted canceled, the
 .I res
-field will contain -EALREADY. In this case, the request may or may not
+field will contain
+.BR -EALREADY .
+In this case, the request may or may not
 terminate. In general, requests that are interruptible (like socket IO) will
 get canceled, while disk IO requests cannot be canceled if already started.
 Available since 5.5.
@@ -665,20 +675,20 @@ Available since 5.5.
 .TP
 .B IORING_OP_LINK_TIMEOUT
 This request must be linked with another request through
-.I IOSQE_IO_LINK
+.B IOSQE_IO_LINK
 which is described below. Unlike
-.I IORING_OP_TIMEOUT,
-.I IORING_OP_LINK_TIMEOUT
+.BR IORING_OP_TIMEOUT ,
+.B IORING_OP_LINK_TIMEOUT
 acts on the linked request, not the completion queue. The format of the command
 is otherwise like
-.I IORING_OP_TIMEOUT,
+.BR IORING_OP_TIMEOUT ,
 except there's no completion event count as it's tied to a specific request.
 If used, the timeout specified in the command will cancel the linked command,
 unless the linked command completes before the timeout. The timeout will
 complete with
-.I -ETIME
+.B -ETIME
 if the timer expired and the linked request was attempted canceled, or
-.I -ECANCELED
+.B -ECANCELED
 if the timer got canceled because of completion of the linked request. Like
 .B IORING_OP_TIMEOUT
 the clock source used is
@@ -689,7 +699,7 @@ Available since 5.5.
 .TP
 .B IORING_OP_CONNECT
 Issue the equivalent of a
-.BR connect(2)
+.BR connect (2)
 system call.
 .I fd
 must be set to the socket file descriptor,
@@ -697,13 +707,13 @@ must be set to the socket file descriptor,
 must contain the const pointer to the sockaddr structure, and
 .I off
 must contain the socklen_t addrlen field. See also
-.BR connect(2)
+.BR connect (2)
 for the general description of the related system call. Available since 5.5.
 
 .TP
 .B IORING_OP_FALLOCATE
 Issue the equivalent of a
-.BR fallocate(2)
+.BR fallocate (2)
 system call.
 .I fd
 must be set to the file descriptor,
@@ -713,13 +723,13 @@ must contain the mode associated with the operation,
 must contain the offset on which to operate, and
 .I addr
 must contain the length. See also
-.BR fallocate(2)
+.BR fallocate (2)
 for the general description of the related system call. Available since 5.6.
 
 .TP
 .B IORING_OP_FADVISE
 Issue the equivalent of a
-.BR posix_fadvise(2)
+.BR posix_fadvise (2)
 system call.
 .I fd
 must be set to the file descriptor,
@@ -729,13 +739,13 @@ must contain the offset on which to operate,
 must contain the length, and
 .I fadvise_advice
 must contain the advice associated with the operation. See also
-.BR posix_fadvise(2)
+.BR posix_fadvise (2)
 for the general description of the related system call. Available since 5.6.
 
 .TP
 .B IORING_OP_MADVISE
 Issue the equivalent of a
-.BR madvise(2)
+.BR madvise (2)
 system call.
 .I addr
 must contain the address to operate on,
@@ -744,13 +754,13 @@ must contain the length on which to operate,
 and
 .I fadvise_advice
 must contain the advice associated with the operation. See also
-.BR madvise(2)
+.BR madvise (2)
 for the general description of the related system call. Available since 5.6.
 
 .TP
 .B IORING_OP_OPENAT
 Issue the equivalent of a
-.BR openat(2)
+.BR openat (2)
 system call.
 .I fd
 is the
@@ -764,7 +774,7 @@ argument,
 should contain any flags passed in, and
 .I len
 is access mode of the file. See also
-.BR openat(2)
+.BR openat (2)
 for the general description of the related system call. Available since 5.6.
 
 If the
@@ -781,14 +791,14 @@ Please note that only io_uring has access to such files and no other syscall
 can use them. See
 .B IOSQE_FIXED_FILE
 and
-.B IORING_REGISTER_FILES.
+.BR IORING_REGISTER_FILES .
 
 Available since 5.15.
 
 .TP
 .B IORING_OP_OPENAT2
 Issue the equivalent of a
-.BR openat2(2)
+.BR openat2 (2)
 system call.
 .I fd
 is the
@@ -802,7 +812,7 @@ argument,
 should contain the size of the open_how structure, and
 .I off
 should be set to the address of the open_how structure. See also
-.BR openat2(2)
+.BR openat2 (2)
 for the general description of the related system call. Available since 5.6.
 
 If the
@@ -814,32 +824,31 @@ In this case, instead of returning a file descriptor, the result will contain
 either 0 on success or an error. If the index points to a valid empty slot, the
 installation is guaranteed to not fail. If there is already a file in the slot,
 it will be replaced, similar to
-.B IORING_OP_FILES_UPDATE.
+.BR IORING_OP_FILES_UPDATE .
 Please note that only io_uring has access to such files and no other syscall
 can use them. See
 .B IOSQE_FIXED_FILE
 and
-.B IORING_REGISTER_FILES.
+.BR IORING_REGISTER_FILES .
 
 Available since 5.15.
 
 .TP
 .B IORING_OP_CLOSE
 Issue the equivalent of a
-.BR close(2)
+.BR close (2)
 system call.
 .I fd
 is the file descriptor to be closed. See also
-.BR close(2)
+.BR close (2)
 for the general description of the related system call. Available since 5.6.
 If the
 .I file_index
 field is set to a positive number, this command can be used to close files
 that were direct opened through
-.B IORING_OP_OPENAT
-,
-.B IORING_OP_OPENAT2
-, or
+.BR IORING_OP_OPENAT ,
+.BR IORING_OP_OPENAT2 ,
+or
 .B IORING_OP_ACCEPT
 using the io_uring specific direct descriptors. Note that only one of the
 descriptor fields may be set. The direct close feature is available since
@@ -848,7 +857,7 @@ the 5.15 kernel, where direct descriptors were introduced.
 .TP
 .B IORING_OP_STATX
 Issue the equivalent of a
-.BR statx(2)
+.BR statx (2)
 system call.
 .I fd
 is the
@@ -870,7 +879,7 @@ argument, and
 must contain a pointer to the
 .I statxbuf
 to be filled in. See also
-.BR statx(2)
+.BR statx (2)
 for the general description of the related system call. Available since 5.6.
 
 .TP
@@ -878,9 +887,9 @@ for the general description of the related system call. Available since 5.6.
 .TP
 .B IORING_OP_WRITE
 Issue the equivalent of a
-.BR pread(2)
+.BR pread (2)
 or
-.BR pwrite(2)
+.BR pwrite (2)
 system call.
 .I fd
 is the file descriptor to be operated on,
@@ -898,23 +907,23 @@ must be set to zero or -1. If
 is set to
 .B -1
 , the offset will use (and advance) the file position, like the
-.BR read(2)
+.BR read (2)
 and
-.BR write(2)
+.BR write (2)
 system calls. These are non-vectored versions of the
 .B IORING_OP_READV
 and
 .B IORING_OP_WRITEV
 opcodes. See also
-.BR read(2)
+.BR read (2)
 and
-.BR write(2)
+.BR write (2)
 for the general description of the related system call. Available since 5.6.
 
 .TP
 .B IORING_OP_SPLICE
 Issue the equivalent of a
-.BR splice(2)
+.BR splice (2)
 system call.
 .I splice_fd_in
 is the file descriptor to read from,
@@ -926,20 +935,20 @@ is the file descriptor to write to,
 is an offset from which to start writing to. A sentinel value of
 .B -1
 is used to pass the equivalent of a NULL for the offsets to
-.BR splice(2).
+.BR splice (2).
 .I len
 contains the number of bytes to copy.
 .I splice_flags
 contains a bit mask for the flag field associated with the system call.
 Please note that one of the file descriptors must refer to a pipe.
 See also
-.BR splice(2)
+.BR splice (2)
 for the general description of the related system call. Available since 5.7.
 
 .TP
 .B IORING_OP_TEE
 Issue the equivalent of a
-.BR tee(2)
+.BR tee (2)
 system call.
 .I splice_fd_in
 is the file descriptor to read from,
@@ -951,7 +960,7 @@ contains the number of bytes to copy, and
 contains a bit mask for the flag field associated with the system call.
 Please note that both of the file descriptors must refer to a pipe.
 See also
-.BR tee(2)
+.BR tee (2)
 for the general description of the related system call. Available since 5.8.
 
 .TP
@@ -1013,7 +1022,7 @@ from. Available since 5.7.
 .TP
 .B IORING_OP_REMOVE_BUFFERS
 Remove buffers previously registered with
-.B IORING_OP_PROVIDE_BUFFERS.
+.BR IORING_OP_PROVIDE_BUFFERS .
 .I fd
 must contain the number of buffers to remove, and
 .I buf_group
@@ -1023,7 +1032,7 @@ since 5.7.
 .TP
 .B IORING_OP_SHUTDOWN
 Issue the equivalent of a
-.BR shutdown(2)
+.BR shutdown (2)
 system call.
 .I fd
 is the file descriptor to the socket being shutdown, and
@@ -1035,77 +1044,77 @@ argument. No no other fields should be set. Available since 5.11.
 .TP
 .B IORING_OP_RENAMEAT
 Issue the equivalent of a
-.BR renameat2(2)
+.BR renameat2 (2)
 system call.
 .I fd
 should be set to the
-.I olddirfd,
+.IR olddirfd ,
 .I addr
 should be set to the
-.I oldpath,
+.IR oldpath ,
 .I len
 should be set to the
-.I newdirfd,
+.IR newdirfd ,
 .I addr
 should be set to the
-.I oldpath,
+.IR oldpath ,
 .I addr2
 should be set to the
-.I newpath,
+.IR newpath ,
 and finally
 .I rename_flags
 should be set to the
 .I flags
 passed in to
-.BR renameat2(2).
+.BR renameat2 (2).
 Available since 5.11.
 
 .TP
 .B IORING_OP_UNLINKAT
 Issue the equivalent of a
-.BR unlinkat2(2)
+.BR unlinkat2 (2)
 system call.
 .I fd
 should be set to the
-.I dirfd,
+.IR dirfd ,
 .I addr
 should be set to the
-.I pathname,
+.IR pathname ,
 and
 .I unlink_flags
 should be set to the
 .I flags
 being passed in to
-.BR unlinkat(2).
+.BR unlinkat (2).
 Available since 5.11.
 
 .TP
 .B IORING_OP_MKDIRAT
 Issue the equivalent of a
-.BR mkdirat2(2)
+.BR mkdirat2 (2)
 system call.
 .I fd
 should be set to the
-.I dirfd,
+.IR dirfd ,
 .I addr
 should be set to the
-.I pathname,
+.IR pathname ,
 and
 .I len
 should be set to the
 .I mode
 being passed in to
-.BR mkdirat(2).
+.BR mkdirat (2).
 Available since 5.15.
 
 .TP
 .B IORING_OP_SYMLINKAT
 Issue the equivalent of a
-.BR symlinkat2(2)
+.BR symlinkat2 (2)
 system call.
 .I fd
 should be set to the
-.I newdirfd,
+.IR newdirfd ,
 .I addr
 should be set to the
 .I target
@@ -1114,32 +1123,32 @@ and
 should be set to the
 .I linkpath
 being passed in to
-.BR symlinkat(2).
+.BR symlinkat (2).
 Available since 5.15.
 
 .TP
 .B IORING_OP_LINKAT
 Issue the equivalent of a
-.BR linkat2(2)
+.BR linkat2 (2)
 system call.
 .I fd
 should be set to the
-.I olddirfd,
+.IR olddirfd ,
 .I addr
 should be set to the
-.I oldpath,
+.IR oldpath ,
 .I len
 should be set to the
-.I newdirfd,
+.IR newdirfd ,
 .I addr2
 should be set to the
-.I newpath,
+.IR newpath ,
 and
 .I hardlink_flags
 should be set to the
 .I flags
 being passed in to
-.BR linkat(2).
+.BR linkat (2).
 Available since 5.15.
 
 .TP
@@ -1166,7 +1175,7 @@ to pass messages via the two fields. Available since 5.18.
 .TP
 .B IORING_OP_SOCKET
 Issue the equivalent of a
-.BR socket(2)
+.BR socket (2)
 system call.
 .I fd
 must contain the communication domain,
@@ -1176,24 +1185,25 @@ must contain the communication type,
 must contain the protocol, and
 .I rw_flags
 is currently unused and must be set to zero. See also
-.BR socket(2)
+.BR socket (2)
 for the general description of the related system call. Available since 5.19.
 
 If the
 .I file_index
 field is set to a positive number, the file won't be installed into the
 normal file table as usual but will be placed into the fixed file table at index
-.I file_index - 1.
+.I file_index
+- 1.
 In this case, instead of returning a file descriptor, the result will contain
 either 0 on success or an error. If the index points to a valid empty slot, the
 installation is guaranteed to not fail. If there is already a file in the slot,
 it will be replaced, similar to
-.B IORING_OP_FILES_UPDATE.
+.BR IORING_OP_FILES_UPDATE .
 Please note that only io_uring has access to such files and no other syscall
 can use them. See
 .B IOSQE_FIXED_FILE
 and
-.B IORING_REGISTER_FILES.
+.BR IORING_REGISTER_FILES .
 
 Available since 5.19.
 
@@ -1210,10 +1220,12 @@ Available since 5.19.
 .B IORING_OP_SEND_ZC
 Issue the zerocopy equivalent of a
 .BR send(2)
-system call. Similar to IORING_OP_SEND, but tries to avoid making intermediate
+system call. Similar to
+.BR IORING_OP_SEND ,
+but tries to avoid making intermediate
 copies of data. Zerocopy execution is not guaranteed and may fall back to
 copying. The request may also fail with
-.B -EOPNOTSUPP ,
+.BR -EOPNOTSUPP ,
 when a protocol doesn't support zerocopy, in which case users are recommended
 to use copying sends instead.
 
@@ -1222,7 +1234,7 @@ The
 field of the first
 .I "struct io_uring_cqe"
 may likely contain
-.B IORING_CQE_F_MORE ,
+.BR IORING_CQE_F_MORE ,
 which means that there will be a second completion event / notification for
 the request, with the
 .I user_data
@@ -1235,7 +1247,7 @@ notification's
 field will be set to zero and the
 .I flags
 field will contain
-.B IORING_CQE_F_NOTIF .
+.BR IORING_CQE_F_NOTIF .
 The two step model is needed because the kernel may hold on to buffers for a
 long time, e.g. waiting for a TCP ACK, and having a separate cqe for request
 completions allows userspace to push more data without extra delays. Note,
@@ -1258,7 +1270,7 @@ holds the flags associated with the system call. When
 is non-zero it points to the address of the target with
 .I addr_len
 specifying its size, turning the request into a
-.BR sendto(2)
+.BR sendto (2)
 system call equivalent.
 
 Available since 6.0.
@@ -1293,20 +1305,20 @@ Issue the zerocopy equivalent of a
 .BR sendmsg (2)
 system call.
 Works just like
-.IR IORING_OP_SENDMSG ,
+.BR IORING_OP_SENDMSG ,
 but like
-.I IORING_OP_SEND_ZC
+.B IORING_OP_SEND_ZC
 supports
-.IR IORING_RECVSEND_FIXED_BUF .
+.BR IORING_RECVSEND_FIXED_BUF .
 For additional notes regarding zero copy see
-.IR IORING_OP_SEND_ZC .
+.BR IORING_OP_SEND_ZC .
 
 Available since 6.1
 
 .TP
 .B IORING_OP_WAITID
 Issue the equivalent of a
-.BR waitid(2)
+.BR waitid (2)
 system call.
 .I len
 must contain the idtype being queried/waited for and
@@ -1316,7 +1328,7 @@ must contain the 'pid' (or id) being waited for.
 is the 'options' being set (the child state changes to wait for).
 .I addr2
 is a pointer to siginfo_t, if any, being filled in. See also
-.BR waitid(2)
+.BR waitid (2)
 for the general description of the related system call. Available since 6.5.
 
 .TP
@@ -1328,13 +1340,13 @@ for the general description of the related system call. Available since 6.5.
 .TP
 .B IORING_OP_FGETXATTR
 Issue the equivalent of a
-.BR setxattr(2)
+.BR setxattr (2)
 or
-.BR getxattr(2)
+.BR getxattr (2)
 or
-.BR fsetxattr(2)
+.BR fsetxattr (2)
 or
-.BR fgetxattr(2)
+.BR fgetxattr (2)
 system call.
 .I addr
 must contain a pointer to a buffer containing the name of the extended
@@ -1346,15 +1358,15 @@ in which the value of the extended attribute is to be placed or is read from.
 Additional flags maybe provided in
 .IR xattr_flags .
 For
-.IR setxattr(2)
+.BR setxattr (2)
 or
-.IR getxattr(2)
+.BR getxattr (2)
 .I addr3
 must contain a pointer to the path of the file.
 For
-.IR fsetxattr(2)
+.BR fsetxattr (2)
 or
-.IR fgetxattr(2)
+.BR fgetxattr (2)
 .I fd
 must contain the file descriptor of the file.
 
@@ -1363,7 +1375,7 @@ Available since 5.19.
 .TP
 .B IORING_OP_BIND
 Issues the equivalent of the
-.IR bind (2)
+.BR bind (2)
 system call.
 .I fd
 must contain the file descriptor of the socket,
@@ -1378,7 +1390,7 @@ Available since 6.11.
 .TP
 .B IORING_OP_LISTEN
 Issues the equivalent of the
-.IR listen(2)
+.BR listen (2)
 system call.
 .I fd
 must contain the file descriptor of the socket and
@@ -1391,7 +1403,7 @@ Available since 6.11.
 .TP
 .B IORING_OP_FTRUNCATE
 Issues the equivalent of the
-.IR ftruncate (2)
+.BR ftruncate (2)
 system call.
 .I fd
 must contain the file descriptor of the file to truncate and
@@ -1403,41 +1415,41 @@ Available since 6.9.
 .TP
 .B IORING_OP_READ_MULTISHOT
 Like
-.IR IORING_OP_READ ,
+.BR IORING_OP_READ ,
 but similar to requests prepared with
 .IR io_uring_prep_multishot_accept (3)
 additional reads and thus CQEs will be performed based on this single SQE once
 there is more data available.
 Is restricted to pollable files and will fall back to single shot if the file
 does not support
-.IR NOWAIT .
+.BR NOWAIT .
 Like other multishot type requests, the application should look at the CQE
 flags and see if
-.I IORING_CQE_F_MORE
+.B IORING_CQE_F_MORE
 is set on completion as an indication of whether or not the read request will
 generate further CQEs. Available since 6.7.
 
 .TP
 .B IORING_OP_FUTEX_WAIT
 Issues the equivalent of the
-.IR futex_wait (2)
+.BR futex_wait (2)
 system call.
 .I addr
 must hold a pointer to the futex,
 .I addr2
 must hold the value to which the futex has to be changed so this caller to
-.IR futex_wait (2)
+.BR futex_wait (2)
 can be woken by a call to
-.IR futex_wake (2),
+.BR futex_wake (2),
 .I addr3
 must hold the bitmask of this
-.IR futex_wait (2)
+.BR futex_wait (2)
 caller.
 For a caller of
-.IR futex_wake (2)
+.BR futex_wake (2)
 to wake a waiter additionally the bitmask of the waiter and waker must have
 at least one set bit in common.
-.IR fd
+.I fd
 must contain additional flags passed in.
 
 Available since 6.7.
@@ -1445,7 +1457,7 @@ Available since 6.7.
 .TP
 .B IORING_OP_FUTEX_WAKE
 Issues the equivalent of the
-.IR futex_wake (2)
+.BR futex_wake (2)
 system call.
 .I addr
 must hold a pointer to the futex,
@@ -1453,11 +1465,11 @@ must hold a pointer to the futex,
 must hold the maximum number of waiters waiting on this futex to wake,
 .I addr3
 must hold the bitmask of this
-.IR futex_wake (2)
+.BR futex_wake (2)
 call.
 To wake a waiter additionally the bitmask of the waiter and waker must have
 at least one set bit in common.
-.IR fd
+.I fd
 must contain additional flags passed in.
 
 Available since 6.7.
@@ -1465,13 +1477,15 @@ Available since 6.7.
 .TP
 .B IORING_OP_FUTEX_WAITV
 Issues the equivalent of the
-.IR futex_waitv (2)
+.BR futex_waitv (2)
 system call.
 .I addr
 must hold a pointer to the futexv struct,
 .I len
 must hold the length of the futexv struct, which may not be 0 and must be
-smaller than FUTEX_WAITV_MAX (as of 6.11 == 128).
+smaller than
+.B FUTEX_WAITV_MAX
+(as of 6.11 == 128).
 
 Available since 6.7.
 
@@ -1508,7 +1522,7 @@ section of the
 .BR io_uring_register (2)
 man page). Note that this isn't always available for all commands. If used on
 a command that doesn't support fixed files, the SQE will error with
-.B -EBADF.
+.BR -EBADF .
 Available since 5.1.
 .TP
 .B IOSQE_IO_DRAIN
@@ -1538,7 +1552,10 @@ as the error code. Available since 5.3.
 Like IOSQE_IO_LINK, but it doesn't sever regardless of the completion result.
 Note that the link will still sever if we fail submitting the parent request,
 hard links are only resilient in the presence of completion results for
-requests that did submit correctly. IOSQE_IO_HARDLINK implies IOSQE_IO_LINK.
+requests that did submit correctly.
+.B IOSQE_IO_HARDLINK
+implies
+.BR IOSQE_IO_LINK .
 Available since 5.5.
 .TP
 .B IOSQE_ASYNC
@@ -1573,7 +1590,7 @@ fails, an appropriate CQE will be posted as usual and if there is no
 .B IOSQE_IO_HARDLINK,
 CQEs for all linked requests will be omitted. The notion of failure/success is
 opcode specific and is the same as with breaking chains of
-.B IOSQE_IO_LINK.
+.BR IOSQE_IO_LINK .
 One special case is when the request has a linked timeout, then the CQE
 generation for the linked timeout is decided solely by whether it has
 .B IOSQE_CQE_SKIP_SUCCESS
@@ -1588,10 +1605,10 @@ enough for userspace to know the state of the system. One such example would
 be writing to a synchronisation file.
 
 This flag is incompatible with
-.B IOSQE_IO_DRAIN.
+.BR IOSQE_IO_DRAIN .
 Using both of them in a single ring is undefined behavior, even when they are
 not used together in a single request. Currently, after the first request with
-.B IOSQE_CQE_SKIP_SUCCESS,
+.BR IOSQE_CQE_SKIP_SUCCESS ,
 all subsequent requests marked with drain will be failed at submission time.
 Note that the error reporting is best effort only, and restrictions may change
 in the future.
@@ -1658,7 +1675,7 @@ is an index into an array of fixed buffers, and is only valid if fixed
 buffers were registered.
 .I personality
 is the credentials id to use for this operation. See
-.BR io_uring_register(2)
+.BR io_uring_register (2)
 for how to register personalities with io_uring. If set to 0, the current
 personality of the submitting task is used.
 .PP
@@ -1694,13 +1711,14 @@ is used for certain commands, like
 or in conjunction with
 .B IOSQE_BUFFER_SELECT
 or
-.B IORING_OP_MSG_RING,
-, see those entries for details.
+.BR IORING_OP_MSG_RING ,
+see those entries for details.
 .I res
 is the operation-specific result, but io_uring-specific errors
 (e.g. flags or opcode invalid) are returned through this field.
 They are described in section
-.B CQE ERRORS.
+.B CQE
+.BR ERRORS .
 .PP
 For read and write opcodes, the
 return values match
@@ -1734,7 +1752,8 @@ as submission happens outside the context of the system call.
 
 The errors related to a submission queue entry will be returned through a
 completion queue entry (see section
-.B CQE ERRORS),
+.B CQE
+.BR ERRORS ),
 rather than through the system call itself.
 
 Errors that occur not on behalf of a submission queue entry are returned via the
@@ -1822,7 +1841,7 @@ does not refer to an io_uring instance.
 .B EINTR
 The operation was interrupted by a delivery of a signal before it could
 complete; see
-.BR signal(7).
+.BR signal (7).
 Can happen while waiting for events with
 .B IORING_ENTER_GETEVENTS.
 .TP

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -576,7 +576,7 @@ or the specified number of events have completed. Either condition will
 trigger the event. If set to 0, completed events are not counted, which
 effectively acts like a timer. io_uring timeouts use the
 .B CLOCK_MONOTONIC
-clock source. The request will complete with
+as the default clock source. The request will complete with
 .B -ETIME
 if the timeout got completed through expiration of the timer, or
 .I 0

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -607,6 +607,25 @@ instead of
 .in
 .PP
 
+.PP
+.in +7
+Since 6.4,
+.B IORING_TIMEOUT_MULTISHOT
+can be set in
+.IR timeout_flags ,
+which will result in the timer producing multiple consecutive completions
+like other multi shot operations e.g.
+.B IORING_OP_READ_MULTISHOT
+or
+.BR IORING_POLL_ADD_MULTI .
+.I off
+must be set to the amount of desired completions.
+.B IORING_TIMEOUT_MULTISHOT
+must not be used with
+.BR IORING_TIMEOUT_ABS .
+.in
+.PP
+
 .TP
 .B IORING_OP_TIMEOUT_REMOVE
 If
@@ -2010,3 +2029,12 @@ was set in the
 field of the submission queue entry, but the
 .I opcode
 doesn't support buffer selection.
+.TP
+.B EINVAL
+.B IORING_OP_TIMEOUT
+was specified, but
+.I timeout_flags
+specified more than one clock source or
+.B IORING_TIMEOUT_MULTISHOT
+was set alongside
+.BR IORING_TIMEOUT_ABS .


### PR DESCRIPTION
<!-- Explain your changes here... -->
This 
1. Adds documentation for
    1. IORING_TIMEOUT_MULTISHOT
    2. IORING_TIMEOUT_ETIME_SUCCESS
    3. some possible errors regarding the timeout op
2. Updates the sqe definition in the man page to the current one in io_uring.h
3. Attempts to fix various formatting errors/inconsistencies, like use of .I rather than .B for flags described in man page.
4. Add some small remarks about the return value of the install registered fd op and the default clock of the timeout op
----
## git request-pull output:
```
The following changes since commit ad42755a00e27eaeb20089c2984b0211d3292a96:

  test/futex: don't leave futex wait pending (2024-09-14 10:04:40 -0600)

are available in the Git repository at:

  https://github.com/CPestka/liburing io_uring_enter_man

for you to fetch changes up to 1438d97086c349859709b51d1a12ad120a40b1f8:

  man/io_uring_enter: Add doc for IORING_TIMEOUT_ETIME_SUCCESS (2024-09-15 13:39:40 +0200)

----------------------------------------------------------------
CPestka (6):
      man/io_uring_enter: Various formatting fixes
      man/io_uring_enter: Update sqe definition in man page
      man/io_uring_enter: Add docs for multi shot variant of timer op
      man/io_uring_enter: Add remark about default clock for timer ops
      man/io_uring_enter: Add remark about return value of reg fd -> fd op
      man/io_uring_enter: Add doc for IORING_TIMEOUT_ETIME_SUCCESS

 man/io_uring_enter.2 | 474 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-------------------------------------------------------------------------------------------------------
 1 file changed, 283 insertions(+), 191 deletions(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
5. Follow the commit message format rules below.
6. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
5. Then an empty line.
6. Then a description (may be omitted for truly trivial changes).
7. Then an empty line again (if it has a description).
8. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
