### PR TITLE
[GIT PULL] SQ and CQ code cleanup

### DIFF
--- a/man/io_uring_peek_cqe.3
+++ b/man/io_uring_peek_cqe.3
@@ -12,9 +12,9 @@ io_uring_peek_cqe \- check if an io_uring completion event is available
 .BI "int io_uring_peek_cqe(struct io_uring *" ring ","
 .BI "                      struct io_uring_cqe **" cqe_ptr ");"
 .PP
-.BI "int io_uring_peek_batch_cqe(struct io_uring *" ring ","
-.BI "                            struct io_uring_cqe **" cqe_ptrs ","
-.BI "                            unsigned " count ");"
+.BI "unsigned io_uring_peek_batch_cqe(struct io_uring *" ring ","
+.BI "                                 struct io_uring_cqe **" cqe_ptrs ","
+.BI "                                 unsigned " count ");"
 .fi
 .SH DESCRIPTION
 .PP
@@ -49,7 +49,9 @@ returns
 .B 0
 and the cqe_ptr parameter is filled in. On success
 .BR io_uring_peek_batch_cqe (3)
-returns the number of completions filled in. On failure, they may return
+returns the number of completions filled in. On failure,
+.BR io_uring_peek_cqe (3)
+may return
 .BR -EAGAIN .
 .SH SEE ALSO
 .BR io_uring_submit (3),

--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -349,16 +349,17 @@ io_uring_cqe_iter_init(const struct io_uring *ring)
 	};
 }
 
-IOURINGINLINE struct io_uring_cqe *
-io_uring_cqe_iter_next(struct io_uring_cqe_iter *iter)
+IOURINGINLINE bool io_uring_cqe_iter_next(struct io_uring_cqe_iter *iter,
+					  struct io_uring_cqe **cqe)
 {
 	const struct io_uring *ring = iter->ring;
 	const struct io_uring_cq *cq = &ring->cq;
 
 	if (iter->head == iter->tail)
-		return NULL;
+		return false;
 
-	return &cq->cqes[io_uring_cqe_index(ring, iter->head++, cq->ring_mask)];
+	*cqe = &cq->cqes[io_uring_cqe_index(ring, iter->head++, cq->ring_mask)];
+	return true;
 }
 
 /*
@@ -369,7 +370,7 @@ io_uring_cqe_iter_next(struct io_uring_cqe_iter *iter)
  */
 #define io_uring_for_each_cqe(ring, head, cqe)					\
 	for (struct io_uring_cqe_iter __ITER__ = io_uring_cqe_iter_init(ring);	\
-	     (head) = __ITER__.head, cqe = io_uring_cqe_iter_next(&__ITER__);	\
+	     (head) = __ITER__.head, io_uring_cqe_iter_next(&__ITER__, &(cqe));	\
 	     (void)(head))
 
 /*

--- a/src/queue.c
+++ b/src/queue.c
@@ -151,6 +151,32 @@ int io_uring_get_events(struct io_uring *ring)
 	return __sys_io_uring_enter(ring->enter_ring_fd, 0, 0, flags, NULL);
 }
 
+static inline bool io_uring_peek_batch_cqe_(struct io_uring *ring,
+					    struct io_uring_cqe **cqes,
+					    unsigned *count)
+{
+	unsigned ready = io_uring_cq_ready(ring);
+	int shift = 0;
+	unsigned head;
+	unsigned mask;
+	unsigned last;
+
+	if (!ready)
+		return false;
+
+	if (ring->flags & IORING_SETUP_CQE32)
+		shift = 1;
+	head = *ring->cq.khead;
+	mask = ring->cq.ring_mask;
+	if (ready < *count)
+		*count = ready;
+	last = head + *count;
+	for (;head != last; head++)
+		*(cqes++) = &ring->cq.cqes[(head & mask) << shift];
+
+	return true;
+}
+
 /*
  * Fill in an array of IO completions up to count, if any are available.
  * Returns the amount of IO completions filled.
@@ -158,38 +184,17 @@ int io_uring_get_events(struct io_uring *ring)
 unsigned io_uring_peek_batch_cqe(struct io_uring *ring,
 				 struct io_uring_cqe **cqes, unsigned count)
 {
-	unsigned ready;
-	bool overflow_checked = false;
-	int shift = 0;
-
-	if (ring->flags & IORING_SETUP_CQE32)
-		shift = 1;
-
-again:
-	ready = io_uring_cq_ready(ring);
-	if (ready) {
-		unsigned head = *ring->cq.khead;
-		unsigned mask = ring->cq.ring_mask;
-		unsigned last;
-
-		count = count > ready ? ready : count;
-		last = head + count;
-		for (;head != last; head++)
-			*(cqes++) = &ring->cq.cqes[(head & mask) << shift];
-
+	if (io_uring_peek_batch_cqe_(ring, cqes, &count))
 		return count;
-	}
 
-	if (overflow_checked)
+	if (!cq_ring_needs_flush(ring))
 		return 0;
 
-	if (cq_ring_needs_flush(ring)) {
-		io_uring_get_events(ring);
-		overflow_checked = true;
-		goto again;
-	}
+	io_uring_get_events(ring);
+	if (!io_uring_peek_batch_cqe_(ring, cqes, &count))
+		return 0;
 
-	return 0;
+	return count;
 }
 
 /*

--- a/src/queue.c
+++ b/src/queue.c
@@ -171,12 +171,11 @@ again:
 		unsigned head = *ring->cq.khead;
 		unsigned mask = ring->cq.ring_mask;
 		unsigned last;
-		int i = 0;
 
 		count = count > ready ? ready : count;
 		last = head + count;
-		for (;head != last; head++, i++)
-			cqes[i] = &ring->cq.cqes[(head & mask) << shift];
+		for (;head != last; head++)
+			*(cqes++) = &ring->cq.cqes[(head & mask) << shift];
 
 		return count;
 	}

--- a/src/queue.c
+++ b/src/queue.c
@@ -156,7 +156,7 @@ static inline bool io_uring_peek_batch_cqe_(struct io_uring *ring,
 					    unsigned *count)
 {
 	unsigned ready = io_uring_cq_ready(ring);
-	int shift = 0;
+	unsigned shift;
 	unsigned head;
 	unsigned mask;
 	unsigned last;
@@ -164,8 +164,7 @@ static inline bool io_uring_peek_batch_cqe_(struct io_uring *ring,
 	if (!ready)
 		return false;
 
-	if (ring->flags & IORING_SETUP_CQE32)
-		shift = 1;
+	shift = io_uring_cqe_shift(ring);
 	head = *ring->cq.khead;
 	mask = ring->cq.ring_mask;
 	if (ready < *count)

--- a/src/sanitize.c
+++ b/src/sanitize.c
@@ -122,15 +122,10 @@ void liburing_sanitize_ring(struct io_uring *ring)
 {
 	struct io_uring_sq *sq = &ring->sq;
 	struct io_uring_sqe *sqe;
-	unsigned int head;
+	unsigned head = io_uring_load_sq_head(ring);
 	unsigned shift = io_uring_sqe_shift(ring);
 
 	initialize_sanitize_handlers();
-
-	if (!(ring->flags & IORING_SETUP_SQPOLL))
-		head = *sq->khead;
-	else
-		head = io_uring_smp_load_acquire(sq->khead);
 
 	while (head != sq->sqe_tail) {
 		sqe = &sq->sqes[(head & sq->ring_mask) << shift];

--- a/src/sanitize.c
+++ b/src/sanitize.c
@@ -123,12 +123,10 @@ void liburing_sanitize_ring(struct io_uring *ring)
 	struct io_uring_sq *sq = &ring->sq;
 	struct io_uring_sqe *sqe;
 	unsigned int head;
-	int shift = 0;
+	unsigned shift = io_uring_sqe_shift(ring);
 
 	initialize_sanitize_handlers();
 
-	if (ring->flags & IORING_SETUP_SQE128)
-		shift = 1;
 	if (!(ring->flags & IORING_SETUP_SQPOLL))
 		head = *sq->khead;
 	else

--- a/src/setup.c
+++ b/src/setup.c
@@ -94,6 +94,12 @@ void io_uring_setup_ring_pointers(struct io_uring_params *p,
 	cq->ring_entries = *cq->kring_entries;
 }
 
+static size_t params_sqes_size(const struct io_uring_params *p, unsigned sqes)
+{
+	sqes <<= io_uring_sqe_shift_from_flags(p->flags);
+	return sqes * sizeof(struct io_uring_sqe);
+}
+
 int io_uring_mmap(int fd, struct io_uring_params *p, struct io_uring_sq *sq,
 		  struct io_uring_cq *cq)
 {
@@ -131,11 +137,9 @@ int io_uring_mmap(int fd, struct io_uring_params *p, struct io_uring_sq *sq,
 		}
 	}
 
-	size = sizeof(struct io_uring_sqe);
-	if (p->flags & IORING_SETUP_SQE128)
-		size += 64;
-	sq->sqes = __sys_mmap(0, size * p->sq_entries, PROT_READ | PROT_WRITE,
-			      MAP_SHARED | MAP_POPULATE, fd, IORING_OFF_SQES);
+	sq->sqes = __sys_mmap(0, params_sqes_size(p, p->sq_entries),
+			      PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE,
+			      fd, IORING_OFF_SQES);
 	if (IS_ERR(sq->sqes)) {
 		ret = PTR_ERR(sq->sqes);
 err:
@@ -160,6 +164,12 @@ __cold int io_uring_queue_mmap(int fd, struct io_uring_params *p,
 	return io_uring_mmap(fd, p, &ring->sq, &ring->cq);
 }
 
+static size_t io_uring_sqes_size(const struct io_uring *ring)
+{
+	return (ring->sq.ring_entries << io_uring_sqe_shift(ring)) *
+	       sizeof(struct io_uring_sqe);
+}
+
 /*
  * Ensure that the mmap'ed rings aren't available to a child after a fork(2).
  * This uses madvise(..., MADV_DONTFORK) on the mmap'ed ranges.
@@ -172,10 +182,7 @@ __cold int io_uring_ring_dontfork(struct io_uring *ring)
 	if (!ring->sq.ring_ptr || !ring->sq.sqes || !ring->cq.ring_ptr)
 		return -EINVAL;
 
-	len = sizeof(struct io_uring_sqe);
-	if (ring->flags & IORING_SETUP_SQE128)
-		len += 64;
-	len *= ring->sq.ring_entries;
+	len = io_uring_sqes_size(ring);
 	ret = __sys_madvise(ring->sq.sqes, len, MADV_DONTFORK);
 	if (ret < 0)
 		return ret;
@@ -209,7 +216,7 @@ static int io_uring_alloc_huge(unsigned entries, struct io_uring_params *p,
 {
 	unsigned long page_size = get_page_size();
 	unsigned sq_entries, cq_entries;
-	size_t ring_mem, sqes_mem, cqes_mem, sqe_size;
+	size_t ring_mem, sqes_mem, cqes_mem;
 	unsigned long mem_used = 0;
 	void *ptr;
 	int ret;
@@ -220,10 +227,7 @@ static int io_uring_alloc_huge(unsigned entries, struct io_uring_params *p,
 
 	ring_mem = KRING_SIZE;
 
-	sqe_size = sizeof(struct io_uring_sqe);
-	if (p->flags & IORING_SETUP_SQE128)
-		sqe_size <<= 1;
-	sqes_mem = sq_entries * sqe_size;
+	sqes_mem = params_sqes_size(p, sq_entries);
 	if (!(p->flags & IORING_SETUP_NO_SQARRAY))
 		sqes_mem += sq_entries * sizeof(unsigned);
 	sqes_mem = (sqes_mem + page_size - 1) & ~(page_size - 1);
@@ -433,13 +437,9 @@ __cold void io_uring_queue_exit(struct io_uring *ring)
 {
 	struct io_uring_sq *sq = &ring->sq;
 	struct io_uring_cq *cq = &ring->cq;
-	size_t sqe_size = sizeof(struct io_uring_sqe);
-
-	if (ring->flags & IORING_SETUP_SQE128)
-		sqe_size <<= 1;
 
 	if (!(ring->int_flags & INT_FLAG_APP_MEM)) {
-		__sys_munmap(sq->sqes, sqe_size * sq->ring_entries);
+		__sys_munmap(sq->sqes, io_uring_sqes_size(ring));
 		io_uring_unmap_rings(sq, cq);
 	}
 
@@ -513,10 +513,7 @@ static size_t rings_size(struct io_uring_params *p, unsigned entries,
 	cq_size = (cq_size + 63) & ~63UL;
 	pages = (size_t) 1 << npages(cq_size, page_size);
 
-	sq_size = sizeof(struct io_uring_sqe);
-	if (p->flags & IORING_SETUP_SQE128)
-		sq_size += 64;
-	sq_size *= entries;
+	sq_size = params_sqes_size(p, entries);
 	pages += (size_t) 1 << npages(sq_size, page_size);
 	return pages * page_size;
 }

--- a/src/setup.c
+++ b/src/setup.c
@@ -438,14 +438,9 @@ __cold void io_uring_queue_exit(struct io_uring *ring)
 	if (ring->flags & IORING_SETUP_SQE128)
 		sqe_size <<= 1;
 
-	if (!sq->ring_sz && !(ring->int_flags & INT_FLAG_APP_MEM)) {
+	if (!(ring->int_flags & INT_FLAG_APP_MEM)) {
 		__sys_munmap(sq->sqes, sqe_size * sq->ring_entries);
 		io_uring_unmap_rings(sq, cq);
-	} else {
-		if (!(ring->int_flags & INT_FLAG_APP_MEM)) {
-			__sys_munmap(sq->sqes, *sq->kring_entries * sqe_size);
-			io_uring_unmap_rings(sq, cq);
-		}
 	}
 
 	/*


### PR DESCRIPTION
Consolidate duplicated code and other cleanups in io_uring_get_sqe() and CQE polling.

Introduce a `struct io_uring_cqe_iter` and related functions to provide a non-macro alternative to `io_uring_for_each_cqe()`.

Also fix some inaccuracies in the man page for `io_uring_peek_batch_cqe()`.

----
## git request-pull output:
```
The following changes since commit fe8ebe7995512696d94e704c2823e30faa0bdcff:

  Merge branch 'fix/test-einval' of https://github.com/calebsander/liburing (2025-02-24 07:09:48 -0700)

are available in the Git repository at:

  git@github.com:calebsander/liburing.git refactor/big

for you to fetch changes up to e2386cc990744d8be0f60a66b6cf1cafd9d919c7:

  Add io_uring_cqe_shift_from_flags() helper (2025-02-24 23:03:16 -0700)

----------------------------------------------------------------
Caleb Sander Mateos (12):
      Avoid redundant load of sqe_tail in io_uring_get_sqe()
      Reduce indentation in io_uring_get_sqe()
      setup: deduplicate unmap steps
      Add io_uring_sqe_shift() helper
      Add io_uring_load_sq_head() helper
      queue: remove variable i in io_uring_peek_batch_cqe()
      queue: simplify control flow in io_uring_peek_batch_cqe()
      man: fix io_uring_peek_batch_cqe() return documentation
      Add struct io_uring_cqe_iter
      Avoid double branch in io_uring_for_each_cqe()
      Cache cqes, mask, and shift in io_uring_for_each_cqe()
      Add io_uring_cqe_shift_from_flags() helper

 man/io_uring_peek_cqe.3 |  10 ++++++----
 src/include/liburing.h  | 136 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++---------------------------------------------------
 src/queue.c             |  59 +++++++++++++++++++++++++++++++----------------------------
 src/sanitize.c          |  11 ++---------
 src/setup.c             |  74 ++++++++++++++++++++++++++++++-------------------------------------------
 5 files changed, 154 insertions(+), 136 deletions(-)
```
----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
