### PR TITLE
man/io_uring_peek_cqe: fix unclosed quotation mark

### DIFF
--- a/man/io_uring_peek_cqe.3
+++ b/man/io_uring_peek_cqe.3
@@ -14,7 +14,7 @@ io_uring_peek_cqe \- check if an io_uring completion event is available
 .PP
 .BI "int io_uring_peek_batch_cqe(struct io_uring *" ring ","
 .BI "                            struct io_uring_cqe **" cqe_ptrs ","
-.BI "                            unsigned count ");"
+.BI "                            unsigned " count ");"
 .fi
 .SH DESCRIPTION
 .PP


### PR DESCRIPTION
Due to an unclosed quotation mark, the io_uring_peek_batch_cqe prototype was rendered like this:

       int io_uring_peek_batch_cqe(struct io_uring *ring,
                                   struct io_uring_cqe **cqe_ptrs,
                                   unsigned count );"

----
## git request-pull output:
```
The following changes since commit a0d60e796006fa3dc1a75250a2039abffa52da19:

  man/io_uring_prep_openat2: get rid of non-existent flags argument (2024-11-20 07:52:59 -0700)

are available in the Git repository at:

  https://github.com/tavianator/liburing fix-quotmark

for you to fetch changes up to a35136ae9d75d726f84f387447253cf25dac646c:

  man/io_uring_peek_cqe: fix unclosed quotation mark (2024-11-20 12:12:01 -0500)

----------------------------------------------------------------
Tavian Barnes (1):
      man/io_uring_peek_cqe: fix unclosed quotation mark

 man/io_uring_peek_cqe.3 | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
