### PR TITLE
[GIT PULL] register: use io_uring_rsrc_update instead of io_uring_files_update

### DIFF
--- a/man/io_uring_register.2
+++ b/man/io_uring_register.2
@@ -304,7 +304,7 @@ or replacing an existing entry with a new existing entry.
 .I arg
 must contain a pointer to a
 .I struct
-.IR io_uring_files_update ,
+.IR io_uring_rsrc_update ,
 which contains
 an offset on which to start the update, and an array of file descriptors to
 use for the update.

--- a/src/register.c
+++ b/src/register.c
@@ -111,9 +111,9 @@ int io_uring_register_files_update(struct io_uring *ring, unsigned off,
 {
 	liburing_sanitize_address(files);
 
-	struct io_uring_files_update up = {
+	struct io_uring_rsrc_update up = {
 		.offset	= off,
-		.fds	= (unsigned long) files,
+		.data	= (unsigned long) files,
 	};
 
 	return do_register(ring, IORING_REGISTER_FILES_UPDATE, &up, nr_files);


### PR DESCRIPTION
`struct io_uring_files_update` has a comment saying it is deprecated in favor of `struct io_uring_rsrc_update`. So switch the 2 references to it to use `io_uring_rsrc_update` instead.

----
## git request-pull output:
```
The following changes since commit 47eacd321f107eb53b1d872d5a376ba7885e8e76:

  Merge branch 'master' of https://github.com/Sberm/liburing (2025-05-07 17:03:21 -0600)

are available in the Git repository at:

  git@github.com:calebsander/liburing.git fix/io_uring_rsrc_update

for you to fetch changes up to 16777f99dc780b1e49407dcff63d64e137c3ff37:

  register: use io_uring_rsrc_update instead of io_uring_files_update (2025-05-09 18:53:27 -0600)

----------------------------------------------------------------
Caleb Sander Mateos (1):
      register: use io_uring_rsrc_update instead of io_uring_files_update

 man/io_uring_register.2 | 2 +-
 src/register.c          | 4 ++--
 2 files changed, 3 insertions(+), 3 deletions(-)
```
----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
