### PR TITLE
DoS vulnerability in timeout handling on older kernels

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -127,7 +127,9 @@ static int _io_uring_get_cqe(struct io_uring *ring,
 	} while (1);
 
 	*cqe_ptr = cqe;
-	return err;
+        if (err >= 0 && !cqe)
+        return -EAGAIN;
+        return err;
 }
 
 int __io_uring_get_cqe(struct io_uring *ring, struct io_uring_cqe **cqe_ptr,


### PR DESCRIPTION
Denial of Service (DoS) vulnerability in `liburing`'s timeout handling on older Linux kernels (those without `IORING_FEAT_EXT_ARG`).

The vulnerability occurs when an application uses a timeout function and a user-submitted operation happens to have the same `user_data` as the internal secret ID used for timeouts. In this scenario, the `_io_uring_get_cqe` function would return a success code while providing a `NULL` completion event pointer. This leads to a immediate NULL pointer dereference and crashes the application, resulting in a Denial of Service.

The patch modifies the `_io_uring_get_cqe` function in `src/queue.c`. It adds a crucial check to ensure that if a success code (`err >= 0`) is about to be returned, a valid completion event pointer (`cqe`) must exist. If not, the function now correctly returns `-EAGAIN` instead of a misleading success code, preventing the application crash.