### PR TITLE
[GIT PULL] minor kdigest follow-ups

### DIFF
--- a/examples/kdigest.c
+++ b/examples/kdigest.c
@@ -278,7 +278,8 @@ static int get_result(struct kdigest *kdigest, const char *alg, const char *file
 		goto err;
 	}
 
-	fprintf(stdout, "uring %s(%s) returned(len=%u): ", alg, file, cqe->res);
+	fprintf(stdout, "uring %s%s(%s) returned(len=%u): ",
+		kdigest->br ? "bundled " : "", alg, file, cqe->res);
 	for (i = 0; i < cqe->res; i++)
 		fprintf(stdout, "%02x", kdigest->bufs[i]);
 	putc('\n', stdout);

--- a/examples/kdigest.c
+++ b/examples/kdigest.c
@@ -253,16 +253,16 @@ static int digest_file(struct kdigest *kdigest, size_t insize)
 	return 0;
 }
 
-static int get_result(struct io_uring *ring, const char *alg, const char *file)
+static int get_result(struct kdigest *kdigest, const char *alg, const char *file)
 {
+	struct io_uring *ring = &kdigest->ring;
 	struct io_uring_sqe *sqe;
 	struct io_uring_cqe *cqe;
 	int i, ret;
-	/* buffer must be large enough to carry longest hash result */
-	uint8_t buf[128];
+	/* reuse I/O buf block to stash hash result */
 
 	sqe = io_uring_get_sqe(ring);
-	io_uring_prep_recv(sqe, outfd, buf, sizeof(buf), 0);
+	io_uring_prep_recv(sqe, outfd, kdigest->bufs, BS, 0);
 
 	if (io_uring_submit_and_wait(ring, 1) < 0)
 		return 1;
@@ -280,7 +280,7 @@ static int get_result(struct io_uring *ring, const char *alg, const char *file)
 
 	fprintf(stdout, "uring %s(%s) returned(len=%u): ", alg, file, cqe->res);
 	for (i = 0; i < cqe->res; i++)
-		fprintf(stdout, "%02x", buf[i]);
+		fprintf(stdout, "%02x", kdigest->bufs[i]);
 	putc('\n', stdout);
 	ret = 0;
 err:
@@ -384,7 +384,7 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
-	ret = get_result(&kdigest.ring, alg, infile);
+	ret = get_result(&kdigest, alg, infile);
 	if (ret) {
 		fprintf(stderr, "failed to retrieve %s digest result\n", alg);
 		return 1;

--- a/test/bind-listen.c
+++ b/test/bind-listen.c
@@ -180,7 +180,7 @@ static int test_good_server(unsigned int ring_flags)
 	io_uring_cqe_seen(&ring, cqe);
 
 	sqe = io_uring_get_sqe(&ring);
-	io_uring_prep_recv(sqe, CONN_INDEX, buf, BUFSIZ, 0);
+	io_uring_prep_recv(sqe, CONN_INDEX, buf, sizeof(buf), 0);
 	sqe->flags |= IOSQE_FIXED_FILE;
 
 	io_uring_submit(&ring);


### PR DESCRIPTION
A couple of minor follow-ups for the kdigest example and one test/bind-listen buflen fix.

----
## git request-pull output:
```
The following changes since commit 352c8ab127e1924d64fbbd2bf337c06d1c1abd03:

  examples/kdigest: misc updates and improvements (2024-10-01 16:44:35 -0600)

are available in the Git repository at:

  https://github.com/ddiss/liburing.git kdigest_follow_ups

for you to fetch changes up to 33de51d36c3e78dfea2a93abf27dc4f2809f43b6:

  examples/kdigest: print whether bundled sends were used (2024-10-03 03:00:09 +0000)

----------------------------------------------------------------
David Disseldorp (3):
      test/bind-listen: fix incorrect io_uring_prep_recv buflen
      examples/kdigest: reuse I/O buffer for hash result
      examples/kdigest: print whether bundled sends were used

 examples/kdigest.c | 15 ++++++++-------
 test/bind-listen.c |  2 +-
 2 files changed, 9 insertions(+), 8 deletions(-)
```