### PR TITLE
[GIT PULL] add missing noexcept, local inline, const quals

### DIFF
--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -518,6 +518,7 @@ IOURINGINLINE void io_uring_sqe_set_data(struct io_uring_sqe *sqe, void *data)
 }
 
 IOURINGINLINE void *io_uring_cqe_get_data(const struct io_uring_cqe *cqe)
+	LIBURING_NOEXCEPT
 {
 	return (void *) (uintptr_t) cqe->user_data;
 }
@@ -915,7 +916,7 @@ IOURINGINLINE void io_uring_prep_connect(struct io_uring_sqe *sqe, int fd,
 }
 
 IOURINGINLINE void io_uring_prep_bind(struct io_uring_sqe *sqe, int fd,
-				      struct sockaddr *addr,
+				      const struct sockaddr *addr,
 				      socklen_t addrlen)
 	LIBURING_NOEXCEPT
 {
@@ -923,7 +924,7 @@ IOURINGINLINE void io_uring_prep_bind(struct io_uring_sqe *sqe, int fd,
 }
 
 IOURINGINLINE void io_uring_prep_listen(struct io_uring_sqe *sqe, int fd,
-				      int backlog)
+					int backlog)
 	LIBURING_NOEXCEPT
 {
 	io_uring_prep_rw(IORING_OP_LISTEN, sqe, fd, 0, backlog, 0);
@@ -1773,7 +1774,7 @@ IOURINGINLINE int io_uring_wait_cqe_nr(struct io_uring *ring,
 	return __io_uring_get_cqe(ring, cqe_ptr, 0, wait_nr, NULL);
 }
 
-static inline bool io_uring_skip_cqe(struct io_uring *ring,
+_LOCAL_INLINE bool io_uring_skip_cqe(struct io_uring *ring,
 				     struct io_uring_cqe *cqe, int *err)
 {
 	if (cqe->flags & IORING_CQE_F_SKIP)


### PR DESCRIPTION
io_uring_prep_bind can be updated to accept its address by const pointer which makes it consistent with the documented bind system call. We also replace a raw `static inline` with the proper macro for the recently introduced io_uring_skip_cqe helper. And finally, we introduce a missing noexcept specifier for io_uring_cqe_get_data.


<!-- Explain your changes here... -->

----
## git request-pull output:
```
The following changes since commit e951bf0c08c81a2ea0c4b7bca7e4494f2043d367:

  man: include common -ENOMEM error for zero copy send (2025-09-22 09:55:44 -0600)

are available in the Git repository at:

  git@github.com:cmazakas/liburing.git small-fixes

for you to fetch changes up to 7039f036302b2f9119a36c55bd5b898bac1ec7e4:

  add missing noexcept, local inline, const quals (2025-09-24 15:41:47 -0700)

----------------------------------------------------------------
Christian Mazakas (1):
      add missing noexcept, local inline, const quals

 src/include/liburing.h | 7 ++++---
 1 file changed, 4 insertions(+), 3 deletions(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
