### PR TITLE
man/io_uring.7: Fix a typo in the comment of the example

### DIFF
--- a/man/io_uring.7
+++ b/man/io_uring.7
@@ -807,7 +807,7 @@ int submit_to_sq(int fd, int op) {
 
     /*
     * Tell the kernel we have submitted events with the io_uring_enter()
-    * system call. We also pass in the IOURING_ENTER_GETEVENTS flag which
+    * system call. We also pass in the IORING_ENTER_GETEVENTS flag which
     * causes the io_uring_enter() call to wait until min_complete
     * (the 3rd param) events complete.
     * */


### PR DESCRIPTION
There is no IOURING_ENTER_GETEVENTS, should be IORING_ENTER_GETEVENTS without U.


----
## git request-pull output:
```
The following changes since commit cc7a17ecce8b6d692c4d1492d4877161166bc322:

  io_uring.h: Use Tab to separate macro define value (2025-05-07 12:19:58 -0600)

are available in the Git repository at:

  https://github.com/Sberm/liburing.git master

for you to fetch changes up to 4d26b4b6ac326aa0d28b1b2ce4c3724bd5105df9:

  man/io_uring.7: Fix a typo in the comment of the example (2025-05-07 15:01:57 -0700)

----------------------------------------------------------------
Howard Chu (1):
      man/io_uring.7: Fix a typo in the comment of the example

 man/io_uring.7 | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
