### PR TITLE
[GIT PULL] liburing.h: Add const-qualifier for some preps

### DIFF
--- a/man/io_uring_prep_bind.3
+++ b/man/io_uring_prep_bind.3
@@ -12,7 +12,7 @@ io_uring_prep_bind \- prepare a bind request
 .PP
 .BI "void io_uring_prep_bind(struct io_uring_sqe *" sqe ","
 .BI "                          int " sockfd ","
-.BI "                          struct sockaddr *" addr ","
+.BI "                          const struct sockaddr *" addr ","
 .BI "                          socklen_t " addrlen ");"
 .fi
 .SH DESCRIPTION

--- a/man/io_uring_prep_cancel.3
+++ b/man/io_uring_prep_cancel.3
@@ -14,7 +14,7 @@ io_uring_prep_cancel \- prepare a cancelation request
 .BI "                            int " flags ");"
 .PP
 .BI "void io_uring_prep_cancel(struct io_uring_sqe *" sqe ","
-.BI "                          void *" user_data ","
+.BI "                          const void *" user_data ","
 .BI "                          int " flags ");"
 .PP
 .BI "void io_uring_prep_cancel_fd(struct io_uring_sqe *" sqe ","

--- a/man/io_uring_prep_files_update.3
+++ b/man/io_uring_prep_files_update.3
@@ -10,7 +10,7 @@ io_uring_prep_files_update \- prepare a registered file update request
 .B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_files_update(struct io_uring_sqe *" sqe ","
-.BI "                                int *" fds ","
+.BI "                                const int *" fds ","
 .BI "                                unsigned " nr_fds ","
 .BI "                                int " offset ");"
 .fi

--- a/man/io_uring_prep_futex_wait.3
+++ b/man/io_uring_prep_futex_wait.3
@@ -12,7 +12,7 @@ io_uring_prep_futex_wait \- prepare a futex wait request
 .B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_futex_wait(struct io_uring_sqe *" sqe ","
-.BI "                              uint32_t *" futex ","
+.BI "                              const uint32_t *" futex ","
 .BI "                              uint64_t " val ","
 .BI "                              uint64_t " mask ","
 .BI "                              uint32_t " futex_flags ","

--- a/man/io_uring_prep_futex_waitv.3
+++ b/man/io_uring_prep_futex_waitv.3
@@ -12,7 +12,7 @@ io_uring_prep_futex_waitv \- prepare a futex waitv request
 .B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_futex_waitv(struct io_uring_sqe *" sqe ","
-.BI "                               struct futex_waitv *" futexv ","
+.BI "                               const struct futex_waitv *" futexv ","
 .BI "                               uint32_t " nr_futex ","
 .BI "                               unsigned int " flags ");"
 .fi

--- a/man/io_uring_prep_futex_wake.3
+++ b/man/io_uring_prep_futex_wake.3
@@ -12,7 +12,7 @@ io_uring_prep_futex_wake \- prepare a futex wake request
 .B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_futex_wake(struct io_uring_sqe *" sqe ","
-.BI "                              uint32_t *" futex ","
+.BI "                              const uint32_t *" futex ","
 .BI "                              uint64_t " val ","
 .BI "                              uint64_t " mask ","
 .BI "                              uint32_t " futex_flags ","

--- a/man/io_uring_prep_link_timeout.3
+++ b/man/io_uring_prep_link_timeout.3
@@ -10,7 +10,7 @@ io_uring_prep_link_timeout \- a timeout request for linked sqes
 .B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_link_timeout(struct io_uring_sqe *" sqe ","
-.BI "                                struct __kernel_timespec *" ts ","
+.BI "                                const struct __kernel_timespec *" ts ","
 .BI "                                unsigned " flags ");"
 .fi
 .SH DESCRIPTION

--- a/man/io_uring_prep_openat2.3
+++ b/man/io_uring_prep_openat2.3
@@ -16,12 +16,12 @@ io_uring_prep_openat2 \- prepare an openat2 request
 .BI "void io_uring_prep_openat2(struct io_uring_sqe *" sqe ","
 .BI "                           int " dfd ","
 .BI "                           const char *" path ","
-.BI "                           struct open_how *" how ");"
+.BI "                           const struct open_how *" how ");"
 .PP
 .BI "void io_uring_prep_openat2_direct(struct io_uring_sqe *" sqe ","
 .BI "                                  int " dfd ","
 .BI "                                  const char *" path ","
-.BI "                                  struct open_how *" how ","
+.BI "                                  const struct open_how *" how ","
 .BI "                                  unsigned " file_index ");"
 .fi
 .SH DESCRIPTION

--- a/man/io_uring_prep_timeout.3
+++ b/man/io_uring_prep_timeout.3
@@ -10,7 +10,7 @@ io_uring_prep_timeout \- prepare a timeout request
 .B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_timeout(struct io_uring_sqe *" sqe ","
-.BI "                           struct __kernel_timespec *" ts ","
+.BI "                           const struct __kernel_timespec *" ts ","
 .BI "                           unsigned " count ","
 .BI "                           unsigned " flags ");"
 .fi

--- a/man/io_uring_prep_timeout_update.3
+++ b/man/io_uring_prep_timeout_update.3
@@ -10,7 +10,7 @@ io_uring_prep_timeout_update \- prepare a request to update an existing timeout
 .B #include <liburing.h>
 .PP
 .BI "void io_uring_prep_timeout_update(struct io_uring_sqe *" sqe ","
-.BI "                                  struct __kernel_timespec *" ts ","
+.BI "                                  const struct __kernel_timespec *" ts ","
 .BI "                                  __u64 " user_data ","
 .BI "                                  unsigned " flags ");"
 .PP

--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -800,7 +800,7 @@ IOURINGINLINE void io_uring_prep_nop(struct io_uring_sqe *sqe)
 }
 
 IOURINGINLINE void io_uring_prep_timeout(struct io_uring_sqe *sqe,
-					 struct __kernel_timespec *ts,
+					 const struct __kernel_timespec *ts,
 					 unsigned count, unsigned flags)
 	LIBURING_NOEXCEPT
 {
@@ -818,7 +818,7 @@ IOURINGINLINE void io_uring_prep_timeout_remove(struct io_uring_sqe *sqe,
 }
 
 IOURINGINLINE void io_uring_prep_timeout_update(struct io_uring_sqe *sqe,
-						struct __kernel_timespec *ts,
+						const struct __kernel_timespec *ts,
 						__u64 user_data, unsigned flags)
 	LIBURING_NOEXCEPT
 {
@@ -883,7 +883,7 @@ IOURINGINLINE void io_uring_prep_cancel64(struct io_uring_sqe *sqe,
 }
 
 IOURINGINLINE void io_uring_prep_cancel(struct io_uring_sqe *sqe,
-					void *user_data, int flags)
+					const void *user_data, int flags)
 	LIBURING_NOEXCEPT
 {
 	io_uring_prep_cancel64(sqe, (__u64) (uintptr_t) user_data, flags);
@@ -898,7 +898,7 @@ IOURINGINLINE void io_uring_prep_cancel_fd(struct io_uring_sqe *sqe, int fd,
 }
 
 IOURINGINLINE void io_uring_prep_link_timeout(struct io_uring_sqe *sqe,
-					      struct __kernel_timespec *ts,
+					      const struct __kernel_timespec *ts,
 					      unsigned flags)
 	LIBURING_NOEXCEPT
 {
@@ -915,7 +915,7 @@ IOURINGINLINE void io_uring_prep_connect(struct io_uring_sqe *sqe, int fd,
 }
 
 IOURINGINLINE void io_uring_prep_bind(struct io_uring_sqe *sqe, int fd,
-				      struct sockaddr *addr,
+				      const struct sockaddr *addr,
 				      socklen_t addrlen)
 	LIBURING_NOEXCEPT
 {
@@ -940,7 +940,7 @@ IOURINGINLINE void io_uring_prep_epoll_wait(struct io_uring_sqe *sqe, int fd,
 }
 
 IOURINGINLINE void io_uring_prep_files_update(struct io_uring_sqe *sqe,
-					      int *fds, unsigned nr_fds,
+					      const int *fds, unsigned nr_fds,
 					      int offset)
 	LIBURING_NOEXCEPT
 {
@@ -1247,7 +1247,7 @@ io_uring_recvmsg_payload_length(struct io_uring_recvmsg_out *o,
 }
 
 IOURINGINLINE void io_uring_prep_openat2(struct io_uring_sqe *sqe, int dfd,
-					const char *path, struct open_how *how)
+					const char *path, const struct open_how *how)
 	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_OPENAT2, sqe, dfd, path, sizeof(*how),
@@ -1257,7 +1257,7 @@ IOURINGINLINE void io_uring_prep_openat2(struct io_uring_sqe *sqe, int dfd,
 /* open directly into the fixed file table */
 IOURINGINLINE void io_uring_prep_openat2_direct(struct io_uring_sqe *sqe,
 						int dfd, const char *path,
-						struct open_how *how,
+						const struct open_how *how,
 						unsigned file_index)
 	LIBURING_NOEXCEPT
 {
@@ -1271,7 +1271,7 @@ IOURINGINLINE void io_uring_prep_openat2_direct(struct io_uring_sqe *sqe,
 struct epoll_event;
 IOURINGINLINE void io_uring_prep_epoll_ctl(struct io_uring_sqe *sqe, int epfd,
 					   int fd, int op,
-					   struct epoll_event *ev)
+					   const struct epoll_event *ev)
 	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_EPOLL_CTL, sqe, epfd, ev,
@@ -1550,7 +1550,7 @@ IOURINGINLINE void io_uring_prep_waitid(struct io_uring_sqe *sqe,
 }
 
 IOURINGINLINE void io_uring_prep_futex_wake(struct io_uring_sqe *sqe,
-					    uint32_t *futex, uint64_t val,
+					    const uint32_t *futex, uint64_t val,
 					    uint64_t mask, uint32_t futex_flags,
 					    unsigned int flags)
 	LIBURING_NOEXCEPT
@@ -1561,7 +1561,7 @@ IOURINGINLINE void io_uring_prep_futex_wake(struct io_uring_sqe *sqe,
 }
 
 IOURINGINLINE void io_uring_prep_futex_wait(struct io_uring_sqe *sqe,
-					    uint32_t *futex, uint64_t val,
+					    const uint32_t *futex, uint64_t val,
 					    uint64_t mask, uint32_t futex_flags,
 					    unsigned int flags)
 	LIBURING_NOEXCEPT
@@ -1573,7 +1573,7 @@ IOURINGINLINE void io_uring_prep_futex_wait(struct io_uring_sqe *sqe,
 
 struct futex_waitv;
 IOURINGINLINE void io_uring_prep_futex_waitv(struct io_uring_sqe *sqe,
-					     struct futex_waitv *futex,
+					     const struct futex_waitv *futex,
 					     uint32_t nr_futex,
 					     unsigned int flags)
 	LIBURING_NOEXCEPT


### PR DESCRIPTION
## Overview

Add `const` qualifiers to pointer arguments in `io_uring_prep_*` functions for operations where the pointer referent is not mutated.

This improves type-safety and clarity for downstream consumers, especially for FFI-bindings (e.g., Rust).

Affected functions:
- `io_uring_prep_bind`
- `io_uring_prep_cancel`
- `io_uring_prep_epoll_ctl`
- `io_uring_prep_files_update`
- `io_uring_prep_futex_wait`
- `io_uring_prep_futex_waitv`
- `io_uring_prep_futex_wake`
- `io_uring_prep_link_timeout`
- `io_uring_prep_openat2`
- `io_uring_prep_openat2_direct`
- `io_uring_prep_timeout`
- `io_uring_prep_timeout_update`

## Details

This PR was motivated by trying to refine some signatures for an FFI Rust crate binding these functions.

I submitted an earlier PR somewhat hastily at #1467 which incorrectly included some prep functions for operations where the pointer referent clear is mutated, so I closed that PR and reworked it into this.

Just for the sake of clarity, and to catch any mistakes in my reasoning, I've listed brief explanations for why I modified each prep function, along with brief explanations for why I didn't modify others.

I also realize that the prep functions themselves don't perform the mutation, but the reasoning below is considered from the point of the caller submitting resources to the kernel, such that after they call the prep function they must assume that mutations may occur until they process an associated final cqe for the operation.

#### input-only non-pointer args:

- `io_uring_prep_cancel64`
- `io_uring_prep_cancel_fd`
- `io_uring_prep_close`
- `io_uring_prep_close_direct`
- `io_uring_prep_connect`
- `io_uring_prep_cmd_discard`
- `io_uring_prep_fadvise`
- `io_uring_prep_fadvise64`
- `io_uring_prep_fallocate`
- `io_uring_prep_fixed_fd_install`
- `io_uring_prep_fsync`
- `io_uring_prep_ftruncate`
- `io_uring_prep_listen`
- `io_uring_prep_msg_ring`
- `io_uring_prep_msg_ring_cqe_flags`
- `io_uring_prep_msg_ring_fd`
- `io_uring_prep_msg_ring_fd_alloc`
- `io_uring_prep_nop`
- `io_uring_prep_poll_add`
- `io_uring_prep_poll_multishot`
- `io_uring_prep_poll_remove`
- `io_uring_prep_poll_update`
- `io_uring_prep_read_multishot`
- `io_uring_prep_remove_buffers`
- `io_uring_prep_send_bundle`
- `io_uring_prep_shutdown`
- `io_uring_prep_socket`
- `io_uring_prep_socket_direct`
- `io_uring_prep_socket_direct_alloc`
- `io_uring_prep_splice`
- `io_uring_prep_sync_file_range`
- `io_uring_prep_tee`

#### const pointer args:

- `io_uring_prep_rw`: (only sets the addr field)
- `io_uring_prep_bind`: (references addr/len)
- `io_uring_prep_cancel`: (compares user_data pointer)
- `io_uring_prep_epoll_ctl`: (references epoll_event)
- `io_uring_prep_files_update`: (references fds)
- `io_uring_prep_fsetxattr`: (references value)
- `io_uring_prep_futex_wait`: (references futex)
- `io_uring_prep_futex_waitv`: (references futex)
- `io_uring_prep_futex_wake`: (references futex)
- `io_uring_prep_link`: (references paths)
- `io_uring_prep_link_timeout`: (references timespec)
- `io_uring_prep_linkat`: (references paths)
- `io_uring_prep_mkdir`: (references path)
- `io_uring_prep_mkdirat`: (references path)
- `io_uring_prep_open`: (references path)
- `io_uring_prep_open_direct`: (references path)
- `io_uring_prep_openat`: (references path)
- `io_uring_prep_openat_direct`: (references path)
- `io_uring_prep_openat2`: (references path; assuming future extensions don't mutate)
- `io_uring_prep_openat2_direct`: (references path; assuming future extensions don't mutate)
- `io_uring_prep_readv`: (references iovecs; individual iovec mutated through iov_base field)
- `io_uring_prep_readv2`: (references iovecs; individual iovec mutated through iov_base field)
- `io_uring_prep_readv_fixed`: (references iovecs; individual iovec mutated through iov_base field)
- `io_uring_prep_rename`: (references paths)
- `io_uring_prep_renameat`: (references paths)
- `io_uring_prep_send`: (references buf)
- `io_uring_prep_send_set_attr`: (references addr)
- `io_uring_prep_send_zc`: (references buf)
- `io_uring_prep_send_zc_fixed`: (references buf)
- `io_uring_prep_sendmsg`: (references msghdr)
- `io_uring_prep_sendmsg_zc`: (references msghdr)
- `io_uring_prep_sendmsg_zc_fixed`: (references msghdr)
- `io_uring_prep_sendto`: (references buf/addr)
- `io_uring_prep_setxattr`: (references name/value/path)
- `io_uring_prep_symlink`: (references target/linkpath)
- `io_uring_prep_symlinkat`: (references target/linkpath)
- `io_uring_prep_timeout`: (references timespec)
- `io_uring_prep_timeout_remove`: (references timespec)
- `io_uring_prep_timeout_update`: (references timespec)
- `io_uring_prep_unlink`: (references path)
- `io_uring_prep_unlinkat`: (references path)
- `io_uring_prep_write`: (references buf)
- `io_uring_prep_write_fixed`: (references buf)
- `io_uring_prep_writev`: (references iovecs)
- `io_uring_prep_writev_fixed`: (references iovecs)
- `io_uring_prep_writev2`: (references iovecs)

#### mutating pointer args:

- `io_uring_prep_accept`: (writes-back peer addr/len)
- `io_uring_prep_accept_direct`: (writes-back peer addr/len)
- `io_uring_prep_cmd_sock`: (writes-back optval for getsockopt equivalent)
- `io_uring_prep_epoll_wait`: (writes-back occurred events)
- `io_uring_prep_fgetxattr`: (writes-back attr value)
- `io_uring_prep_getxattr`: (writes-back attr value)
- `io_uring_prep_madvise`: (some advise mutates addr)
- `io_uring_prep_madvise64`: (some advise mutates addr)
- `io_uring_prep_multishot_accept`: (writes-back peer addr/len)
- `io_uring_prep_multishot_accept_direct`: (writes-back peer addr/len)
- `io_uring_prep_pipe`: (writes-back created fds)
- `io_uring_prep_pipe_direct`: (writes-back created fds)
- `io_uring_prep_provide_buffers`: (registers buffers for future mutation)
- `io_uring_prep_read`: (writes-back the read data)
- `io_uring_prep_read_fixed`: (writes-back the read data)
- `io_uring_prep_recv`: (writes-back the received data)
- `io_uring_prep_recv_multishot`: (writes-back the received data)
- `io_uring_prep_recvmsg`: (updates msghdr fields)
- `io_uring_prep_recvmsg_multishot`: (updates msghdr fields)
- `io_uring_prep_statx`: (references path; updates statxbuf fields)
- `io_uring_prep_waitid`: (updates infop fields)

----
## git request-pull output:
```
The following changes since commit e951bf0c08c81a2ea0c4b7bca7e4494f2043d367:

  man: include common -ENOMEM error for zero copy send (2025-09-22 09:55:44 -0600)

are available in the Git repository at:

  https://github.com/silvanshade/liburing const-for-preps

for you to fetch changes up to a0f9a19a769dd0298229200affc2ab3f9c37dd1b:

  liburing.h: Add const-qualifier for some preps (2025-09-24 15:21:33 -0600)

----------------------------------------------------------------
Darin Morrison (1):
      liburing.h: Add const-qualifier for some preps

 src/include/liburing.h | 28 ++++++++++++++--------------
 1 file changed, 14 insertions(+), 14 deletions(-)
```
