### PR TITLE
[GIT PULL] test/futex: Fix alternation of async cancel requests

### DIFF
--- a/test/futex.c
+++ b/test/futex.c
@@ -149,7 +149,7 @@ static int test(int flags, int vectored)
 		return ret;
 
 	for (i = 0; i < LOOPS; i++) {
-		int async_cancel = (!i % 2);
+		int async_cancel = !(i % 2);
 		int async_wait = !(i % 3);
 		ret = __test(&ring, vectored, async_wait, async_cancel);
 		if (ret) {


### PR DESCRIPTION
Fixing a minor logic issue in the futex test to properly alternate between non-blocking and async cancel requests.

One could also think about simplifying the logic to:

```
int async_cancel = i & 1;
int async_wait = i & 2;
```

Best,
Chris


<!-- Explain your changes here... -->

----
## git request-pull output:
```
The following changes since commit 5503c2b545709e1cf8484670aa7088a827f4818d:

  liburing.h: Support C++20 module export feature (2025-09-15 13:01:30 -0600)

are available in the Git repository at:

  https://github.com/zeehha/liburing test-futex-fix-alternation

for you to fetch changes up to db3ed3805d23e37c71ca00dae0182ed756ab9fb6:

  test/futex: Fix alternation of async cancel requests (2025-09-18 17:30:11 +0200)

----------------------------------------------------------------
Chris Hofer (1):
      test/futex: Fix alternation of async cancel requests

 test/futex.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
