### PR TITLE
[GIT PULL] Test fixes and compatibility with older kernels

### DIFF
--- a/test/connect.c
+++ b/test/connect.c
@@ -371,8 +371,10 @@ static int test(int flags)
 	int ret;
 
 	ret = io_uring_queue_init(8, &ring, flags);
+	if (ret == -EINVAL)
+		return T_EXIT_SKIP;
 	if (ret) {
-		fprintf(stderr, "io_uring_queue_setup() = %d\n", ret);
+		fprintf(stderr, "io_uring_queue_init() = %d\n", ret);
 		return T_EXIT_FAIL;
 	}
 

--- a/test/connect.c
+++ b/test/connect.c
@@ -413,30 +413,32 @@ static int test(int flags)
 
 int main(int argc, char *argv[])
 {
+	bool any_passed = false;
 	int ret;
 
 	if (argc > 1)
 		return T_EXIT_SKIP;
 
 	ret = test(0);
-	if (ret == -1) {
+	any_passed |= ret == T_EXIT_PASS;
+	if (ret == T_EXIT_FAIL) {
 		fprintf(stderr, "test 0 failed\n");
 		return T_EXIT_FAIL;
 	}
-	if (no_connect)
-		return T_EXIT_SKIP;
 
 	ret = test(IORING_SETUP_SQPOLL);
-	if (ret == -1) {
+	any_passed |= ret == T_EXIT_PASS;
+	if (ret == T_EXIT_FAIL) {
 		fprintf(stderr, "test SQPOLL failed\n");
 		return T_EXIT_FAIL;
 	}
 
 	ret = test(IORING_SETUP_SINGLE_ISSUER|IORING_SETUP_DEFER_TASKRUN);
-	if (ret == -1) {
+	any_passed |= ret == T_EXIT_PASS;
+	if (ret == T_EXIT_FAIL) {
 		fprintf(stderr, "test DEFER failed\n");
 		return T_EXIT_FAIL;
 	}
 
-	return T_EXIT_PASS;
+	return any_passed ? T_EXIT_PASS : T_EXIT_SKIP;
 }

--- a/test/iopoll-overflow.c
+++ b/test/iopoll-overflow.c
@@ -77,11 +77,11 @@ int main(int argc, char *argv[])
 			IORING_SETUP_SUBMIT_ALL;
 	p.cq_entries = 64;
 	ret = t_create_ring_params(64, &ring, &p);
-	if (ret == T_SETUP_SKIP)
-		return 0;
+	if (ret == T_SETUP_SKIP || ret == -EINVAL)
+		return T_EXIT_SKIP;
 	if (ret != T_SETUP_OK) {
 		fprintf(stderr, "ring create failed: %d\n", ret);
-		return 1;
+		return T_EXIT_FAIL;
 	}
 
 	if (argc > 1) {

--- a/test/resize-rings.c
+++ b/test/resize-rings.c
@@ -556,6 +556,8 @@ static int test(int flags, int fd, int async)
 		return T_EXIT_SKIP;
 
 	ret = io_uring_queue_init_params(8, &ring, &p);
+	if (ret == -EINVAL)
+		return T_EXIT_SKIP;
 	if (ret < 0) {
 		fprintf(stderr, "ring setup failed: %d\n", ret);
 		return T_EXIT_FAIL;

--- a/test/timeout.c
+++ b/test/timeout.c
@@ -1073,6 +1073,9 @@ static int test_update_multishot_timeouts(struct io_uring *ring, unsigned long m
 	int ret, i, nr = 6;
 	__u32 mode = 0;
 
+	if (no_multishot)
+		return T_EXIT_SKIP;
+
 	msec_to_ts(&ts, base_ms);
 
 	msec_to_ts(&ts_upd, ms);
@@ -1935,7 +1938,7 @@ int main(int argc, char *argv[])
 		}
 
 		ret = test_update_multishot_timeouts(&ring, 200);
-		if (ret) {
+		if (ret && ret != T_EXIT_SKIP) {
 			fprintf(stderr, "test_update_multishot_timeouts linked failed\n");
 			return ret;
 		}

--- a/test/wq-aff.c
+++ b/test/wq-aff.c
@@ -98,7 +98,11 @@ static int test(int sqpoll)
 		p.sq_thread_cpu = SQPOLL_CPU;
 	}
 
-	io_uring_queue_init_params(8, &ring, &p);
+	ret = io_uring_queue_init_params(8, &ring, &p);
+	if (ret) {
+		fprintf(stderr, "Queue init: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
 
 	CPU_ZERO(&set);
 	CPU_SET(IOWQ_CPU, &set);


### PR DESCRIPTION
Fix some testing gaps where errors would not cause the tests to fail.

Also add some `-EINVAL` result checks to allow tests to skip rather than fail on older kernels (tested on 5.15).

----
## git request-pull output:
```
The following changes since commit 5c788d514b9ed6d1a3624150de8aa6db403c1c65:

  Fix missing `aligned_alloc()` on some Android devices (2025-02-20 07:51:15 -0700)

are available in the Git repository at:

  git@github.com:calebsander/liburing.git fix/test-einval

for you to fetch changes up to c7fd16a7d7af305384c44baa74b4bd07bb378295:

  test/wq-aff: check io_uring_queue_init_params() success (2025-02-23 11:22:53 -0700)

----------------------------------------------------------------
Caleb Sander Mateos (6):
      test/connect: propagate return value from test()
      test/connect: skip on -EINVAL in io_uring_setup
      test/iopoll-overflow: skip on -EINVAL in io_uring_setup
      test/resize-rings: skip on -EINVAL in io_uring_setup
      test/timeout: skip test_update_multishot_timeouts if not supported
      test/wq-aff: check io_uring_queue_init_params() success

 test/connect.c         | 18 +++++++++++-------
 test/iopoll-overflow.c |  6 +++---
 test/resize-rings.c    |  2 ++
 test/timeout.c         |  5 ++++-
 test/wq-aff.c          |  6 +++++-
 5 files changed, 25 insertions(+), 12 deletions(-)
```
----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
