### PR TITLE
[GIT PULL] configure: fix compile error of __kernel_timespec

### DIFF
--- a/configure
+++ b/configure
@@ -596,8 +596,28 @@ typedef int __kernel_rwf_t;
 
 EOF
 fi
+
+cat >> $compat_h << EOF
+#if defined(__has_include)
+/* introduced in C++17 & C23 */
+/* quotes "" quotes needed for GCC < 10 */
+#if __has_include("linux/time_types.h")
+#include <linux/time_types.h>
+#else
+struct __kernel_timespec {
+	int64_t		tv_sec;
+	long long	tv_nsec;
+};
+#endif
+
+#define UAPI_LINUX_IO_URING_H_SKIP_LINUX_TIME_TYPES_H 1
+#endif
+
+EOF
+
 if test "$__kernel_timespec" != "yes"; then
 cat >> $compat_h << EOF
+#if !defined(__has_include)
 #include <stdint.h>
 
 struct __kernel_timespec {
@@ -607,14 +627,15 @@ struct __kernel_timespec {
 
 /* <linux/time_types.h> is not available, so it can't be included */
 #define UAPI_LINUX_IO_URING_H_SKIP_LINUX_TIME_TYPES_H 1
-
+#endif
 EOF
 else
 cat >> $compat_h << EOF
+#if !defined(__has_include)
 #include <linux/time_types.h>
 /* <linux/time_types.h> is included above and not needed again */
 #define UAPI_LINUX_IO_URING_H_SKIP_LINUX_TIME_TYPES_H 1
-
+#endif
 EOF
 fi
 if test "$open_how" != "yes"; then


### PR DESCRIPTION
In modern package management system, such as conan/vcpkg, compat.h was generated on the building machine, and then used on other machines. It can cause compiling errors: __kernel_timespec redefined.

If __has_include defined, generated preprocessor check in campat.h otherwise, fallback to current solution.


<!-- Explain your changes here... -->

----
## git request-pull output:
```
<!-- START REPLACE ME -->
The following changes since commit fe1fc8c0516954d345ee5f7613b8e4740b69b9c1:

  liburing.h: Only use `IOURINGINLINE` macro for FFI functions (2025-06-30 15:39:05 -0600)

are available in the Git repository at:

  https://github.com/kexianda/liburing.git fix

for you to fetch changes up to 06667b2a1a945527e73b6f7fbe2f9fdc6071b519:

  configure: fix compile error of __kernel_timespec (2025-07-02 16:53:40 +0800)

----------------------------------------------------------------
Xianda Ke (1):
      configure: fix compile error of __kernel_timespec

 configure | 25 +++++++++++++++++++++++--
 1 file changed, 23 insertions(+), 2 deletions(-)
<!-- END REPLACE ME -->
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
