### PR TITLE
[GIT PULL] Extend documentation of SQE pointer lifetimes

### DIFF
--- a/man/io_uring.7
+++ b/man/io_uring.7
@@ -430,6 +430,43 @@ events to complete.
 This way,
 you can be sure to find completion events in the completion queue without
 having to poll it for events later.
+.SS SQE pointer lifetimes & data stability
+Due to the fixed size of the submission queue entry (SQE) some data you
+provide in order to perform a desired operation will be passed in the
+form of a pointer rather than value. In this situation, you may free
+the memory backing the pointer once the succeeding
+.BR io_uring_enter (2)
+call has completed; providing it is only required by the operation when submitting.
+
+When
+.B IORING_SETUP_SQPOLL
+is not enabled, this is done when you call
+.BR io_uring_submit (3)
+In The event
+.B IORING_SETUP_SQPOLL
+is enabled, you must ensure any provided pointers remain valid until completion.
+
+However, very early kernels (5.4 and earlier) required state to be
+ stable until the completion occurred regardless. Applications can test for this
+ behavior by inspecting the
+.B IORING_FEAT_SUBMIT_STABLE
+flag passed back from
+.BR io_uring_queue_init_params (3).
+
+As an example, the
+.B IORING_OP_TIMEOUT
+operation takes a pointer to a __kernel_timespec struct. This struct is
+then read by the kernel when you submit the submission queue entries,
+once submitted, you may free the backing memory of the __kernel_timespec
+as it will not be read again by the kernel.
+
+It should be noted that this behaviour does not apply to data that is read
+or written while the operation is inflight. For example, the pointers to
+a buffer used as part of a
+.B IORING_OP_WRITE
+or
+.B IORING_OP_READ
+operation must remain valid until completion.
 .SS Reading completion events
 Similar to the submission queue (SQ),
 the completion queue (CQ) is a shared buffer between the kernel and user


### PR DESCRIPTION
Extends `man/io_uring.7` to include a more detailed description of pointer lifetime rules within io_uring.  

This is off the back of a discussion that happened on Discord a little while ago, where there was some confusion 
around how long pointers to certain SQE parameters had to live and remain valid, in particular, the confusion
extends from the mention of `IORING_FEAT_SUBMIT_STABLE` in certain notes of various ops, but does not clarify
whether or not the described behaviour applies to all pointers provided to the SQE.

It is probably worth referencing this section on those applicable ops, but that is a job for another PR.

----
## git request-pull output:
```
The following changes since commit 03b511049579e4472c285930d55d90aaba8161ca:

  Merge branch 'small_fix' of https://github.com/schlad/liburing (2025-10-10 07:18:35 -0600)

are available in the Git repository at:

  https://github.com/ChillFish8/liburing chillfish8/expand-docs-around-data-stability

for you to fetch changes up to c10975704ec8b581ac949238bcb14d38facdac1a:

  man: Extend documentation of pointer lifetimes (2025-10-29 21:30:06 +0000)

----------------------------------------------------------------
chillfish8 (1):
      man: Extend documentation of pointer lifetimes

 man/io_uring.7 | 28 ++++++++++++++++++++++++++++
 1 file changed, 28 insertions(+)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
