### PR TITLE
test/recvsend_bundle: enlarge recv buf-ring to 2 MiB to avoid ENOBUFS…

### DIFF
--- a/test/recvsend_bundle.c
+++ b/test/recvsend_bundle.c
@@ -21,7 +21,7 @@ static int nr_msgs;
 static int use_tcp;
 static int classic_buffers;
 
-#define RECV_BIDS	8192
+#define RECV_BIDS	16384
 #define RECV_BID_MASK	(RECV_BIDS - 1)
 
 #include "liburing.h"


### PR DESCRIPTION
This is a minimal, test-only tweak to stabilize results across different arches without changing test logic.

IMHO, ideally we would find a way to allocate the buffer based on the system under test runtime socket SO_RCVBUF, so we would have a test without the hardcoded  RECV_BIDS and thus the buffer size.

So while I do not have a ready patch/solution, I wanted to see what do you think about it. 