### PR TITLE
[GIT PULL] Add notes about parallel send/receive to the manual.

### DIFF
--- a/man/io_uring.7
+++ b/man/io_uring.7
@@ -128,14 +128,38 @@ It is not necessary for the kernel to process one request after another,
 in the order you placed them.
 Given that the interface is a ring,
 the requests are attempted in order,
-however that doesn't imply any sort of ordering on their completion.
+however that doesn't imply any sort of ordering on their execution or 
+completion.
 When more than one request is in flight,
-it is not possible to determine which one will complete first.
+it is not possible to determine which one will execute or complete first.
 When you dequeue CQEs off the CQ,
 you should always check which submitted request it corresponds to.
 The most common method for doing so is utilizing the
 .I user_data
 field in the request, which is passed back on the completion side.
+.IP \(bu
+Concretely, for operations where strict ordering is required, 
+such as for sends and receives on a stream-oriented TCP socket, 
+it is generally unsafe to have more than one outstanding send,
+or more than one outstanding receive (the two directions are independant)
+on a given socket at a time, as the kernel may reorder their execution 
+if poll arming or other background kernel activities are involved.
+However,
+.B io_uring
+provides various facilities to enable applications to efficiently 
+pipeline their operations safely. If the requests are submitted in a
+single batch, the application may use 
+.B IOSQE_IO_LINK
+to enforce an execution order in the kernel. Otherwise,
+.B io_uring
+provides advanced features like 
+.I multi shot
+and send/receive 
+.I bundles
+to allow applications to provide more data in fewer, more efficient trips 
+to the kernel. Even if these features are used, applications must still
+ensure they do not overlap different sends or different receives on a
+given file.
 .PP
 Adding to and reading from the queues:
 .IP \(bu


### PR DESCRIPTION
Add notes about parallel send/receive to the manual.

The overlapping of operations on stream-oriented files can cause subtle 
reordering behaviors that have confused multiple people over time. 
Add a new paragraph that clearly outlines that overlapping sends,
or overlapping receives, is generally unsafe.

Context: https://github.com/axboe/liburing/discussions/1372

Related issues with previous discussions:
- https://github.com/axboe/liburing/issues/1359
- https://github.com/axboe/liburing/issues/1282
- https://github.com/axboe/liburing/issues/1001

Signed-off-by: Francis Brosseau <francis@malagauche.com>