### PR TITLE
test/init-mem: zero the ringbuf memory

### DIFF
--- a/test/init-mem.c
+++ b/test/init-mem.c
@@ -41,6 +41,8 @@ static int setup_ctx(struct ctx *ctx, struct q_entries *q)
 	if (posix_memalign(&ctx->mem, 4096, 2*1024*1024))
 		return T_EXIT_FAIL;
 
+	memset(ctx->mem, 0, 2*1024*1024);
+
 	ctx->pre = ctx->mem + 4096 - sizeof(unsigned long long);
 	*ctx->pre = PRE_RED;
 


### PR DESCRIPTION
This is a similar fix to commit 8100d7b5f862 (test/buf-ring-nommap: zero the ringbuf memory). The same is needed for test/init-mem as it crashes with `MALLOC_PERTURB_=69` too.

So zero the ringbuf memory after posix_memalign() too.

Fixes #1291.