### PR TITLE
liburing.h: Add noexcept specifiers for C++

### DIFF
--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -76,6 +76,12 @@
 #endif
 
 #ifdef __cplusplus
+#define LIBURING_NOEXCEPT noexcept
+#else
+#define LIBURING_NOEXCEPT
+#endif
+
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -153,7 +159,7 @@ struct io_uring_zcrx_rq {
  * Library interface
  */
 
-static inline __u64 uring_ptr_to_u64(const void *ptr)
+static inline __u64 uring_ptr_to_u64(const void *ptr) LIBURING_NOEXCEPT
 {
 	return (__u64) (unsigned long) ptr;
 }
@@ -162,18 +168,19 @@ static inline __u64 uring_ptr_to_u64(const void *ptr)
  * return an allocated io_uring_probe structure, or NULL if probe fails (for
  * example, if it is not available). The caller is responsible for freeing it
  */
-struct io_uring_probe *io_uring_get_probe_ring(struct io_uring *ring);
+struct io_uring_probe *io_uring_get_probe_ring(struct io_uring *ring)
+	LIBURING_NOEXCEPT;
 /* same as io_uring_get_probe_ring, but takes care of ring init and teardown */
-struct io_uring_probe *io_uring_get_probe(void);
+struct io_uring_probe *io_uring_get_probe(void) LIBURING_NOEXCEPT;
 
 /*
  * frees a probe allocated through io_uring_get_probe() or
  * io_uring_get_probe_ring()
  */
-void io_uring_free_probe(struct io_uring_probe *probe);
+void io_uring_free_probe(struct io_uring_probe *probe) LIBURING_NOEXCEPT;
 
 IOURINGINLINE int io_uring_opcode_supported(const struct io_uring_probe *p,
-					    int op)
+					    int op) LIBURING_NOEXCEPT
 {
 	if (op > p->last_op)
 		return 0;
@@ -182,143 +189,167 @@ IOURINGINLINE int io_uring_opcode_supported(const struct io_uring_probe *p,
 
 int io_uring_queue_init_mem(unsigned entries, struct io_uring *ring,
 				struct io_uring_params *p,
-				void *buf, size_t buf_size);
+				void *buf, size_t buf_size) LIBURING_NOEXCEPT;
 int io_uring_queue_init_params(unsigned entries, struct io_uring *ring,
-				struct io_uring_params *p);
+				struct io_uring_params *p) LIBURING_NOEXCEPT;
 int io_uring_queue_init(unsigned entries, struct io_uring *ring,
-			unsigned flags);
+			unsigned flags) LIBURING_NOEXCEPT;
 int io_uring_queue_mmap(int fd, struct io_uring_params *p,
-			struct io_uring *ring);
-int io_uring_ring_dontfork(struct io_uring *ring);
-void io_uring_queue_exit(struct io_uring *ring);
+			struct io_uring *ring) LIBURING_NOEXCEPT;
+int io_uring_ring_dontfork(struct io_uring *ring) LIBURING_NOEXCEPT;
+void io_uring_queue_exit(struct io_uring *ring) LIBURING_NOEXCEPT;
 unsigned io_uring_peek_batch_cqe(struct io_uring *ring,
-	struct io_uring_cqe **cqes, unsigned count);
+	struct io_uring_cqe **cqes, unsigned count) LIBURING_NOEXCEPT;
 int io_uring_wait_cqes(struct io_uring *ring, struct io_uring_cqe **cqe_ptr,
 		       unsigned wait_nr, struct __kernel_timespec *ts,
-		       sigset_t *sigmask);
+		       sigset_t *sigmask) LIBURING_NOEXCEPT;
 int io_uring_wait_cqes_min_timeout(struct io_uring *ring,
 				   struct io_uring_cqe **cqe_ptr,
 				   unsigned wait_nr,
 				   struct __kernel_timespec *ts,
 				   unsigned int min_ts_usec,
-				   sigset_t *sigmask);
+				   sigset_t *sigmask) LIBURING_NOEXCEPT;
 int io_uring_wait_cqe_timeout(struct io_uring *ring,
 			      struct io_uring_cqe **cqe_ptr,
-			      struct __kernel_timespec *ts);
-int io_uring_submit(struct io_uring *ring);
-int io_uring_submit_and_wait(struct io_uring *ring, unsigned wait_nr);
+			      struct __kernel_timespec *ts) LIBURING_NOEXCEPT;
+int io_uring_submit(struct io_uring *ring) LIBURING_NOEXCEPT;
+int io_uring_submit_and_wait(struct io_uring *ring, unsigned wait_nr)
+	LIBURING_NOEXCEPT;
 int io_uring_submit_and_wait_timeout(struct io_uring *ring,
 				     struct io_uring_cqe **cqe_ptr,
 				     unsigned wait_nr,
 				     struct __kernel_timespec *ts,
-				     sigset_t *sigmask);
+				     sigset_t *sigmask) LIBURING_NOEXCEPT;
 int io_uring_submit_and_wait_min_timeout(struct io_uring *ring,
 					 struct io_uring_cqe **cqe_ptr,
 					 unsigned wait_nr,
 					 struct __kernel_timespec *ts,
 					 unsigned min_wait,
-					 sigset_t *sigmask);
+					 sigset_t *sigmask) LIBURING_NOEXCEPT;
 int io_uring_submit_and_wait_reg(struct io_uring *ring,
 				 struct io_uring_cqe **cqe_ptr, unsigned wait_nr,
-				 int reg_index);
+				 int reg_index) LIBURING_NOEXCEPT;
 
 int io_uring_register_wait_reg(struct io_uring *ring,
-			       struct io_uring_reg_wait *reg, int nr);
-int io_uring_resize_rings(struct io_uring *ring, struct io_uring_params *p);
+			       struct io_uring_reg_wait *reg, int nr)
+   LIBURING_NOEXCEPT;
+int io_uring_resize_rings(struct io_uring *ring, struct io_uring_params *p)
+	LIBURING_NOEXCEPT;
 int io_uring_clone_buffers_offset(struct io_uring *dst, struct io_uring *src,
 				  unsigned int dst_off, unsigned int src_off,
-				  unsigned int nr, unsigned int flags);
+				  unsigned int nr, unsigned int flags)
+	LIBURING_NOEXCEPT;
 int __io_uring_clone_buffers_offset(struct io_uring *dst, struct io_uring *src,
 				  unsigned int dst_off, unsigned int src_off,
-				  unsigned int nr, unsigned int flags);
-int io_uring_clone_buffers(struct io_uring *dst, struct io_uring *src);
+				  unsigned int nr, unsigned int flags)
+	LIBURING_NOEXCEPT;
+int io_uring_clone_buffers(struct io_uring *dst, struct io_uring *src)
+	LIBURING_NOEXCEPT;
 int __io_uring_clone_buffers(struct io_uring *dst, struct io_uring *src,
-				unsigned int flags);
+			     unsigned int flags) LIBURING_NOEXCEPT;
 int io_uring_register_buffers(struct io_uring *ring, const struct iovec *iovecs,
-			      unsigned nr_iovecs);
+			      unsigned nr_iovecs) LIBURING_NOEXCEPT;
 int io_uring_register_buffers_tags(struct io_uring *ring,
 				   const struct iovec *iovecs,
-				   const __u64 *tags, unsigned nr);
-int io_uring_register_buffers_sparse(struct io_uring *ring, unsigned nr);
+				   const __u64 *tags, unsigned nr)
+	LIBURING_NOEXCEPT;
+int io_uring_register_buffers_sparse(struct io_uring *ring, unsigned nr)
+	LIBURING_NOEXCEPT;
 int io_uring_register_buffers_update_tag(struct io_uring *ring,
 					 unsigned off,
 					 const struct iovec *iovecs,
-					 const __u64 *tags, unsigned nr);
-int io_uring_unregister_buffers(struct io_uring *ring);
+					 const __u64 *tags, unsigned nr)
+	LIBURING_NOEXCEPT;
+int io_uring_unregister_buffers(struct io_uring *ring) LIBURING_NOEXCEPT;
 
 int io_uring_register_files(struct io_uring *ring, const int *files,
-			    unsigned nr_files);
+			    unsigned nr_files) LIBURING_NOEXCEPT;
 int io_uring_register_files_tags(struct io_uring *ring, const int *files,
-				 const __u64 *tags, unsigned nr);
-int io_uring_register_files_sparse(struct io_uring *ring, unsigned nr);
+				 const __u64 *tags, unsigned nr)
+	LIBURING_NOEXCEPT;
+int io_uring_register_files_sparse(struct io_uring *ring, unsigned nr)
+	LIBURING_NOEXCEPT;
 int io_uring_register_files_update_tag(struct io_uring *ring, unsigned off,
 				       const int *files, const __u64 *tags,
-				       unsigned nr_files);
+				       unsigned nr_files) LIBURING_NOEXCEPT;
 
-int io_uring_unregister_files(struct io_uring *ring);
+int io_uring_unregister_files(struct io_uring *ring) LIBURING_NOEXCEPT;
 int io_uring_register_files_update(struct io_uring *ring, unsigned off,
-				   const int *files, unsigned nr_files);
-int io_uring_register_eventfd(struct io_uring *ring, int fd);
-int io_uring_register_eventfd_async(struct io_uring *ring, int fd);
-int io_uring_unregister_eventfd(struct io_uring *ring);
+				   const int *files, unsigned nr_files)
+	LIBURING_NOEXCEPT;
+int io_uring_register_eventfd(struct io_uring *ring, int fd) LIBURING_NOEXCEPT;
+int io_uring_register_eventfd_async(struct io_uring *ring, int fd)
+	LIBURING_NOEXCEPT;
+int io_uring_unregister_eventfd(struct io_uring *ring) LIBURING_NOEXCEPT;
 int io_uring_register_probe(struct io_uring *ring, struct io_uring_probe *p,
-			    unsigned nr);
-int io_uring_register_personality(struct io_uring *ring);
-int io_uring_unregister_personality(struct io_uring *ring, int id);
+			    unsigned nr) LIBURING_NOEXCEPT;
+int io_uring_register_personality(struct io_uring *ring) LIBURING_NOEXCEPT;
+int io_uring_unregister_personality(struct io_uring *ring, int id)
+	LIBURING_NOEXCEPT;
 int io_uring_register_restrictions(struct io_uring *ring,
 				   struct io_uring_restriction *res,
-				   unsigned int nr_res);
-int io_uring_enable_rings(struct io_uring *ring);
-int __io_uring_sqring_wait(struct io_uring *ring);
+				   unsigned int nr_res) LIBURING_NOEXCEPT;
+int io_uring_enable_rings(struct io_uring *ring) LIBURING_NOEXCEPT;
+int __io_uring_sqring_wait(struct io_uring *ring) LIBURING_NOEXCEPT;
 #ifdef _GNU_SOURCE
 int io_uring_register_iowq_aff(struct io_uring *ring, size_t cpusz,
-				const cpu_set_t *mask);
+				const cpu_set_t *mask) LIBURING_NOEXCEPT;
 #endif
-int io_uring_unregister_iowq_aff(struct io_uring *ring);
+int io_uring_unregister_iowq_aff(struct io_uring *ring) LIBURING_NOEXCEPT;
 int io_uring_register_iowq_max_workers(struct io_uring *ring,
-				       unsigned int *values);
-int io_uring_register_ring_fd(struct io_uring *ring);
-int io_uring_unregister_ring_fd(struct io_uring *ring);
-int io_uring_close_ring_fd(struct io_uring *ring);
+				       unsigned int *values) LIBURING_NOEXCEPT;
+int io_uring_register_ring_fd(struct io_uring *ring) LIBURING_NOEXCEPT;
+int io_uring_unregister_ring_fd(struct io_uring *ring) LIBURING_NOEXCEPT;
+int io_uring_close_ring_fd(struct io_uring *ring) LIBURING_NOEXCEPT;
 int io_uring_register_buf_ring(struct io_uring *ring,
-			       struct io_uring_buf_reg *reg, unsigned int flags);
-int io_uring_unregister_buf_ring(struct io_uring *ring, int bgid);
-int io_uring_buf_ring_head(struct io_uring *ring, int buf_group, uint16_t *head);
+	struct io_uring_buf_reg *reg, unsigned int flags) LIBURING_NOEXCEPT;
+int io_uring_unregister_buf_ring(struct io_uring *ring, int bgid)
+	LIBURING_NOEXCEPT;
+int io_uring_buf_ring_head(struct io_uring *ring,
+	int buf_group, uint16_t *head) LIBURING_NOEXCEPT;
 int io_uring_register_sync_cancel(struct io_uring *ring,
-				 struct io_uring_sync_cancel_reg *reg);
-int io_uring_register_sync_msg(struct io_uring_sqe *sqe);
+				  struct io_uring_sync_cancel_reg *reg)
+	LIBURING_NOEXCEPT;
+int io_uring_register_sync_msg(struct io_uring_sqe *sqe) LIBURING_NOEXCEPT;
 
 int io_uring_register_file_alloc_range(struct io_uring *ring,
-					unsigned off, unsigned len);
+				       unsigned off, unsigned len)
+	LIBURING_NOEXCEPT;
 
-int io_uring_register_napi(struct io_uring *ring, struct io_uring_napi *napi);
-int io_uring_unregister_napi(struct io_uring *ring, struct io_uring_napi *napi);
+int io_uring_register_napi(struct io_uring *ring, struct io_uring_napi *napi)
+	LIBURING_NOEXCEPT;
+int io_uring_unregister_napi(struct io_uring *ring, struct io_uring_napi *napi)
+	LIBURING_NOEXCEPT;
 int io_uring_register_ifq(struct io_uring *ring,
-			  struct io_uring_zcrx_ifq_reg *reg);
+			  struct io_uring_zcrx_ifq_reg *reg) LIBURING_NOEXCEPT;
 
 int io_uring_register_clock(struct io_uring *ring,
-			    struct io_uring_clock_register *arg);
+			    struct io_uring_clock_register *arg)
+   LIBURING_NOEXCEPT;
 
-int io_uring_get_events(struct io_uring *ring);
-int io_uring_submit_and_get_events(struct io_uring *ring);
+int io_uring_get_events(struct io_uring *ring) LIBURING_NOEXCEPT;
+int io_uring_submit_and_get_events(struct io_uring *ring) LIBURING_NOEXCEPT;
 
 /*
  * io_uring syscalls.
  */
 int io_uring_enter(unsigned int fd, unsigned int to_submit,
-		   unsigned int min_complete, unsigned int flags, sigset_t *sig);
+		   unsigned int min_complete, unsigned int flags, sigset_t *sig)
+	LIBURING_NOEXCEPT;
 int io_uring_enter2(unsigned int fd, unsigned int to_submit,
 		    unsigned int min_complete, unsigned int flags,
-		    void *arg, size_t sz);
-int io_uring_setup(unsigned int entries, struct io_uring_params *p);
+		    void *arg, size_t sz) LIBURING_NOEXCEPT;
+int io_uring_setup(unsigned int entries, struct io_uring_params *p)
+	LIBURING_NOEXCEPT;
 int io_uring_register(unsigned int fd, unsigned int opcode, const void *arg,
-		      unsigned int nr_args);
+		      unsigned int nr_args) LIBURING_NOEXCEPT;
 
 /*
  * Mapped/registered regions
  */
 int io_uring_register_region(struct io_uring *ring,
-			     struct io_uring_mem_region_reg *reg);
+			     struct io_uring_mem_region_reg *reg)
+	LIBURING_NOEXCEPT;
 
 /*
  * Mapped buffer ring alloc/register + unregister/free helpers
@@ -326,9 +357,9 @@ int io_uring_register_region(struct io_uring *ring,
 struct io_uring_buf_ring *io_uring_setup_buf_ring(struct io_uring *ring,
 						  unsigned int nentries,
 						  int bgid, unsigned int flags,
-						  int *err);
+						  int *err) LIBURING_NOEXCEPT;
 int io_uring_free_buf_ring(struct io_uring *ring, struct io_uring_buf_ring *br,
-			   unsigned int nentries, int bgid);
+			   unsigned int nentries, int bgid) LIBURING_NOEXCEPT;
 
 /*
  * Helper for the peek/wait single cqe functions. Exported because of that,
@@ -336,12 +367,13 @@ int io_uring_free_buf_ring(struct io_uring *ring, struct io_uring_buf_ring *br,
  */
 int __io_uring_get_cqe(struct io_uring *ring,
 			struct io_uring_cqe **cqe_ptr, unsigned submit,
-			unsigned wait_nr, sigset_t *sigmask);
+			unsigned wait_nr, sigset_t *sigmask) LIBURING_NOEXCEPT;
 
 /*
  * Enable/disable setting of iowait by the kernel.
  */
-int io_uring_set_iowait(struct io_uring *ring, bool enable_iowait);
+int io_uring_set_iowait(struct io_uring *ring, bool enable_iowait)
+	LIBURING_NOEXCEPT;
 
 #define LIBURING_UDATA_TIMEOUT	((__u64) -1)
 
@@ -351,11 +383,13 @@ int io_uring_set_iowait(struct io_uring *ring, bool enable_iowait);
  * CQE `index` can be computed as &cq.cqes[(index & cq.ring_mask) << cqe_shift].
  */
 IOURINGINLINE unsigned io_uring_cqe_shift_from_flags(unsigned flags)
+	LIBURING_NOEXCEPT
 {
 	return !!(flags & IORING_SETUP_CQE32);
 }
 
 IOURINGINLINE unsigned io_uring_cqe_shift(const struct io_uring *ring)
+	LIBURING_NOEXCEPT
 {
 	return io_uring_cqe_shift_from_flags(ring->flags);
 }
@@ -370,6 +404,7 @@ struct io_uring_cqe_iter {
 
 static inline struct io_uring_cqe_iter
 io_uring_cqe_iter_init(const struct io_uring *ring)
+	LIBURING_NOEXCEPT
 {
 	return (struct io_uring_cqe_iter) {
 		.cqes = ring->cq.cqes,
@@ -383,6 +418,7 @@ io_uring_cqe_iter_init(const struct io_uring *ring)
 
 static inline bool io_uring_cqe_iter_next(struct io_uring_cqe_iter *iter,
 					  struct io_uring_cqe **cqe)
+	LIBURING_NOEXCEPT
 {
 	if (iter->head == iter->tail)
 		return false;
@@ -406,6 +442,7 @@ static inline bool io_uring_cqe_iter_next(struct io_uring_cqe_iter *iter,
  * Must be called after io_uring_for_each_cqe()
  */
 IOURINGINLINE void io_uring_cq_advance(struct io_uring *ring, unsigned nr)
+	LIBURING_NOEXCEPT
 {
 	if (nr) {
 		struct io_uring_cq *cq = &ring->cq;
@@ -424,6 +461,7 @@ IOURINGINLINE void io_uring_cq_advance(struct io_uring *ring, unsigned nr)
  */
 IOURINGINLINE void io_uring_cqe_seen(struct io_uring *ring,
 				     struct io_uring_cqe *cqe)
+	LIBURING_NOEXCEPT
 {
 	if (cqe)
 		io_uring_cq_advance(ring, 1);
@@ -438,6 +476,7 @@ IOURINGINLINE void io_uring_cqe_seen(struct io_uring *ring,
  * at command completion time with io_uring_cqe_get_data().
  */
 IOURINGINLINE void io_uring_sqe_set_data(struct io_uring_sqe *sqe, void *data)
+	LIBURING_NOEXCEPT
 {
 	sqe->user_data = (unsigned long) data;
 }
@@ -454,6 +493,7 @@ IOURINGINLINE void *io_uring_cqe_get_data(const struct io_uring_cqe *cqe)
  */
 IOURINGINLINE void io_uring_sqe_set_data64(struct io_uring_sqe *sqe,
 					   __u64 data)
+	LIBURING_NOEXCEPT
 {
 	sqe->user_data = data;
 }
@@ -470,24 +510,28 @@ IOURINGINLINE __u64 io_uring_cqe_get_data64(const struct io_uring_cqe *cqe)
 
 IOURINGINLINE void io_uring_sqe_set_flags(struct io_uring_sqe *sqe,
 					  unsigned flags)
+	LIBURING_NOEXCEPT
 {
 	sqe->flags = (__u8) flags;
 }
 
 IOURINGINLINE void io_uring_sqe_set_buf_group(struct io_uring_sqe *sqe,
 					      int bgid)
+	LIBURING_NOEXCEPT
 {
 	sqe->buf_group = (__u16) bgid;
 }
 
 IOURINGINLINE void __io_uring_set_target_fixed_file(struct io_uring_sqe *sqe,
 						    unsigned int file_index)
+	LIBURING_NOEXCEPT
 {
 	/* 0 means no fixed files, indexes should be encoded as "index + 1" */
 	sqe->file_index = file_index + 1;
 }
 
 IOURINGINLINE void io_uring_initialize_sqe(struct io_uring_sqe *sqe)
+	LIBURING_NOEXCEPT
 {
 	sqe->flags = 0;
 	sqe->ioprio = 0;
@@ -502,6 +546,7 @@ IOURINGINLINE void io_uring_initialize_sqe(struct io_uring_sqe *sqe)
 IOURINGINLINE void io_uring_prep_rw(int op, struct io_uring_sqe *sqe, int fd,
 				    const void *addr, unsigned len,
 				    __u64 offset)
+	LIBURING_NOEXCEPT
 {
 	sqe->opcode = (__u8) op;
 	sqe->fd = fd;
@@ -536,6 +581,7 @@ IOURINGINLINE void io_uring_prep_splice(struct io_uring_sqe *sqe,
 					int fd_out, int64_t off_out,
 					unsigned int nbytes,
 					unsigned int splice_flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_SPLICE, sqe, fd_out, NULL, nbytes,
 				(__u64) off_out);
@@ -548,6 +594,7 @@ IOURINGINLINE void io_uring_prep_tee(struct io_uring_sqe *sqe,
 				     int fd_in, int fd_out,
 				     unsigned int nbytes,
 				     unsigned int splice_flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_TEE, sqe, fd_out, NULL, nbytes, 0);
 	sqe->splice_off_in = 0;
@@ -558,6 +605,7 @@ IOURINGINLINE void io_uring_prep_tee(struct io_uring_sqe *sqe,
 IOURINGINLINE void io_uring_prep_readv(struct io_uring_sqe *sqe, int fd,
 				       const struct iovec *iovecs,
 				       unsigned nr_vecs, __u64 offset)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_READV, sqe, fd, iovecs, nr_vecs, offset);
 }
@@ -566,6 +614,7 @@ IOURINGINLINE void io_uring_prep_readv2(struct io_uring_sqe *sqe, int fd,
 				       const struct iovec *iovecs,
 				       unsigned nr_vecs, __u64 offset,
 				       int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_readv(sqe, fd, iovecs, nr_vecs, offset);
 	sqe->rw_flags = flags;
@@ -574,6 +623,7 @@ IOURINGINLINE void io_uring_prep_readv2(struct io_uring_sqe *sqe, int fd,
 IOURINGINLINE void io_uring_prep_read_fixed(struct io_uring_sqe *sqe, int fd,
 					    void *buf, unsigned nbytes,
 					    __u64 offset, int buf_index)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_READ_FIXED, sqe, fd, buf, nbytes, offset);
 	sqe->buf_index = (__u16) buf_index;
@@ -583,6 +633,7 @@ IOURINGINLINE void io_uring_prep_readv_fixed(struct io_uring_sqe *sqe, int fd,
 					     const struct iovec *iovecs,
 					     unsigned nr_vecs, __u64 offset,
 					     int flags, int buf_index)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_readv2(sqe, fd, iovecs, nr_vecs, offset, flags);
 	sqe->opcode = IORING_OP_READV_FIXED;
@@ -592,6 +643,7 @@ IOURINGINLINE void io_uring_prep_readv_fixed(struct io_uring_sqe *sqe, int fd,
 IOURINGINLINE void io_uring_prep_writev(struct io_uring_sqe *sqe, int fd,
 					const struct iovec *iovecs,
 					unsigned nr_vecs, __u64 offset)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_WRITEV, sqe, fd, iovecs, nr_vecs, offset);
 }
@@ -600,6 +652,7 @@ IOURINGINLINE void io_uring_prep_writev2(struct io_uring_sqe *sqe, int fd,
 				       const struct iovec *iovecs,
 				       unsigned nr_vecs, __u64 offset,
 				       int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_writev(sqe, fd, iovecs, nr_vecs, offset);
 	sqe->rw_flags = flags;
@@ -608,6 +661,7 @@ IOURINGINLINE void io_uring_prep_writev2(struct io_uring_sqe *sqe, int fd,
 IOURINGINLINE void io_uring_prep_write_fixed(struct io_uring_sqe *sqe, int fd,
 					     const void *buf, unsigned nbytes,
 					     __u64 offset, int buf_index)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_WRITE_FIXED, sqe, fd, buf, nbytes, offset);
 	sqe->buf_index = (__u16) buf_index;
@@ -617,6 +671,7 @@ IOURINGINLINE void io_uring_prep_writev_fixed(struct io_uring_sqe *sqe, int fd,
 				       const struct iovec *iovecs,
 				       unsigned nr_vecs, __u64 offset,
 				       int flags, int buf_index)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_writev2(sqe, fd, iovecs, nr_vecs, offset, flags);
 	sqe->opcode = IORING_OP_WRITEV_FIXED;
@@ -625,6 +680,7 @@ IOURINGINLINE void io_uring_prep_writev_fixed(struct io_uring_sqe *sqe, int fd,
 
 IOURINGINLINE void io_uring_prep_recvmsg(struct io_uring_sqe *sqe, int fd,
 					 struct msghdr *msg, unsigned flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_RECVMSG, sqe, fd, msg, 1, 0);
 	sqe->msg_flags = flags;
@@ -633,6 +689,7 @@ IOURINGINLINE void io_uring_prep_recvmsg(struct io_uring_sqe *sqe, int fd,
 IOURINGINLINE void io_uring_prep_recvmsg_multishot(struct io_uring_sqe *sqe,
 						   int fd, struct msghdr *msg,
 						   unsigned flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_recvmsg(sqe, fd, msg, flags);
 	sqe->ioprio |= IORING_RECV_MULTISHOT;
@@ -641,12 +698,14 @@ IOURINGINLINE void io_uring_prep_recvmsg_multishot(struct io_uring_sqe *sqe,
 IOURINGINLINE void io_uring_prep_sendmsg(struct io_uring_sqe *sqe, int fd,
 					 const struct msghdr *msg,
 					 unsigned flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_SENDMSG, sqe, fd, msg, 1, 0);
 	sqe->msg_flags = flags;
 }
 
 IOURINGINLINE unsigned __io_uring_prep_poll_mask(unsigned poll_mask)
+	LIBURING_NOEXCEPT
 {
 #if __BYTE_ORDER == __BIG_ENDIAN
 	poll_mask = __swahw32(poll_mask);
@@ -656,6 +715,7 @@ IOURINGINLINE unsigned __io_uring_prep_poll_mask(unsigned poll_mask)
 
 IOURINGINLINE void io_uring_prep_poll_add(struct io_uring_sqe *sqe, int fd,
 					  unsigned poll_mask)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_POLL_ADD, sqe, fd, NULL, 0, 0);
 	sqe->poll32_events = __io_uring_prep_poll_mask(poll_mask);
@@ -663,6 +723,7 @@ IOURINGINLINE void io_uring_prep_poll_add(struct io_uring_sqe *sqe, int fd,
 
 IOURINGINLINE void io_uring_prep_poll_multishot(struct io_uring_sqe *sqe,
 						int fd, unsigned poll_mask)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_poll_add(sqe, fd, poll_mask);
 	sqe->len = IORING_POLL_ADD_MULTI;
@@ -670,6 +731,7 @@ IOURINGINLINE void io_uring_prep_poll_multishot(struct io_uring_sqe *sqe,
 
 IOURINGINLINE void io_uring_prep_poll_remove(struct io_uring_sqe *sqe,
 					     __u64 user_data)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_POLL_REMOVE, sqe, -1, NULL, 0, 0);
 	sqe->addr = user_data;
@@ -679,6 +741,7 @@ IOURINGINLINE void io_uring_prep_poll_update(struct io_uring_sqe *sqe,
 					     __u64 old_user_data,
 					     __u64 new_user_data,
 					     unsigned poll_mask, unsigned flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_POLL_REMOVE, sqe, -1, NULL, flags,
 			 new_user_data);
@@ -688,12 +751,14 @@ IOURINGINLINE void io_uring_prep_poll_update(struct io_uring_sqe *sqe,
 
 IOURINGINLINE void io_uring_prep_fsync(struct io_uring_sqe *sqe, int fd,
 				       unsigned fsync_flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_FSYNC, sqe, fd, NULL, 0, 0);
 	sqe->fsync_flags = fsync_flags;
 }
 
 IOURINGINLINE void io_uring_prep_nop(struct io_uring_sqe *sqe)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_NOP, sqe, -1, NULL, 0, 0);
 }
@@ -701,6 +766,7 @@ IOURINGINLINE void io_uring_prep_nop(struct io_uring_sqe *sqe)
 IOURINGINLINE void io_uring_prep_timeout(struct io_uring_sqe *sqe,
 					 struct __kernel_timespec *ts,
 					 unsigned count, unsigned flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_TIMEOUT, sqe, -1, ts, 1, count);
 	sqe->timeout_flags = flags;
@@ -708,6 +774,7 @@ IOURINGINLINE void io_uring_prep_timeout(struct io_uring_sqe *sqe,
 
 IOURINGINLINE void io_uring_prep_timeout_remove(struct io_uring_sqe *sqe,
 						__u64 user_data, unsigned flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_TIMEOUT_REMOVE, sqe, -1, NULL, 0, 0);
 	sqe->addr = user_data;
@@ -717,6 +784,7 @@ IOURINGINLINE void io_uring_prep_timeout_remove(struct io_uring_sqe *sqe,
 IOURINGINLINE void io_uring_prep_timeout_update(struct io_uring_sqe *sqe,
 						struct __kernel_timespec *ts,
 						__u64 user_data, unsigned flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_TIMEOUT_REMOVE, sqe, -1, NULL, 0,
 				(uintptr_t) ts);
@@ -727,6 +795,7 @@ IOURINGINLINE void io_uring_prep_timeout_update(struct io_uring_sqe *sqe,
 IOURINGINLINE void io_uring_prep_accept(struct io_uring_sqe *sqe, int fd,
 					struct sockaddr *addr,
 					socklen_t *addrlen, int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_ACCEPT, sqe, fd, addr, 0,
 				uring_ptr_to_u64(addrlen));
@@ -738,6 +807,7 @@ IOURINGINLINE void io_uring_prep_accept_direct(struct io_uring_sqe *sqe, int fd,
 					       struct sockaddr *addr,
 					       socklen_t *addrlen, int flags,
 					       unsigned int file_index)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_accept(sqe, fd, addr, addrlen, flags);
 	/* offset by 1 for allocation */
@@ -749,6 +819,7 @@ IOURINGINLINE void io_uring_prep_accept_direct(struct io_uring_sqe *sqe, int fd,
 IOURINGINLINE void io_uring_prep_multishot_accept(struct io_uring_sqe *sqe,
 						  int fd, struct sockaddr *addr,
 						  socklen_t *addrlen, int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_accept(sqe, fd, addr, addrlen, flags);
 	sqe->ioprio |= IORING_ACCEPT_MULTISHOT;
@@ -760,6 +831,7 @@ IOURINGINLINE void io_uring_prep_multishot_accept_direct(struct io_uring_sqe *sq
 							 struct sockaddr *addr,
 							 socklen_t *addrlen,
 							 int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_multishot_accept(sqe, fd, addr, addrlen, flags);
 	__io_uring_set_target_fixed_file(sqe, IORING_FILE_INDEX_ALLOC - 1);
@@ -767,6 +839,7 @@ IOURINGINLINE void io_uring_prep_multishot_accept_direct(struct io_uring_sqe *sq
 
 IOURINGINLINE void io_uring_prep_cancel64(struct io_uring_sqe *sqe,
 					  __u64 user_data, int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_ASYNC_CANCEL, sqe, -1, NULL, 0, 0);
 	sqe->addr = user_data;
@@ -775,12 +848,14 @@ IOURINGINLINE void io_uring_prep_cancel64(struct io_uring_sqe *sqe,
 
 IOURINGINLINE void io_uring_prep_cancel(struct io_uring_sqe *sqe,
 					void *user_data, int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_cancel64(sqe, (__u64) (uintptr_t) user_data, flags);
 }
 
 IOURINGINLINE void io_uring_prep_cancel_fd(struct io_uring_sqe *sqe, int fd,
 					   unsigned int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_ASYNC_CANCEL, sqe, fd, NULL, 0, 0);
 	sqe->cancel_flags = (__u32) flags | IORING_ASYNC_CANCEL_FD;
@@ -789,6 +864,7 @@ IOURINGINLINE void io_uring_prep_cancel_fd(struct io_uring_sqe *sqe, int fd,
 IOURINGINLINE void io_uring_prep_link_timeout(struct io_uring_sqe *sqe,
 					      struct __kernel_timespec *ts,
 					      unsigned flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_LINK_TIMEOUT, sqe, -1, ts, 1, 0);
 	sqe->timeout_flags = flags;
@@ -797,6 +873,7 @@ IOURINGINLINE void io_uring_prep_link_timeout(struct io_uring_sqe *sqe,
 IOURINGINLINE void io_uring_prep_connect(struct io_uring_sqe *sqe, int fd,
 					 const struct sockaddr *addr,
 					 socklen_t addrlen)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_CONNECT, sqe, fd, addr, 0, addrlen);
 }
@@ -804,12 +881,14 @@ IOURINGINLINE void io_uring_prep_connect(struct io_uring_sqe *sqe, int fd,
 IOURINGINLINE void io_uring_prep_bind(struct io_uring_sqe *sqe, int fd,
 				      struct sockaddr *addr,
 				      socklen_t addrlen)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_BIND, sqe, fd, addr, 0, addrlen);
 }
 
 IOURINGINLINE void io_uring_prep_listen(struct io_uring_sqe *sqe, int fd,
 				      int backlog)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_LISTEN, sqe, fd, 0, backlog, 0);
 }
@@ -818,6 +897,7 @@ struct epoll_event;
 IOURINGINLINE void io_uring_prep_epoll_wait(struct io_uring_sqe *sqe, int fd,
 					    struct epoll_event *events,
 					    int maxevents, unsigned flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_EPOLL_WAIT, sqe, fd, events, maxevents, 0);
 	sqe->rw_flags = flags;
@@ -826,6 +906,7 @@ IOURINGINLINE void io_uring_prep_epoll_wait(struct io_uring_sqe *sqe, int fd,
 IOURINGINLINE void io_uring_prep_files_update(struct io_uring_sqe *sqe,
 					      int *fds, unsigned nr_fds,
 					      int offset)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_FILES_UPDATE, sqe, -1, fds, nr_fds,
 				(__u64) offset);
@@ -833,6 +914,7 @@ IOURINGINLINE void io_uring_prep_files_update(struct io_uring_sqe *sqe,
 
 IOURINGINLINE void io_uring_prep_fallocate(struct io_uring_sqe *sqe, int fd,
 					   int mode, __u64 offset, __u64 len)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_FALLOCATE, sqe, fd,
 			0, (unsigned int) mode, (__u64) offset);
@@ -842,6 +924,7 @@ IOURINGINLINE void io_uring_prep_fallocate(struct io_uring_sqe *sqe, int fd,
 IOURINGINLINE void io_uring_prep_openat(struct io_uring_sqe *sqe, int dfd,
 					const char *path, int flags,
 					mode_t mode)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_OPENAT, sqe, dfd, path, mode, 0);
 	sqe->open_flags = (__u32) flags;
@@ -852,6 +935,7 @@ IOURINGINLINE void io_uring_prep_openat_direct(struct io_uring_sqe *sqe,
 					       int dfd, const char *path,
 					       int flags, mode_t mode,
 					       unsigned file_index)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_openat(sqe, dfd, path, flags, mode);
 	/* offset by 1 for allocation */
@@ -862,6 +946,7 @@ IOURINGINLINE void io_uring_prep_openat_direct(struct io_uring_sqe *sqe,
 
 IOURINGINLINE void io_uring_prep_open(struct io_uring_sqe *sqe,
 					const char *path, int flags, mode_t mode)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_openat(sqe, AT_FDCWD, path, flags, mode);
 }
@@ -870,17 +955,20 @@ IOURINGINLINE void io_uring_prep_open(struct io_uring_sqe *sqe,
 IOURINGINLINE void io_uring_prep_open_direct(struct io_uring_sqe *sqe,
 							const char *path, int flags, mode_t mode,
 							unsigned file_index)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_openat_direct(sqe, AT_FDCWD, path, flags, mode, file_index);
 }
 
 IOURINGINLINE void io_uring_prep_close(struct io_uring_sqe *sqe, int fd)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_CLOSE, sqe, fd, NULL, 0, 0);
 }
 
 IOURINGINLINE void io_uring_prep_close_direct(struct io_uring_sqe *sqe,
 					      unsigned file_index)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_close(sqe, 0);
 	__io_uring_set_target_fixed_file(sqe, file_index);
@@ -888,6 +976,7 @@ IOURINGINLINE void io_uring_prep_close_direct(struct io_uring_sqe *sqe,
 
 IOURINGINLINE void io_uring_prep_read(struct io_uring_sqe *sqe, int fd,
 				      void *buf, unsigned nbytes, __u64 offset)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_READ, sqe, fd, buf, nbytes, offset);
 }
@@ -895,6 +984,7 @@ IOURINGINLINE void io_uring_prep_read(struct io_uring_sqe *sqe, int fd,
 IOURINGINLINE void io_uring_prep_read_multishot(struct io_uring_sqe *sqe,
 						int fd, unsigned nbytes,
 						__u64 offset, int buf_group)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_READ_MULTISHOT, sqe, fd, NULL, nbytes,
 			 offset);
@@ -905,6 +995,7 @@ IOURINGINLINE void io_uring_prep_read_multishot(struct io_uring_sqe *sqe,
 IOURINGINLINE void io_uring_prep_write(struct io_uring_sqe *sqe, int fd,
 				       const void *buf, unsigned nbytes,
 				       __u64 offset)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_WRITE, sqe, fd, buf, nbytes, offset);
 }
@@ -913,6 +1004,7 @@ struct statx;
 IOURINGINLINE void io_uring_prep_statx(struct io_uring_sqe *sqe, int dfd,
 				       const char *path, int flags,
 				       unsigned mask, struct statx *statxbuf)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_STATX, sqe, dfd, path, mask,
 				uring_ptr_to_u64(statxbuf));
@@ -921,6 +1013,7 @@ IOURINGINLINE void io_uring_prep_statx(struct io_uring_sqe *sqe, int dfd,
 
 IOURINGINLINE void io_uring_prep_fadvise(struct io_uring_sqe *sqe, int fd,
 					 __u64 offset, __u32 len, int advice)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_FADVISE, sqe, fd, NULL, (__u32) len, offset);
 	sqe->fadvise_advice = (__u32) advice;
@@ -928,6 +1021,7 @@ IOURINGINLINE void io_uring_prep_fadvise(struct io_uring_sqe *sqe, int fd,
 
 IOURINGINLINE void io_uring_prep_madvise(struct io_uring_sqe *sqe, void *addr,
 					 __u32 length, int advice)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_MADVISE, sqe, -1, addr, (__u32) length, 0);
 	sqe->fadvise_advice = (__u32) advice;
@@ -935,6 +1029,7 @@ IOURINGINLINE void io_uring_prep_madvise(struct io_uring_sqe *sqe, void *addr,
 
 IOURINGINLINE void io_uring_prep_fadvise64(struct io_uring_sqe *sqe, int fd,
 					 __u64 offset, off_t len, int advice)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_FADVISE, sqe, fd, NULL, 0, offset);
 	sqe->addr = len;
@@ -943,6 +1038,7 @@ IOURINGINLINE void io_uring_prep_fadvise64(struct io_uring_sqe *sqe, int fd,
 
 IOURINGINLINE void io_uring_prep_madvise64(struct io_uring_sqe *sqe, void *addr,
 					 off_t length, int advice)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_MADVISE, sqe, -1, addr, 0, length);
 	sqe->fadvise_advice = (__u32) advice;
@@ -950,6 +1046,7 @@ IOURINGINLINE void io_uring_prep_madvise64(struct io_uring_sqe *sqe, void *addr,
 
 IOURINGINLINE void io_uring_prep_send(struct io_uring_sqe *sqe, int sockfd,
 				      const void *buf, size_t len, int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_SEND, sqe, sockfd, buf, (__u32) len, 0);
 	sqe->msg_flags = (__u32) flags;
@@ -957,6 +1054,7 @@ IOURINGINLINE void io_uring_prep_send(struct io_uring_sqe *sqe, int sockfd,
 
 IOURINGINLINE void io_uring_prep_send_bundle(struct io_uring_sqe *sqe,
 					     int sockfd, size_t len, int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_send(sqe, sockfd, NULL, len, flags);
 	sqe->ioprio |= IORING_RECVSEND_BUNDLE;
@@ -965,6 +1063,7 @@ IOURINGINLINE void io_uring_prep_send_bundle(struct io_uring_sqe *sqe,
 IOURINGINLINE void io_uring_prep_send_set_addr(struct io_uring_sqe *sqe,
 						const struct sockaddr *dest_addr,
 						__u16 addr_len)
+	LIBURING_NOEXCEPT
 {
 	sqe->addr2 = (unsigned long)(const void *)dest_addr;
 	sqe->addr_len = addr_len;
@@ -974,6 +1073,7 @@ IOURINGINLINE void io_uring_prep_sendto(struct io_uring_sqe *sqe, int sockfd,
 					const void *buf, size_t len, int flags,
 					const struct sockaddr *addr,
 					socklen_t addrlen)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_send(sqe, sockfd, buf, len, flags);
 	io_uring_prep_send_set_addr(sqe, addr, addrlen);
@@ -982,6 +1082,7 @@ IOURINGINLINE void io_uring_prep_sendto(struct io_uring_sqe *sqe, int sockfd,
 IOURINGINLINE void io_uring_prep_send_zc(struct io_uring_sqe *sqe, int sockfd,
 					 const void *buf, size_t len, int flags,
 					 unsigned zc_flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_SEND_ZC, sqe, sockfd, buf, (__u32) len, 0);
 	sqe->msg_flags = (__u32) flags;
@@ -993,6 +1094,7 @@ IOURINGINLINE void io_uring_prep_send_zc_fixed(struct io_uring_sqe *sqe,
 						size_t len, int flags,
 						unsigned zc_flags,
 						unsigned buf_index)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_send_zc(sqe, sockfd, buf, len, flags, zc_flags);
 	sqe->ioprio |= IORING_RECVSEND_FIXED_BUF;
@@ -1002,6 +1104,7 @@ IOURINGINLINE void io_uring_prep_send_zc_fixed(struct io_uring_sqe *sqe,
 IOURINGINLINE void io_uring_prep_sendmsg_zc(struct io_uring_sqe *sqe, int fd,
 					    const struct msghdr *msg,
 					    unsigned flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_sendmsg(sqe, fd, msg, flags);
 	sqe->opcode = IORING_OP_SENDMSG_ZC;
@@ -1012,6 +1115,7 @@ IOURINGINLINE void io_uring_prep_sendmsg_zc_fixed(struct io_uring_sqe *sqe,
 						const struct msghdr *msg,
 						unsigned flags,
 						unsigned buf_index)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_sendmsg_zc(sqe, fd, msg, flags);
 	sqe->ioprio |= IORING_RECVSEND_FIXED_BUF;
@@ -1020,6 +1124,7 @@ IOURINGINLINE void io_uring_prep_sendmsg_zc_fixed(struct io_uring_sqe *sqe,
 
 IOURINGINLINE void io_uring_prep_recv(struct io_uring_sqe *sqe, int sockfd,
 				      void *buf, size_t len, int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_RECV, sqe, sockfd, buf, (__u32) len, 0);
 	sqe->msg_flags = (__u32) flags;
@@ -1028,6 +1133,7 @@ IOURINGINLINE void io_uring_prep_recv(struct io_uring_sqe *sqe, int sockfd,
 IOURINGINLINE void io_uring_prep_recv_multishot(struct io_uring_sqe *sqe,
 						int sockfd, void *buf,
 						size_t len, int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_recv(sqe, sockfd, buf, len, flags);
 	sqe->ioprio |= IORING_RECV_MULTISHOT;
@@ -1035,6 +1141,7 @@ IOURINGINLINE void io_uring_prep_recv_multishot(struct io_uring_sqe *sqe,
 
 IOURINGINLINE struct io_uring_recvmsg_out *
 io_uring_recvmsg_validate(void *buf, int buf_len, struct msghdr *msgh)
+	LIBURING_NOEXCEPT
 {
 	unsigned long header = msgh->msg_controllen + msgh->msg_namelen +
 				sizeof(struct io_uring_recvmsg_out);
@@ -1044,6 +1151,7 @@ io_uring_recvmsg_validate(void *buf, int buf_len, struct msghdr *msgh)
 }
 
 IOURINGINLINE void *io_uring_recvmsg_name(struct io_uring_recvmsg_out *o)
+	LIBURING_NOEXCEPT
 {
 	return (void *) &o[1];
 }
@@ -1051,6 +1159,7 @@ IOURINGINLINE void *io_uring_recvmsg_name(struct io_uring_recvmsg_out *o)
 IOURINGINLINE struct cmsghdr *
 io_uring_recvmsg_cmsg_firsthdr(struct io_uring_recvmsg_out *o,
 			       struct msghdr *msgh)
+	LIBURING_NOEXCEPT
 {
 	if (o->controllen < sizeof(struct cmsghdr))
 		return NULL;
@@ -1062,6 +1171,7 @@ io_uring_recvmsg_cmsg_firsthdr(struct io_uring_recvmsg_out *o,
 IOURINGINLINE struct cmsghdr *
 io_uring_recvmsg_cmsg_nexthdr(struct io_uring_recvmsg_out *o, struct msghdr *msgh,
 			      struct cmsghdr *cmsg)
+	LIBURING_NOEXCEPT
 {
 	unsigned char *end;
 
@@ -1082,6 +1192,7 @@ io_uring_recvmsg_cmsg_nexthdr(struct io_uring_recvmsg_out *o, struct msghdr *msg
 
 IOURINGINLINE void *io_uring_recvmsg_payload(struct io_uring_recvmsg_out *o,
 					     struct msghdr *msgh)
+	LIBURING_NOEXCEPT
 {
 	return (void *)((unsigned char *)io_uring_recvmsg_name(o) +
 			msgh->msg_namelen + msgh->msg_controllen);
@@ -1090,6 +1201,7 @@ IOURINGINLINE void *io_uring_recvmsg_payload(struct io_uring_recvmsg_out *o,
 IOURINGINLINE unsigned int
 io_uring_recvmsg_payload_length(struct io_uring_recvmsg_out *o,
 				int buf_len, struct msghdr *msgh)
+	LIBURING_NOEXCEPT
 {
 	unsigned long payload_start, payload_end;
 
@@ -1100,6 +1212,7 @@ io_uring_recvmsg_payload_length(struct io_uring_recvmsg_out *o,
 
 IOURINGINLINE void io_uring_prep_openat2(struct io_uring_sqe *sqe, int dfd,
 					const char *path, struct open_how *how)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_OPENAT2, sqe, dfd, path, sizeof(*how),
 				(uint64_t) (uintptr_t) how);
@@ -1110,6 +1223,7 @@ IOURINGINLINE void io_uring_prep_openat2_direct(struct io_uring_sqe *sqe,
 						int dfd, const char *path,
 						struct open_how *how,
 						unsigned file_index)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_openat2(sqe, dfd, path, how);
 	/* offset by 1 for allocation */
@@ -1122,6 +1236,7 @@ struct epoll_event;
 IOURINGINLINE void io_uring_prep_epoll_ctl(struct io_uring_sqe *sqe, int epfd,
 					   int fd, int op,
 					   struct epoll_event *ev)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_EPOLL_CTL, sqe, epfd, ev,
 				(__u32) op, (__u32) fd);
@@ -1130,6 +1245,7 @@ IOURINGINLINE void io_uring_prep_epoll_ctl(struct io_uring_sqe *sqe, int epfd,
 IOURINGINLINE void io_uring_prep_provide_buffers(struct io_uring_sqe *sqe,
 						 void *addr, int len, int nr,
 						 int bgid, int bid)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_PROVIDE_BUFFERS, sqe, nr, addr, (__u32) len,
 				(__u64) bid);
@@ -1138,6 +1254,7 @@ IOURINGINLINE void io_uring_prep_provide_buffers(struct io_uring_sqe *sqe,
 
 IOURINGINLINE void io_uring_prep_remove_buffers(struct io_uring_sqe *sqe,
 						int nr, int bgid)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_REMOVE_BUFFERS, sqe, nr, NULL, 0, 0);
 	sqe->buf_group = (__u16) bgid;
@@ -1145,12 +1262,14 @@ IOURINGINLINE void io_uring_prep_remove_buffers(struct io_uring_sqe *sqe,
 
 IOURINGINLINE void io_uring_prep_shutdown(struct io_uring_sqe *sqe, int fd,
 					  int how)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_SHUTDOWN, sqe, fd, NULL, (__u32) how, 0);
 }
 
 IOURINGINLINE void io_uring_prep_unlinkat(struct io_uring_sqe *sqe, int dfd,
 					  const char *path, int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_UNLINKAT, sqe, dfd, path, 0, 0);
 	sqe->unlink_flags = (__u32) flags;
@@ -1158,6 +1277,7 @@ IOURINGINLINE void io_uring_prep_unlinkat(struct io_uring_sqe *sqe, int dfd,
 
 IOURINGINLINE void io_uring_prep_unlink(struct io_uring_sqe *sqe,
 					  const char *path, int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_unlinkat(sqe, AT_FDCWD, path, flags);
 }
@@ -1165,6 +1285,7 @@ IOURINGINLINE void io_uring_prep_unlink(struct io_uring_sqe *sqe,
 IOURINGINLINE void io_uring_prep_renameat(struct io_uring_sqe *sqe, int olddfd,
 					  const char *oldpath, int newdfd,
 					  const char *newpath, unsigned int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_RENAMEAT, sqe, olddfd, oldpath,
 				(__u32) newdfd,
@@ -1175,6 +1296,7 @@ IOURINGINLINE void io_uring_prep_renameat(struct io_uring_sqe *sqe, int olddfd,
 IOURINGINLINE void io_uring_prep_rename(struct io_uring_sqe *sqe,
 					const char *oldpath,
 					const char *newpath)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_renameat(sqe, AT_FDCWD, oldpath, AT_FDCWD, newpath, 0);
 }
@@ -1182,6 +1304,7 @@ IOURINGINLINE void io_uring_prep_rename(struct io_uring_sqe *sqe,
 IOURINGINLINE void io_uring_prep_sync_file_range(struct io_uring_sqe *sqe,
 						 int fd, unsigned len,
 						 __u64 offset, int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_SYNC_FILE_RANGE, sqe, fd, NULL, len, offset);
 	sqe->sync_range_flags = (__u32) flags;
@@ -1189,12 +1312,14 @@ IOURINGINLINE void io_uring_prep_sync_file_range(struct io_uring_sqe *sqe,
 
 IOURINGINLINE void io_uring_prep_mkdirat(struct io_uring_sqe *sqe, int dfd,
 					const char *path, mode_t mode)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_MKDIRAT, sqe, dfd, path, mode, 0);
 }
 
 IOURINGINLINE void io_uring_prep_mkdir(struct io_uring_sqe *sqe,
 					const char *path, mode_t mode)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_mkdirat(sqe, AT_FDCWD, path, mode);
 }
@@ -1202,6 +1327,7 @@ IOURINGINLINE void io_uring_prep_mkdir(struct io_uring_sqe *sqe,
 IOURINGINLINE void io_uring_prep_symlinkat(struct io_uring_sqe *sqe,
 					   const char *target, int newdirfd,
 					   const char *linkpath)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_SYMLINKAT, sqe, newdirfd, target, 0,
 				(uint64_t) (uintptr_t) linkpath);
@@ -1210,6 +1336,7 @@ IOURINGINLINE void io_uring_prep_symlinkat(struct io_uring_sqe *sqe,
 IOURINGINLINE void io_uring_prep_symlink(struct io_uring_sqe *sqe,
 					 const char *target,
 					 const char *linkpath)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_symlinkat(sqe, target, AT_FDCWD, linkpath);
 }
@@ -1217,6 +1344,7 @@ IOURINGINLINE void io_uring_prep_symlink(struct io_uring_sqe *sqe,
 IOURINGINLINE void io_uring_prep_linkat(struct io_uring_sqe *sqe, int olddfd,
 					const char *oldpath, int newdfd,
 					const char *newpath, int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_LINKAT, sqe, olddfd, oldpath, (__u32) newdfd,
 				(uint64_t) (uintptr_t) newpath);
@@ -1226,6 +1354,7 @@ IOURINGINLINE void io_uring_prep_linkat(struct io_uring_sqe *sqe, int olddfd,
 IOURINGINLINE void io_uring_prep_link(struct io_uring_sqe *sqe,
 				      const char *oldpath, const char *newpath,
 				      int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_linkat(sqe, AT_FDCWD, oldpath, AT_FDCWD, newpath, flags);
 }
@@ -1233,6 +1362,7 @@ IOURINGINLINE void io_uring_prep_link(struct io_uring_sqe *sqe,
 IOURINGINLINE void io_uring_prep_msg_ring_cqe_flags(struct io_uring_sqe *sqe,
 					  int fd, unsigned int len, __u64 data,
 					  unsigned int flags, unsigned int cqe_flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_MSG_RING, sqe, fd, NULL, len, data);
 	sqe->msg_ring_flags = IORING_MSG_RING_FLAGS_PASS | flags;
@@ -1242,6 +1372,7 @@ IOURINGINLINE void io_uring_prep_msg_ring_cqe_flags(struct io_uring_sqe *sqe,
 IOURINGINLINE void io_uring_prep_msg_ring(struct io_uring_sqe *sqe, int fd,
 					  unsigned int len, __u64 data,
 					  unsigned int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_MSG_RING, sqe, fd, NULL, len, data);
 	sqe->msg_ring_flags = flags;
@@ -1250,6 +1381,7 @@ IOURINGINLINE void io_uring_prep_msg_ring(struct io_uring_sqe *sqe, int fd,
 IOURINGINLINE void io_uring_prep_msg_ring_fd(struct io_uring_sqe *sqe, int fd,
 					     int source_fd, int target_fd,
 					     __u64 data, unsigned int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_MSG_RING, sqe, fd,
 			 (void *) (uintptr_t) IORING_MSG_SEND_FD, 0, data);
@@ -1264,6 +1396,7 @@ IOURINGINLINE void io_uring_prep_msg_ring_fd(struct io_uring_sqe *sqe, int fd,
 IOURINGINLINE void io_uring_prep_msg_ring_fd_alloc(struct io_uring_sqe *sqe,
 						   int fd, int source_fd,
 						   __u64 data, unsigned int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_msg_ring_fd(sqe, fd, source_fd, IORING_FILE_INDEX_ALLOC,
 				  data, flags);
@@ -1272,6 +1405,7 @@ IOURINGINLINE void io_uring_prep_msg_ring_fd_alloc(struct io_uring_sqe *sqe,
 IOURINGINLINE void io_uring_prep_getxattr(struct io_uring_sqe *sqe,
 					  const char *name, char *value,
 					  const char *path, unsigned int len)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_GETXATTR, sqe, 0, name, len,
 				(__u64) (uintptr_t) value);
@@ -1283,6 +1417,7 @@ IOURINGINLINE void io_uring_prep_setxattr(struct io_uring_sqe *sqe,
 					  const char *name, const char *value,
 					  const char *path, int flags,
 					  unsigned int len)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_SETXATTR, sqe, 0, name, len,
 				(__u64) (uintptr_t) value);
@@ -1293,6 +1428,7 @@ IOURINGINLINE void io_uring_prep_setxattr(struct io_uring_sqe *sqe,
 IOURINGINLINE void io_uring_prep_fgetxattr(struct io_uring_sqe *sqe,
 					   int fd, const char *name,
 					   char *value, unsigned int len)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_FGETXATTR, sqe, fd, name, len,
 				(__u64) (uintptr_t) value);
@@ -1302,6 +1438,7 @@ IOURINGINLINE void io_uring_prep_fgetxattr(struct io_uring_sqe *sqe,
 IOURINGINLINE void io_uring_prep_fsetxattr(struct io_uring_sqe *sqe, int fd,
 					   const char *name, const char	*value,
 					   int flags, unsigned int len)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_FSETXATTR, sqe, fd, name, len,
 				(__u64) (uintptr_t) value);
@@ -1311,6 +1448,7 @@ IOURINGINLINE void io_uring_prep_fsetxattr(struct io_uring_sqe *sqe, int fd,
 IOURINGINLINE void io_uring_prep_socket(struct io_uring_sqe *sqe, int domain,
 					int type, int protocol,
 					unsigned int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_SOCKET, sqe, domain, NULL, protocol, type);
 	sqe->rw_flags = flags;
@@ -1321,6 +1459,7 @@ IOURINGINLINE void io_uring_prep_socket_direct(struct io_uring_sqe *sqe,
 					       int protocol,
 					       unsigned file_index,
 					       unsigned int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_SOCKET, sqe, domain, NULL, protocol, type);
 	sqe->rw_flags = flags;
@@ -1334,6 +1473,7 @@ IOURINGINLINE void io_uring_prep_socket_direct_alloc(struct io_uring_sqe *sqe,
 						     int domain, int type,
 						     int protocol,
 						     unsigned int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_SOCKET, sqe, domain, NULL, protocol, type);
 	sqe->rw_flags = flags;
@@ -1350,6 +1490,7 @@ IOURINGINLINE void io_uring_prep_cmd_sock(struct io_uring_sqe *sqe,
 					  int optname,
 					  void *optval,
 					  int optlen)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_URING_CMD, sqe, fd, NULL, 0, 0);
 	sqe->optval = (unsigned long) (uintptr_t) optval;
@@ -1364,6 +1505,7 @@ IOURINGINLINE void io_uring_prep_waitid(struct io_uring_sqe *sqe,
 					id_t id,
 					siginfo_t *infop,
 					int options, unsigned int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_WAITID, sqe, id, NULL, (unsigned) idtype, 0);
 	sqe->waitid_flags = flags;
@@ -1375,6 +1517,7 @@ IOURINGINLINE void io_uring_prep_futex_wake(struct io_uring_sqe *sqe,
 					    uint32_t *futex, uint64_t val,
 					    uint64_t mask, uint32_t futex_flags,
 					    unsigned int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_FUTEX_WAKE, sqe, futex_flags, futex, 0, val);
 	sqe->futex_flags = flags;
@@ -1385,6 +1528,7 @@ IOURINGINLINE void io_uring_prep_futex_wait(struct io_uring_sqe *sqe,
 					    uint32_t *futex, uint64_t val,
 					    uint64_t mask, uint32_t futex_flags,
 					    unsigned int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_FUTEX_WAIT, sqe, futex_flags, futex, 0, val);
 	sqe->futex_flags = flags;
@@ -1396,6 +1540,7 @@ IOURINGINLINE void io_uring_prep_futex_waitv(struct io_uring_sqe *sqe,
 					     struct futex_waitv *futex,
 					     uint32_t nr_futex,
 					     unsigned int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_FUTEX_WAITV, sqe, 0, futex, nr_futex, 0);
 	sqe->futex_flags = flags;
@@ -1404,6 +1549,7 @@ IOURINGINLINE void io_uring_prep_futex_waitv(struct io_uring_sqe *sqe,
 IOURINGINLINE void io_uring_prep_fixed_fd_install(struct io_uring_sqe *sqe,
 						  int fd,
 						  unsigned int flags)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_FIXED_FD_INSTALL, sqe, fd, NULL, 0, 0);
 	sqe->flags = IOSQE_FIXED_FILE;
@@ -1413,6 +1559,7 @@ IOURINGINLINE void io_uring_prep_fixed_fd_install(struct io_uring_sqe *sqe,
 #ifdef _GNU_SOURCE
 IOURINGINLINE void io_uring_prep_ftruncate(struct io_uring_sqe *sqe,
 				       int fd, loff_t len)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_FTRUNCATE, sqe, fd, 0, 0, len);
 }
@@ -1421,6 +1568,7 @@ IOURINGINLINE void io_uring_prep_ftruncate(struct io_uring_sqe *sqe,
 IOURINGINLINE void io_uring_prep_cmd_discard(struct io_uring_sqe *sqe,
 					     int fd,
 					     uint64_t offset, uint64_t nbytes)
+	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_URING_CMD, sqe, fd, 0, 0, 0);
 	sqe->cmd_op = BLOCK_URING_CMD_DISCARD;
@@ -1430,6 +1578,7 @@ IOURINGINLINE void io_uring_prep_cmd_discard(struct io_uring_sqe *sqe,
 
 /* Read the kernel's SQ head index with appropriate memory ordering */
 IOURINGINLINE unsigned io_uring_load_sq_head(const struct io_uring *ring)
+	LIBURING_NOEXCEPT
 {
 	/*
 	 * Without acquire ordering, we could overwrite a SQE before the kernel
@@ -1447,6 +1596,7 @@ IOURINGINLINE unsigned io_uring_load_sq_head(const struct io_uring *ring)
  * the SQ ring
  */
 IOURINGINLINE unsigned io_uring_sq_ready(const struct io_uring *ring)
+	LIBURING_NOEXCEPT
 {
 	/* always use real head, to avoid losing sync for short submit */
 	return ring->sq.sqe_tail - io_uring_load_sq_head(ring);
@@ -1456,6 +1606,7 @@ IOURINGINLINE unsigned io_uring_sq_ready(const struct io_uring *ring)
  * Returns how much space is left in the SQ ring.
  */
 IOURINGINLINE unsigned io_uring_sq_space_left(const struct io_uring *ring)
+	LIBURING_NOEXCEPT
 {
 	return ring->sq.ring_entries - io_uring_sq_ready(ring);
 }
@@ -1466,11 +1617,13 @@ IOURINGINLINE unsigned io_uring_sq_space_left(const struct io_uring *ring)
  * SQE `index` can be computed as &sq.sqes[(index & sq.ring_mask) << sqe_shift].
  */
 IOURINGINLINE unsigned io_uring_sqe_shift_from_flags(unsigned flags)
+	LIBURING_NOEXCEPT
 {
 	return !!(flags & IORING_SETUP_SQE128);
 }
 
 IOURINGINLINE unsigned io_uring_sqe_shift(const struct io_uring *ring)
+	LIBURING_NOEXCEPT
 {
 	return io_uring_sqe_shift_from_flags(ring->flags);
 }
@@ -1483,6 +1636,7 @@ IOURINGINLINE unsigned io_uring_sqe_shift(const struct io_uring *ring)
  * this feature.
  */
 IOURINGINLINE int io_uring_sqring_wait(struct io_uring *ring)
+	LIBURING_NOEXCEPT
 {
 	if (!(ring->flags & IORING_SETUP_SQPOLL))
 		return 0;
@@ -1496,6 +1650,7 @@ IOURINGINLINE int io_uring_sqring_wait(struct io_uring *ring)
  * Returns how many unconsumed entries are ready in the CQ ring
  */
 IOURINGINLINE unsigned io_uring_cq_ready(const struct io_uring *ring)
+	LIBURING_NOEXCEPT
 {
 	return io_uring_smp_load_acquire(ring->cq.ktail) - *ring->cq.khead;
 }
@@ -1505,6 +1660,7 @@ IOURINGINLINE unsigned io_uring_cq_ready(const struct io_uring *ring)
  * the CQ ring
  */
 IOURINGINLINE bool io_uring_cq_has_overflow(const struct io_uring *ring)
+	LIBURING_NOEXCEPT
 {
 	return IO_URING_READ_ONCE(*ring->sq.kflags) & IORING_SQ_CQ_OVERFLOW;
 }
@@ -1513,6 +1669,7 @@ IOURINGINLINE bool io_uring_cq_has_overflow(const struct io_uring *ring)
  * Returns true if the eventfd notification is currently enabled
  */
 IOURINGINLINE bool io_uring_cq_eventfd_enabled(const struct io_uring *ring)
+	LIBURING_NOEXCEPT
 {
 	if (!ring->cq.kflags)
 		return true;
@@ -1526,6 +1683,7 @@ IOURINGINLINE bool io_uring_cq_eventfd_enabled(const struct io_uring *ring)
  */
 IOURINGINLINE int io_uring_cq_eventfd_toggle(struct io_uring *ring,
 					     bool enabled)
+	LIBURING_NOEXCEPT
 {
 	uint32_t flags;
 
@@ -1555,6 +1713,7 @@ IOURINGINLINE int io_uring_cq_eventfd_toggle(struct io_uring *ring,
 IOURINGINLINE int io_uring_wait_cqe_nr(struct io_uring *ring,
 				      struct io_uring_cqe **cqe_ptr,
 				      unsigned wait_nr)
+	LIBURING_NOEXCEPT
 {
 	return __io_uring_get_cqe(ring, cqe_ptr, 0, wait_nr, NULL);
 }
@@ -1567,6 +1726,7 @@ IOURINGINLINE int io_uring_wait_cqe_nr(struct io_uring *ring,
 IOURINGINLINE int __io_uring_peek_cqe(struct io_uring *ring,
 				      struct io_uring_cqe **cqe_ptr,
 				      unsigned *nr_available)
+	LIBURING_NOEXCEPT
 {
 	struct io_uring_cqe *cqe;
 	int err = 0;
@@ -1576,7 +1736,7 @@ IOURINGINLINE int __io_uring_peek_cqe(struct io_uring *ring,
 
 	do {
 		unsigned tail = io_uring_smp_load_acquire(ring->cq.ktail);
-		
+
 		/**
 		 * A load_acquire on the head prevents reordering with the
 		 * cqe load below, ensuring that we see the correct cq entry.
@@ -1614,6 +1774,7 @@ IOURINGINLINE int __io_uring_peek_cqe(struct io_uring *ring,
  */
 IOURINGINLINE int io_uring_peek_cqe(struct io_uring *ring,
 				    struct io_uring_cqe **cqe_ptr)
+	LIBURING_NOEXCEPT
 {
 	if (!__io_uring_peek_cqe(ring, cqe_ptr, NULL) && *cqe_ptr)
 		return 0;
@@ -1627,6 +1788,7 @@ IOURINGINLINE int io_uring_peek_cqe(struct io_uring *ring,
  */
 IOURINGINLINE int io_uring_wait_cqe(struct io_uring *ring,
 				    struct io_uring_cqe **cqe_ptr)
+	LIBURING_NOEXCEPT
 {
 	if (!__io_uring_peek_cqe(ring, cqe_ptr, NULL) && *cqe_ptr)
 		return 0;
@@ -1642,6 +1804,7 @@ IOURINGINLINE int io_uring_wait_cqe(struct io_uring *ring,
  * Returns a vacant sqe, or NULL if we're full.
  */
 IOURINGINLINE struct io_uring_sqe *_io_uring_get_sqe(struct io_uring *ring)
+	LIBURING_NOEXCEPT
 {
 	struct io_uring_sq *sq = &ring->sq;
 	unsigned head = io_uring_load_sq_head(ring), tail = sq->sqe_tail;
@@ -1660,11 +1823,13 @@ IOURINGINLINE struct io_uring_sqe *_io_uring_get_sqe(struct io_uring *ring)
  * Return the appropriate mask for a buffer ring of size 'ring_entries'
  */
 IOURINGINLINE int io_uring_buf_ring_mask(__u32 ring_entries)
+	LIBURING_NOEXCEPT
 {
 	return ring_entries - 1;
 }
 
 IOURINGINLINE void io_uring_buf_ring_init(struct io_uring_buf_ring *br)
+	LIBURING_NOEXCEPT
 {
 	br->tail = 0;
 }
@@ -1676,6 +1841,7 @@ IOURINGINLINE void io_uring_buf_ring_add(struct io_uring_buf_ring *br,
 					 void *addr, unsigned int len,
 					 unsigned short bid, int mask,
 					 int buf_offset)
+	LIBURING_NOEXCEPT
 {
 	struct io_uring_buf *buf = &br->bufs[(br->tail + buf_offset) & mask];
 
@@ -1691,6 +1857,7 @@ IOURINGINLINE void io_uring_buf_ring_add(struct io_uring_buf_ring *br,
  */
 IOURINGINLINE void io_uring_buf_ring_advance(struct io_uring_buf_ring *br,
 					     int count)
+	LIBURING_NOEXCEPT
 {
 	unsigned short new_tail = br->tail + count;
 
@@ -1700,6 +1867,7 @@ IOURINGINLINE void io_uring_buf_ring_advance(struct io_uring_buf_ring *br,
 IOURINGINLINE void __io_uring_buf_ring_cq_advance(struct io_uring *ring,
 						  struct io_uring_buf_ring *br,
 						  int cq_count, int buf_count)
+	LIBURING_NOEXCEPT
 {
 	io_uring_buf_ring_advance(br, buf_count);
 	io_uring_cq_advance(ring, cq_count);
@@ -1715,6 +1883,7 @@ IOURINGINLINE void __io_uring_buf_ring_cq_advance(struct io_uring *ring,
 IOURINGINLINE void io_uring_buf_ring_cq_advance(struct io_uring *ring,
 						struct io_uring_buf_ring *br,
 						int count)
+	LIBURING_NOEXCEPT
 {
 	__io_uring_buf_ring_cq_advance(ring, br, count, count);
 }
@@ -1722,6 +1891,7 @@ IOURINGINLINE void io_uring_buf_ring_cq_advance(struct io_uring *ring,
 IOURINGINLINE int io_uring_buf_ring_available(struct io_uring *ring,
 					      struct io_uring_buf_ring *br,
 					      unsigned short bgid)
+	LIBURING_NOEXCEPT
 {
 	uint16_t head;
 	int ret;
@@ -1754,6 +1924,7 @@ IOURINGINLINE int io_uring_buf_ring_available(struct io_uring *ring,
  */
 #ifndef LIBURING_INTERNAL
 IOURINGINLINE struct io_uring_sqe *io_uring_get_sqe(struct io_uring *ring)
+	LIBURING_NOEXCEPT
 {
 	return _io_uring_get_sqe(ring);
 }
@@ -1761,11 +1932,15 @@ IOURINGINLINE struct io_uring_sqe *io_uring_get_sqe(struct io_uring *ring)
 struct io_uring_sqe *io_uring_get_sqe(struct io_uring *ring);
 #endif
 
-ssize_t io_uring_mlock_size(unsigned entries, unsigned flags);
-ssize_t io_uring_mlock_size_params(unsigned entries, struct io_uring_params *p);
+ssize_t io_uring_mlock_size(unsigned entries, unsigned flags)
+	LIBURING_NOEXCEPT;
+ssize_t io_uring_mlock_size_params(unsigned entries, struct io_uring_params *p)
+	LIBURING_NOEXCEPT;
 
-ssize_t io_uring_memory_size(unsigned entries, unsigned flags);
-ssize_t io_uring_memory_size_params(unsigned entries, struct io_uring_params *p);
+ssize_t io_uring_memory_size(unsigned entries, unsigned flags)
+	LIBURING_NOEXCEPT;
+ssize_t io_uring_memory_size_params(unsigned entries, struct io_uring_params *p)
+	LIBURING_NOEXCEPT;
 
 /*
  * Versioning information for liburing.
@@ -1776,9 +1951,9 @@ ssize_t io_uring_memory_size_params(unsigned entries, struct io_uring_params *p)
  * Use io_uring_check_version() for runtime checks of the version of
  * liburing that was loaded by the dynamic linker.
  */
-int io_uring_major_version(void);
-int io_uring_minor_version(void);
-bool io_uring_check_version(int major, int minor);
+int io_uring_major_version(void) LIBURING_NOEXCEPT;
+int io_uring_minor_version(void) LIBURING_NOEXCEPT;
+bool io_uring_check_version(int major, int minor) LIBURING_NOEXCEPT;
 
 #define IO_URING_CHECK_VERSION(major,minor) \
   (major > IO_URING_VERSION_MAJOR ||        \

--- a/src/include/liburing/barrier.h
+++ b/src/include/liburing/barrier.h
@@ -23,15 +23,18 @@ after the acquire operation executes. This is implemented using
 
 #ifdef __cplusplus
 #include <atomic>
+#define LIBURING_NOEXCEPT noexcept
 
 template <typename T>
 static inline void IO_URING_WRITE_ONCE(T &var, T val)
+	LIBURING_NOEXCEPT
 {
 	std::atomic_store_explicit(reinterpret_cast<std::atomic<T> *>(&var),
 				   val, std::memory_order_relaxed);
 }
 template <typename T>
 static inline T IO_URING_READ_ONCE(const T &var)
+	LIBURING_NOEXCEPT
 {
 	return std::atomic_load_explicit(
 		reinterpret_cast<const std::atomic<T> *>(&var),
@@ -40,6 +43,7 @@ static inline T IO_URING_READ_ONCE(const T &var)
 
 template <typename T>
 static inline void io_uring_smp_store_release(T *p, T v)
+	LIBURING_NOEXCEPT
 {
 	std::atomic_store_explicit(reinterpret_cast<std::atomic<T> *>(p), v,
 				   std::memory_order_release);
@@ -47,6 +51,7 @@ static inline void io_uring_smp_store_release(T *p, T v)
 
 template <typename T>
 static inline T io_uring_smp_load_acquire(const T *p)
+	LIBURING_NOEXCEPT
 {
 	return std::atomic_load_explicit(
 		reinterpret_cast<const std::atomic<T> *>(p),
@@ -54,6 +59,7 @@ static inline T io_uring_smp_load_acquire(const T *p)
 }
 
 static inline void io_uring_smp_mb()
+	LIBURING_NOEXCEPT
 {
 	std::atomic_thread_fence(std::memory_order_seq_cst);
 }

--- a/src/include/liburing/sanitize.h
+++ b/src/include/liburing/sanitize.h
@@ -3,6 +3,12 @@
 #define LIBURING_SANITIZE_H
 
 #ifdef __cplusplus
+#define LIBURING_NOEXCEPT noexcept
+#else
+#define LIBURING_NOEXCEPT
+#endif
+
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -10,24 +16,30 @@ struct io_uring;
 struct iovec;
 
 #if defined(CONFIG_USE_SANITIZER)
-void liburing_sanitize_ring(struct io_uring *ring);
-void liburing_sanitize_address(const void *addr);
-void liburing_sanitize_region(const void *addr, unsigned int len);
-void liburing_sanitize_iovecs(const struct iovec *iovecs, unsigned nr);
+void liburing_sanitize_ring(struct io_uring *ring) LIBURING_NOEXCEPT;
+void liburing_sanitize_address(const void *addr) LIBURING_NOEXCEPT;
+void liburing_sanitize_region(const void *addr, unsigned int len)
+	LIBURING_NOEXCEPT;
+void liburing_sanitize_iovecs(const struct iovec *iovecs, unsigned nr)
+	LIBURING_NOEXCEPT;
 #else
 #define __maybe_unused	__attribute__((__unused__))
 static inline void liburing_sanitize_ring(struct io_uring __maybe_unused *ring)
+   LIBURING_NOEXCEPT
 {
 }
 static inline void liburing_sanitize_address(const void __maybe_unused *addr)
+   LIBURING_NOEXCEPT
 {
 }
 static inline void liburing_sanitize_region(const void __maybe_unused *addr,
 					    unsigned int __maybe_unused len)
+   LIBURING_NOEXCEPT
 {
 }
 static inline void liburing_sanitize_iovecs(const struct iovec __maybe_unused *iovecs,
 					    unsigned __maybe_unused nr)
+   LIBURING_NOEXCEPT
 {
 }
 #endif


### PR DESCRIPTION
Closes #1117.

A new object macro `LIBURING_NOEXCEPT` is defined to `noexcept` when compiling as C++ and left empty when compiling as C.  This macro is applied to all exported and inline functions in the header files.  A check for C++ >= 2011 is omitted because the library already assumes this in other places.


<!-- Explain your changes here... -->

One could also define `LIBURING_NOEXCEPT` to `__attribute__(nothrow)` when compiling as C, if supported; I decided to keep this as simple as possible for now.  The changes are very repetitive, so please double check that I did not miss anything or make a mistake somewhere.

----
## git request-pull output:
```
The following changes since commit 11e47e4ea96f62969d52613c90c4f01aacf6a9f8:

  Merge branch 'master' of https://github.com/vpx/liburing (2025-07-20 12:34:28 -0600)

are available in the Git repository at:

  https://github.com/rohanlean/liburing noexcept

for you to fetch changes up to 8f8fd9747ec63a4ccb3df4da6ef86254a919a490:

  liburing.h: Add noexcept specifiers for C++ (2025-07-23 18:52:30 +0200)

----------------------------------------------------------------
Rohan Hendrik Lean (1):
      liburing.h: Add noexcept specifiers for C++

 src/include/liburing.h          | 337 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++--------------------------------
 src/include/liburing/barrier.h  |   6 +++
 src/include/liburing/sanitize.h |  20 ++++++--
 3 files changed, 278 insertions(+), 85 deletions(-)

```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
