### PR TITLE
[GIT PULL] workflows/build.yml: fix sanitizer typo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,13 +149,13 @@ jobs:
         ${{matrix.cxx}} --version;
 
     - name: Build
-      if: ${{matrix.sanitizer == '0'}}
+      if: ${{matrix.sanitize == '0'}}
       run: |
         ./configure --cc=${{matrix.cc}} --cxx=${{matrix.cxx}};
         make -j$(nproc) V=1 CPPFLAGS="-Werror" CFLAGS="$FLAGS" CXXFLAGS="$FLAGS";
 
     - name: Build
-      if: ${{matrix.sanitizer == '1'}}
+      if: ${{matrix.sanitize == '1'}}
       run: |
         ./configure --cc=${{matrix.cc}} --cxx=${{matrix.cxx}} --enable-sanitizer;
         make -j$(nproc) V=1 CPPFLAGS="-Werror" CFLAGS="$FLAGS" CXXFLAGS="$FLAGS";


### PR DESCRIPTION
The GitHub Actions workflow file erroneously tests a branch on a non-existent field of the build matrix. Fixing the typo means that the correct workflows are now run.

----
## git request-pull output:
```
The following changes since commit 08468cc3830185c75f9e7edefd88aa01e5c2f8ab:

  Merge branch 'Pr1' of https://github.com/romange/liburing (2025-02-03 05:42:36 -0700)

are available in the Git repository at:

  https://github.com/cmazakas/liburing.git gha-fix

for you to fetch changes up to b16733b1b2302cab50098d402688ac3451902d8c:

  workflows/build.yml: fix sanitizer typo (2025-02-07 07:22:12 -0800)

----------------------------------------------------------------
Christian Mazakas (1):
      workflows/build.yml: fix sanitizer typo

 .github/workflows/build.yml | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```
----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
