### PR TITLE
[GIT PULL] smp_load_acquire(ring->cq.khead) in __io_uring_peek_cqe() for consistent dereferencing

### DIFF
--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -1576,7 +1576,12 @@ IOURINGINLINE int __io_uring_peek_cqe(struct io_uring *ring,
 
 	do {
 		unsigned tail = io_uring_smp_load_acquire(ring->cq.ktail);
-		unsigned head = *ring->cq.khead;
+		
+		/**
+		 * A load_acquire on the head prevents reordering with the
+		 * cqe load below, ensuring that we see the correct cq entry.
+		 */
+		unsigned head = io_uring_smp_load_acquire(ring->cq.khead);
 
 		cqe = NULL;
 		available = tail - head;


### PR DESCRIPTION
__io_uring_peek_cqe() is on the critical path for the user to consume completion-queue entries. It load_acquires the tail, loads the head, uses the head to index into the cq ring.

The C memory consistency model does not enforce ordering for address dependencies, like the one seen in:

```
LD1: unsigned head = *ring->cq.khead;
...
LD2: cqe = &ring->cq.cqes[(head & mask) << shift];
```
where LD2 is address-dependent on LD1. This means that LD2 could load a stale cqe due to LD1 being ordered after LD2. If instead, LD1 was a smp_load_acquire, the ordering would be enforced and correct cqes would be loaded.

Signed-off by: Soham Bagchi <soham.bagchi@utah.edu>
Co-authored by: Marco Elver <elver@google.com>
Co-authored by: Vijay Nagarajan <vijay@cs.utah.edu>
Co-authored by: Ryan Stutsman <stutsman@cs.utah.edu>


<!-- Explain your changes here... -->

----
## git request-pull output:
```
The following changes since commit 2fd790493939c3b37688c2ddea4da9dcc436bb36:

  Merge tag 'gh-bot-musl-build-2025-07-14' of https://github.com/ammarfaizi2/liburing (2025-07-14 07:59:16 -0600)

are available in the Git repository at:

  https://github.com/sohambagchi/liburing master

for you to fetch changes up to 81cb9479c8c409e3cf967c9be4094fdbe05187a5:

  smp_load_acquire(ring->cq.khead) in __io_uring_peek_cqe() for  consistent dereferencing (2025-07-14 16:22:02 -0400)

----------------------------------------------------------------
Soham Bagchi (1):
      smp_load_acquire(ring->cq.khead) in __io_uring_peek_cqe() for  consistent dereferencing

 src/include/liburing.h | 7 ++++++-
 1 file changed, 6 insertions(+), 1 deletion(-)
```
----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
