### PR TITLE
man: fix io_uring_setup() parameter name mismatch

### DIFF
--- a/man/io_uring_setup.2
+++ b/man/io_uring_setup.2
@@ -11,7 +11,7 @@ io_uring_setup \- setup a context for performing asynchronous I/O
 .nf
 .BR "#include <liburing.h>"
 .PP
-.BI "int io_uring_setup(u32 " entries ", struct io_uring_params *" p );
+.BI "int io_uring_setup(u32 " entries ", struct io_uring_params *" params );
 .fi
 .PP
 .SH DESCRIPTION


### PR DESCRIPTION
The parameter name from the **SYNOPSIS** section and the **DESCRIPTION** section did not match. I fixed that.

----
## git request-pull output:
```
The following changes since commit 364452f80f202373158f4452c385c961671f4666:

  io_uring.h: add IORING_FEAT_RW_ATTR definition (2025-03-14 12:28:31 -0600)

are available in the Git repository at:

  https://github.com/crimilo/liburing master

for you to fetch changes up to 42490a8c03f94782178cfa6513b28cf70edb27c6:

  man: fix io_uring_setup() parameter name mismatch (2025-03-20 12:58:26 +0100)

----------------------------------------------------------------
Cristian Milani (1):
      man: fix io_uring_setup() parameter name mismatch

 man/io_uring_setup.2 | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
