### PR TITLE
Fix potential compilation error due to io_uring_for_each_cqe macro

### DIFF
--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -379,15 +379,15 @@ IOURINGINLINE bool io_uring_cqe_iter_next(struct io_uring_cqe_iter *iter,
 }
 
 /*
- * NOTE: we should just get rid of the 'head' being passed in here, it doesn't
+ * NOTE: we should just get rid of the '__head__' being passed in here, it doesn't
  * serve a purpose anymore. The below is a bit of a work-around to ensure that
- * the compiler doesn't complain about 'head' being unused (or only written,
+ * the compiler doesn't complain about '__head__' being unused (or only written,
  * never read), as we use a local iterator for both the head and tail tracking.
  */
-#define io_uring_for_each_cqe(ring, head, cqe)					\
+#define io_uring_for_each_cqe(ring, __head__, cqe)					\
 	for (struct io_uring_cqe_iter __ITER__ = io_uring_cqe_iter_init(ring);	\
-	     (head) = __ITER__.head, io_uring_cqe_iter_next(&__ITER__, &(cqe));	\
-	     (void)(head))
+	     (__head__) = __ITER__.head, io_uring_cqe_iter_next(&__ITER__, &(cqe));	\
+	     (void)(__head__))
 
 /*
  * Must be called after io_uring_for_each_cqe()


### PR DESCRIPTION
In 1c1c806ff4e1 ("Add struct io_uring_cqe_iter") the body of the io_uring_for_each_cqe macro was changed to use io_uring_cqe_iter and its 'head' member. However, the '.head' use site in the macro's body clashes with the macro's 'head' argument. This leads to compilation errors if the macro is invoked with something else as 'head' as second argument.

For example, Samba uses the macro as follows:

io_uring_for_each_cqe(&config->uring, cqhead, cqe) {
   …
}

which results in

In file included from ../../source3/modules/vfs_io_uring.c:49: ../../source3/modules/vfs_io_uring.c: In function ‘_vfs_io_uring_queue_run’: ../../source3/modules/vfs_io_uring.c:297:47: error: ‘struct io_uring_cqe_iter’ has no member named ‘cqhead’; did you mean ‘head’?
  297 |         io_uring_for_each_cqe(&config->uring, cqhead, cqe) {

as reported in https://bugs.gentoo.org/956879

Fixes: 1c1c806ff4e1d2a122180612d5d75cf648a33211