### PR TITLE
[GIT PULL] workflows/build.yml: install default ubuntu-24.04 clang

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,16 +132,8 @@ jobs:
 
     - name: Install Compilers
       run: |
-        if [[ "${{matrix.cc_pkg}}" == "clang" ]]; then \
-            wget https://apt.llvm.org/llvm.sh -O /tmp/llvm.sh; \
-            sudo apt-get purge --auto-remove llvm python3-lldb-14 llvm-14 -y; \
-            sudo bash /tmp/llvm.sh 17; \
-            sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-17 400; \
-            sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-17 400; \
-        else \
-            sudo apt-get update -y; \
-            sudo apt-get install -y ${{matrix.cc_pkg}} ${{matrix.cxx_pkg}}; \
-        fi;
+        sudo apt-get update -y;
+        sudo apt-get install -y ${{matrix.cc_pkg}} ${{matrix.cxx_pkg}};
 
     - name: Display compiler versions
       run: |


### PR DESCRIPTION
Tooling like bindgen seems to encounter difficulties when using clang that isn't installed via apt. Using the default packaged clang from the Ubuntu apt repos simplifies the workflow and provides the build environment with a relatively modern version of clang (clang-18).

clang-18 should be more than sufficient to test building the library.

----
## git request-pull output:
```
The following changes since commit 08468cc3830185c75f9e7edefd88aa01e5c2f8ab:

  Merge branch 'Pr1' of https://github.com/romange/liburing (2025-02-03 05:42:36 -0700)

are available in the Git repository at:

  https://github.com/cmazakas/liburing.git gha-clang

for you to fetch changes up to 019c04dad97e5d3b78eec9786e89e17b021d7fd0:

  workflows/build.yml: install default ubuntu-24.04 clang (2025-02-07 07:26:32 -0800)

----------------------------------------------------------------
Christian Mazakas (1):
      workflows/build.yml: install default ubuntu-24.04 clang

 .github/workflows/build.yml | 12 ++----------
 1 file changed, 2 insertions(+), 10 deletions(-)
```
----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
