### PR TITLE
[GIT PULL] add io_uring_sqe_set_buf group

### DIFF
--- a/man/io_uring_sqe_set_buf_group.3
+++ b/man/io_uring_sqe_set_buf_group.3
@@ -1,0 +1,32 @@
+.\" Copyright (C) 2024 Christian Mazakas <christian.mazakas@gmail.com>
+.\"
+.\" SPDX-License-Identifier: LGPL-2.0-or-later
+.\"
+.TH io_uring_sqe_set_buf_group 3 "December 9, 2024" "liburing-2.9" "liburing Manual"
+.SH NAME
+io_uring_sqe_set_buf_group \- set buf group for submission queue event
+.SH SYNOPSIS
+.nf
+.B #include <liburing.h>
+.PP
+.BI "void io_uring_sqe_set_buf_group(struct io_uring_sqe *" sqe ","
+.BI "                                int " bgid ");"
+.fi
+.SH DESCRIPTION
+.PP
+The
+.BR io_uring_sqe_set_buf_group (3)
+function sets the associated buf_group of the
+.I sqe
+to
+.IR bgid .
+
+After the caller has requested a submission queue entry (SQE) with
+.BR io_uring_get_sqe (3) ,
+they can associate a buf_group with the SQE used for multishot operations.
+
+.SH RETURN VALUE
+None
+.SH SEE ALSO
+.BR io_uring_get_sqe (3),
+.BR io_uring_cqe_set_data (3)

--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -409,6 +409,12 @@ IOURINGINLINE void io_uring_sqe_set_flags(struct io_uring_sqe *sqe,
 	sqe->flags = (__u8) flags;
 }
 
+IOURINGINLINE void io_uring_sqe_set_buf_group(struct io_uring_sqe *sqe,
+					      int bgid)
+{
+	sqe->buf_group = (__u16) bgid;
+}
+
 IOURINGINLINE void __io_uring_set_target_fixed_file(struct io_uring_sqe *sqe,
 						    unsigned int file_index)
 {

--- a/src/liburing-ffi.map
+++ b/src/liburing-ffi.map
@@ -223,4 +223,5 @@ LIBURING_2.9 {
 		io_uring_submit_and_wait_reg;
 		io_uring_clone_buffers_offset;
 		io_uring_register_region;
+		io_uring_sqe_set_buf_group;
 } LIBURING_2.8;

--- a/test/recv-multishot.c
+++ b/test/recv-multishot.c
@@ -165,7 +165,7 @@ static int test(struct args *args)
 		io_uring_prep_recv_multishot(sqe, fds[0], NULL, 0, 0);
 	}
 	sqe->flags |= IOSQE_BUFFER_SELECT;
-	sqe->buf_group = 7;
+        io_uring_sqe_set_buf_group(sqe, 7);
 	io_uring_sqe_set_data64(sqe, 1234);
 	io_uring_submit(&ring);
 
@@ -503,7 +503,7 @@ static int test_enobuf(void)
 	assert(sqe);
 	io_uring_prep_recv_multishot(sqe, fds[0], NULL, 0, 0);
 	io_uring_sqe_set_data64(sqe, 1);
-	sqe->buf_group = 0;
+	io_uring_sqe_set_buf_group(sqe, 0);
 	sqe->flags |= IOSQE_BUFFER_SELECT;
 
 	ret = io_uring_submit(&ring);


### PR DESCRIPTION
Adds the free function io_uring_sqe_set_buf_group so that users of liburing-ffi don't have to navigate the complex io_uring_sqe structure.


<!-- Explain your changes here... -->

----
## git request-pull output:
```
The following changes since commit c3d5d6270cd5ed48d817fc1e8e95f7c8b222f2ff:

  man/io_uring_prep_cancel.3: correct io_uring_prep_cancel_fd() flags (2024-12-07 13:35:56 -0700)

are available in the Git repository at:

  https://github.com/cmazakas/liburing.git set-buf-group

for you to fetch changes up to 1dd8059a7d66d9126021154c24945623ef62a834:

  add io_uring_sqe_set_buf group (2024-12-09 12:00:26 -0800)

----------------------------------------------------------------
Christian Mazakas (1):
      add io_uring_sqe_set_buf group

 man/io_uring_sqe_set_buf_group.3 | 32 ++++++++++++++++++++++++++++++++
 src/include/liburing.h           |  6 ++++++
 src/liburing-ffi.map             |  1 +
 test/recv-multishot.c            |  4 ++--
 4 files changed, 41 insertions(+), 2 deletions(-)
 create mode 100644 man/io_uring_sqe_set_buf_group.3
```

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
