### PR TITLE
[GIT PULL] src/sanitize: add missing op entries

### DIFF
--- a/src/sanitize.c
+++ b/src/sanitize.c
@@ -115,6 +115,10 @@ static inline void initialize_sanitize_handlers()
 	sanitize_handlers[IORING_OP_FTRUNCATE] = sanitize_sqe_addr;
 	sanitize_handlers[IORING_OP_BIND] = sanitize_sqe_addr;
 	sanitize_handlers[IORING_OP_LISTEN] = sanitize_sqe_addr;
+	sanitize_handlers[IORING_OP_RECV_ZC] = sanitize_sqe_addr,
+	sanitize_handlers[IORING_OP_EPOLL_WAIT] = sanitize_sqe_addr,
+	sanitize_handlers[IORING_OP_READV_FIXED] = sanitize_sqe_addr,
+	sanitize_handlers[IORING_OP_WRITEV_FIXED] = sanitize_sqe_addr,
 	sanitize_handlers_initialized = true;
 }
 


### PR DESCRIPTION
Currently the test suite will segfault when running the test epwait.t because of an out-of-bounds access of sanitizer handlers. We add the missing ops and keep the table in sync with the list in io_uring.h

----
## git request-pull output:
```
The following changes since commit 4ee26f88a0592675bf623b76e116124956a048ba:

  Merge branch 'fix/io_uring_enter2-signature' of https://github.com/calebsander/liburing (2025-05-14 13:33:24 -0600)

are available in the Git repository at:

  https://github.com/cmazakas/liburing sanitizer-fix

for you to fetch changes up to a1040018719aba096b1f985b09864d9edb58c603:

  src/sanitize: add missing op entries (2025-05-18 10:24:13 -0700)

----------------------------------------------------------------
Christian Mazakas (1):
      src/sanitize: add missing op entries

 src/sanitize.c | 4 ++++
 1 file changed, 4 insertions(+)
```
----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
