### PR TITLE
[GIT PULL] Added query.h to install

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -100,6 +100,7 @@ install: $(all_targets)
 	install -D -m 644 include/liburing/compat.h $(includedir)/liburing/compat.h
 	install -D -m 644 include/liburing/barrier.h $(includedir)/liburing/barrier.h
 	install -D -m 644 include/liburing/io_uring_version.h $(includedir)/liburing/io_uring_version.h
+	install -D -m 644 include/liburing/io_uring/query.h $(includedir)/liburing/io_uring/query.h
 	install -D -m 644 liburing.a $(libdevdir)/liburing.a
 	install -D -m 644 liburing-ffi.a $(libdevdir)/liburing-ffi.a
 ifeq ($(ENABLE_SHARED),1)
@@ -118,6 +119,7 @@ uninstall:
 	@rm -f $(includedir)/liburing/barrier.h
 	@rm -f $(includedir)/liburing/sanitize.h
 	@rm -f $(includedir)/liburing/io_uring_version.h
+	@rm -f $(includedir)/liburing/io_uring/query.h
 	@rm -f $(libdevdir)/liburing.a
 	@rm -f $(libdevdir)/liburing-ffi.a
 ifeq ($(ENABLE_SHARED),1)


### PR DESCRIPTION
Fixes https://github.com/axboe/liburing/issues/1470

----
## git request-pull output:
```
The following changes since commit e951bf0c08c81a2ea0c4b7bca7e4494f2043d367:

  man: include common -ENOMEM error for zero copy send (2025-09-22 09:55:44 -0600)

are available in the Git repository at:

  https://github.com/rpereira-dev/liburing master

for you to fetch changes up to b02b4205f480b6fbce2dc773805690b1a617ab8f:

  Added query.h to install (2025-09-25 13:27:00 +0000)

----------------------------------------------------------------
Romain Pereira (1):
      Added query.h to install

 src/Makefile | 2 ++
 1 file changed, 2 insertions(+)
```
