### PR TITLE
[GIT PULL] syscall: update io_uring_enter2() signature

### DIFF
--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -16,7 +16,7 @@ io_uring_enter \- initiate and/or complete asynchronous I/O
 .PP
 .BI "int io_uring_enter2(unsigned int " fd ", unsigned int " to_submit ,
 .BI "                    unsigned int " min_complete ", unsigned int " flags ,
-.BI "                    sigset_t *" sig ", size_t " sz );
+.BI "                    void *" arg ", size_t " sz );
 .fi
 .PP
 .SH DESCRIPTION
@@ -72,22 +72,17 @@ the system call is used with this flag set, then it will wait until at least
 one entry is free in the SQ ring.
 .TP
 .B IORING_ENTER_EXT_ARG
-Since kernel 5.11, the system calls arguments have been modified to look like
-the following:
-
-.nf
-.BI "int io_uring_enter2(unsigned int " fd ", unsigned int " to_submit ,
-.BI "                    unsigned int " min_complete ", unsigned int " flags ,
-.BI "                    const void *" arg ", size_t " argsz );
-.fi
-
-which behaves just like the original definition by default. However, if
-.B IORING_ENTER_EXT_ARG
-is set, then instead of a
+By default,
+.I arg
+is a
 .I sigset_t
-being passed in, a pointer to a
+pointer. If
+.B IORING_ENTER_EXT_ARG
+is set (supported since kernel 5.11), then
+.I arg
+is instead a pointer to a
 .I struct io_uring_getevents_arg
-is used instead and
+and
 .I argsz
 must be set to the size of this structure. The definition is as follows:
 

--- a/src/arch/generic/syscall.h
+++ b/src/arch/generic/syscall.h
@@ -23,12 +23,12 @@ static inline int __sys_io_uring_setup(unsigned int entries,
 
 static inline int __sys_io_uring_enter2(unsigned int fd, unsigned int to_submit,
 					unsigned int min_complete,
-					unsigned int flags, sigset_t *sig,
+					unsigned int flags, void *arg,
 					size_t sz)
 {
 	int ret;
 	ret = syscall(__NR_io_uring_enter, fd, to_submit, min_complete, flags,
-		      sig, sz);
+		      arg, sz);
 	return (ret < 0) ? -errno : ret;
 }
 

--- a/src/arch/syscall-defs.h
+++ b/src/arch/syscall-defs.h
@@ -76,11 +76,11 @@ static inline int __sys_io_uring_setup(unsigned int entries,
 
 static inline int __sys_io_uring_enter2(unsigned int fd, unsigned int to_submit,
 					unsigned int min_complete,
-					unsigned int flags, sigset_t *sig,
+					unsigned int flags, void *arg,
 					size_t sz)
 {
 	return (int) __do_syscall6(__NR_io_uring_enter, fd, to_submit,
-				   min_complete, flags, sig, sz);
+				   min_complete, flags, arg, sz);
 }
 
 static inline int __sys_io_uring_enter(unsigned int fd, unsigned int to_submit,

--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -291,7 +291,7 @@ int io_uring_enter(unsigned int fd, unsigned int to_submit,
 		   unsigned int min_complete, unsigned int flags, sigset_t *sig);
 int io_uring_enter2(unsigned int fd, unsigned int to_submit,
 		    unsigned int min_complete, unsigned int flags,
-		    sigset_t *sig, size_t sz);
+		    void *arg, size_t sz);
 int io_uring_setup(unsigned int entries, struct io_uring_params *p);
 int io_uring_register(unsigned int fd, unsigned int opcode, const void *arg,
 		      unsigned int nr_args);

--- a/src/syscall.c
+++ b/src/syscall.c
@@ -11,9 +11,9 @@ int io_uring_enter(unsigned int fd, unsigned int to_submit,
 
 int io_uring_enter2(unsigned int fd, unsigned int to_submit,
 		    unsigned int min_complete, unsigned int flags,
-		    sigset_t *sig, size_t sz)
+		    void *arg, size_t sz)
 {
-	return __sys_io_uring_enter2(fd, to_submit, min_complete, flags, sig,
+	return __sys_io_uring_enter2(fd, to_submit, min_complete, flags, arg,
 				     sz);
 }
 

--- a/test/wait-timeout.c
+++ b/test/wait-timeout.c
@@ -68,7 +68,7 @@ static int t_io_uring_wait(struct io_uring *ring, int nr, unsigned enter_flags,
 
 	enter_flags |= IORING_ENTER_GETEVENTS | IORING_ENTER_EXT_ARG;
 	ret = io_uring_enter2(ring->ring_fd, 0, nr, enter_flags,
-			      (void *)&arg, sizeof(arg));
+			      &arg, sizeof(arg));
 	return ret;
 }
 


### PR DESCRIPTION
Since kernel 5.11, `io_uring_enter2()` accepts a `IORING_ENTER_EXT_ARG` flag allowing a `struct io_uring_getevents_arg * `to be passed in place of the `sigset_t *` argument. Kernel 6.12 adds the `IORING_ENTER_EXT_ARG_REG` flag, which interprets the argument as an offset into a region of `struct io_uring_reg_wait`'s registered with `IORING_REGISTER_CQWAIT_REG`.

Kernel 5.11 was released over 4 years ago, so it seems more accurate for the argument type to be a `void *` rather than a `sigset_t *`. Change the argument type and rename it from "sig" to "arg" to match the man page. Using `void *` removes the need for a confusing pointer cast for callers passing `struct io_uring_getevents_arg *`.

----
## git request-pull output:
```
The following changes since commit 47eacd321f107eb53b1d872d5a376ba7885e8e76:

  Merge branch 'master' of https://github.com/Sberm/liburing (2025-05-07 17:03:21 -0600)

are available in the Git repository at:

  git@github.com:calebsander/liburing.git fix/io_uring_enter2-signature

for you to fetch changes up to 99dbb397550f7318a0c14900e4435795602f028c:

  syscall: update io_uring_enter2() signature (2025-05-14 10:45:28 -0600)

----------------------------------------------------------------
Caleb Sander Mateos (1):
      syscall: update io_uring_enter2() signature

 man/io_uring_enter.2       | 25 ++++++++++---------------
 src/arch/generic/syscall.h |  4 ++--
 src/arch/syscall-defs.h    |  4 ++--
 src/include/liburing.h     |  2 +-
 src/syscall.c              |  4 ++--
 test/wait-timeout.c        |  2 +-
 6 files changed, 18 insertions(+), 23 deletions(-)
```
----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
