### PR TITLE
[GIT PULL] Hide io_uring_get_sqe symbol

### DIFF
--- a/debian/liburing2.symbols
+++ b/debian/liburing2.symbols
@@ -11,7 +11,6 @@ liburing.so.2 liburing2 #MINVER#                                                
  io_uring_get_events@LIBURING_2.3 0.7-1
  io_uring_get_probe@LIBURING_2.0 0.7-1
  io_uring_get_probe_ring@LIBURING_2.0 0.7-1
- io_uring_get_sqe@LIBURING_2.0 0.7-1
  io_uring_mlock_size@LIBURING_2.1 0.7-1
  io_uring_mlock_size_params@LIBURING_2.1 0.7-1
  io_uring_peek_batch_cqe@LIBURING_2.0 0.7-1

--- a/src/ffi.c
+++ b/src/ffi.c
@@ -10,6 +10,11 @@
 
 #include "liburing.h"
 
+struct io_uring_sqe *io_uring_get_sqe(struct io_uring *ring)
+{
+	return _io_uring_get_sqe(ring);
+}
+
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif

--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -1624,8 +1624,6 @@ IOURINGINLINE struct io_uring_sqe *io_uring_get_sqe(struct io_uring *ring)
 {
 	return _io_uring_get_sqe(ring);
 }
-#else
-struct io_uring_sqe *io_uring_get_sqe(struct io_uring *ring);
 #endif
 
 ssize_t io_uring_mlock_size(unsigned entries, unsigned flags);

--- a/src/liburing.map
+++ b/src/liburing.map
@@ -3,7 +3,6 @@ LIBURING_2.0 {
 		io_uring_get_probe;
 		io_uring_get_probe_ring;
 		io_uring_free_probe;
-		io_uring_get_sqe;
 		io_uring_peek_batch_cqe;
 		io_uring_queue_exit;
 		io_uring_queue_init;

--- a/src/queue.c
+++ b/src/queue.c
@@ -8,6 +8,10 @@
 #include "liburing/sanitize.h"
 #include "liburing/io_uring.h"
 
+#ifdef LIBURING_INTERNAL
+static struct io_uring_sqe *io_uring_get_sqe(struct io_uring *ring);
+#endif
+
 /*
  * Returns true if we're not using SQ thread (thus nobody submits but us)
  * or if IORING_SQ_NEED_WAKEUP is set, so submit thread must be explicitly
@@ -468,7 +472,7 @@ int io_uring_submit_and_get_events(struct io_uring *ring)
 }
 
 #ifdef LIBURING_INTERNAL
-struct io_uring_sqe *io_uring_get_sqe(struct io_uring *ring)
+static struct io_uring_sqe *io_uring_get_sqe(struct io_uring *ring)
 {
 	return _io_uring_get_sqe(ring);
 }


### PR DESCRIPTION
The user-facing API for liburing has the user interface with io_uring_get_sqe via a static inline function. However, this function is also defined in the plain liburing archive, which can potential lead to ODR violations.

We instead define it properly only for the liburing-ffi case and keep it hidden when the liburing archive itself is built.

See:
```
exbigboss@pleiades ~/cpp/liburing (symbol-fixes)
❯ nm -an src/liburing-ffi.a | grep io_uring_get_sqe
00000000000013d0 T _io_uring_get_sqe
0000000000001540 T io_uring_get_sqe
exbigboss@pleiades ~/cpp/liburing (symbol-fixes)
❯ nm -an src/liburing.a | grep io_uring_get_sqe
exbigboss@pleiades ~/cpp/liburing (symbol-fixes) [1]
❯
```

----
## git request-pull output:
```
The following changes since commit 6c509e2b0c881a13b83b259a221bf15fc9b3f681:

  test/sqwait: cleanup allocated iovecs (2025-01-22 19:48:36 -0700)

are available in the Git repository at:

  https://github.com/cmazakas/liburing.git symbol-fixes

for you to fetch changes up to 659c39092a7ddfaa68e4f4560475a0e9232af361:

  Hide io_uring_get_sqe symbol (2025-01-27 09:22:34 -0800)

----------------------------------------------------------------
Christian Mazakas (1):
      Hide io_uring_get_sqe symbol

 debian/liburing2.symbols | 1 -
 src/ffi.c                | 5 +++++
 src/include/liburing.h   | 2 --
 src/liburing.map         | 1 -
 src/queue.c              | 4 +++-
 5 files changed, 8 insertions(+), 5 deletions(-)
```

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
