### PR TITLE
[GIT PULL] Man improvements

### DIFF
--- a/man/io_uring.7
+++ b/man/io_uring.7
@@ -453,8 +453,8 @@ its return value.
 
 The
 .I flags
-field carries request-specific information. As of the 6.0 kernel, the following
-flags are defined:
+field carries request-specific information. As of the 6.12 kernel,
+the following flags are defined:
 
 .TP
 .B IORING_CQE_F_BUFFER
@@ -488,7 +488,7 @@ buffer space left, and hence the application should expect more completions
 with this buffer ID. Each completion will continue where the previous one
 left off. This can only happen if the provided buffer ring has been setup
 with
-.B IORING_REGISTER_PBUF_RING
+.B IOU_PBUF_RING_INC
 to allow for incremental / partial consumption of buffers.
 .PP
 The general sequence to read completion events off the completion queue is

--- a/man/io_uring_prep_msg_ring_fd.3
+++ b/man/io_uring_prep_msg_ring_fd.3
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_prep_msg_ring 3 "Mar 16, 2023" "liburing-2.4" "liburing Manual"
+.TH io_uring_prep_msg_ring_fd 3 "Mar 16, 2023" "liburing-2.4" "liburing Manual"
 .SH NAME
 io_uring_prep_msg_ring_fd \- send a direct descriptor to another ring
 .SH SYNOPSIS

--- a/man/io_uring_prep_read_fixed.3
+++ b/man/io_uring_prep_read_fixed.3
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_prep_read 3 "February 13, 2022" "liburing-2.1" "liburing Manual"
+.TH io_uring_prep_read_fixed 3 "February 13, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
 io_uring_prep_read_fixed \- prepare I/O read request with registered buffer
 .SH SYNOPSIS

--- a/man/io_uring_prep_timeout.3
+++ b/man/io_uring_prep_timeout.3
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_prep_poll_timeout 3 "March 12, 2022" "liburing-2.2" "liburing Manual"
+.TH io_uring_prep_timeout 3 "March 12, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
 io_uring_prep_timeout \- prepare a timeout request
 .SH SYNOPSIS

--- a/man/io_uring_prep_timeout_update.3
+++ b/man/io_uring_prep_timeout_update.3
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_prep_poll_timeout_update 3 "March 12, 2022" "liburing-2.2" "liburing Manual"
+.TH io_uring_prep_timeout_update 3 "March 12, 2022" "liburing-2.2" "liburing Manual"
 .SH NAME
 io_uring_prep_timeout_update \- prepare a request to update an existing timeout
 .SH SYNOPSIS

--- a/man/io_uring_prep_write_fixed.3
+++ b/man/io_uring_prep_write_fixed.3
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_prep_write 3 "February 13, 2022" "liburing-2.1" "liburing Manual"
+.TH io_uring_prep_write_fixed 3 "February 13, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
 io_uring_prep_write_fixed \- prepare I/O write request with registered buffer
 .SH SYNOPSIS

--- a/man/io_uring_register.2
+++ b/man/io_uring_register.2
@@ -113,27 +113,25 @@ but aims to have a more extensible ABI.
 
 .I arg
 points to a
-.IR struct io_uring_rsrc_register ,
+.I struct
+.IR io_uring_rsrc_register ,
 and
 .I nr_args
 should be set to the number of bytes in the structure.
 
-.PP
-.in +8n
+.IP
+.in +4n
 .EX
 struct io_uring_rsrc_register {
     __u32 nr;
-    __u32 resv;
+    __u32 flags;
     __u64 resv2;
     __aligned_u64 data;
     __aligned_u64 tags;
 };
-
 .EE
 .in
-.PP
-
-.in +8n
+.IP
 
 The
 .I data
@@ -153,6 +151,23 @@ resource had been unregistered and it's not used anymore, a CQE will be
 posted with
 .I user_data
 set to the specified tag and all other fields zeroed.
+
+The
+.I flags
+field supports the following flags:
+
+.IP
+.in +4n
+.B IORING_RSRC_REGISTER_SPARSE
+If set, io_uring will register
+.I nr
+empty buffers, which need to be updated before use. When this flag is set,
+.I data
+and
+.I tags
+must be NULL. Available since 5.19.
+.in
+.IP
 
 Note that resource updates, e.g.
 .BR IORING_REGISTER_BUFFERS_UPDATE ,

--- a/man/io_uring_register_buf_ring.3
+++ b/man/io_uring_register_buf_ring.3
@@ -72,7 +72,7 @@ The
 .I flags
 argument can be set to one of the following values:
 .TP
-.B IORING_REGISTER_PBUF_RING
+.B IOU_PBUF_RING_INC
 The buffers in this ring can be incrementally consumed. With partial
 consumption, each completion of a given buffer ID will continue where the
 previous one left off, or from the start if no completions have been seen yet.
@@ -81,7 +81,7 @@ have
 .B IORING_CQE_F_BUF_MORE
 set in the
 .I flags
-member.
+member. Available since 6.12.
 .PP
 
 A shared buffer ring looks as follows:
@@ -90,13 +90,13 @@ A shared buffer ring looks as follows:
 .EX
 struct io_uring_buf_ring {
     union {
-	struct {
+        struct {
             __u64 resv1;
             __u32 resv2;
             __u16 resv3;
             __u16 tail;
-	};
-	struct io_uring_buf bufs[0];
+        };
+        struct io_uring_buf bufs[0];
     };
 };
 .EE

--- a/man/io_uring_setup_buf_ring.3
+++ b/man/io_uring_setup_buf_ring.3
@@ -10,10 +10,10 @@ io_uring_setup_buf_ring \- setup and register buffer ring for provided buffers
 .B #include <liburing.h>
 .PP
 .BI "struct io_uring_buf_ring *io_uring_setup_buf_ring(struct io_uring *" ring ",
-.BI "                            unsigned int " nentries ",
-.BI "                            int " bgid ",
-.BI "                            unsigned int " flags ",
-.BI "                            int *" err ");"
+.BI "                                                  unsigned int " nentries ",
+.BI "                                                  int " bgid ",
+.BI "                                                  unsigned int " flags ",
+.BI "                                                  int *" err ");"
 .BI "
 .fi
 .SH DESCRIPTION
@@ -49,7 +49,7 @@ The
 .I flags
 argument can be set to one of the following values:
 .TP
-.B IORING_REGISTER_PBUF_RING
+.B IOU_PBUF_RING_INC
 The buffers in this ring can be incrementally consumed. With partial
 consumption, each completion of a given buffer ID will continue where the
 previous one left off, or from the start if no completions have been seen yet.
@@ -58,7 +58,7 @@ have
 .B IORING_CQE_F_BUF_MORE
 set in the
 .I flags
-member.
+member. Available since 6.12.
 .PP
 
 Under the covers, this function uses

--- a/man/io_uring_sq_space_left.3
+++ b/man/io_uring_sq_space_left.3
@@ -2,7 +2,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_sq_space-left 3 "January 25, 2022" "liburing-2.1" "liburing Manual"
+.TH io_uring_sq_space_left 3 "January 25, 2022" "liburing-2.1" "liburing Manual"
 .SH NAME
 io_uring_sq_space_left \- free space in the SQ ring
 .SH SYNOPSIS


### PR DESCRIPTION
Several fixes and improvements to the man pages:

- fixed buf ring registration flags,
- fixed title headings,
- improved IORING_REGISTER_BUFFERS2 description.

----
## git request-pull output:
```
The following changes since commit 9032c80cdc7e64bf146ec801fa8917bed6493075:

  man/io_uring_register_sync_cancel.3: update io_uring_sync_cancel_reg (2024-11-29 09:14:14 -0700)

are available in the Git repository at:

  https://github.com/wlukowicz/liburing man-fixes

for you to fetch changes up to 416d96ce5a4bb0ffb366b93a3c7333842cc290d8:

  man/io_uring_register.2: improve IORING_REGISTER_BUFFERS2 description (2024-12-01 15:44:56 +0000)

----------------------------------------------------------------
Wojciech Łukowicz (3):
      man: fix buf ring registration flags
      man: fix title headings
      man/io_uring_register.2: improve IORING_REGISTER_BUFFERS2 description

 man/io_uring.7                     |  6 +++---
 man/io_uring_prep_msg_ring_fd.3    |  2 +-
 man/io_uring_prep_read_fixed.3     |  2 +-
 man/io_uring_prep_timeout.3        |  2 +-
 man/io_uring_prep_timeout_update.3 |  2 +-
 man/io_uring_prep_write_fixed.3    |  2 +-
 man/io_uring_register.2            | 31 +++++++++++++++++++++++--------
 man/io_uring_register_buf_ring.3   | 10 +++++-----
 man/io_uring_setup_buf_ring.3      | 12 ++++++------
 man/io_uring_sq_space_left.3       |  2 +-
 10 files changed, 43 insertions(+), 28 deletions(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
