### PR TITLE
test/fallocate: check for `EOPNOTSUPP` too (6.4)

### DIFF
--- a/test/fallocate.c
+++ b/test/fallocate.c
@@ -65,7 +65,7 @@ static int test_fallocate_rlimit(struct io_uring *ring)
 		goto err;
 	}
 
-	if (cqe->res == -EINVAL) {
+	if (cqe->res == -EINVAL || cqe->res == -EOPNOTSUPP) {
 		fprintf(stdout, "Fallocate not supported, skipping\n");
 		no_fallocate = 1;
 		goto skip;


### PR DESCRIPTION
In kernel 6.4, the result still can be `EOPNOTSUPP`. Check for that too.