### PR TITLE
[GIT PULL] setup: fix 1-byte munmap in NO_MMAP error paths

### DIFF
--- a/src/setup.c
+++ b/src/setup.c
@@ -285,7 +285,7 @@ static int io_uring_alloc_huge(unsigned entries, struct io_uring_params *p,
 					MAP_SHARED|MAP_ANONYMOUS|map_hugetlb,
 					-1, 0);
 		if (IS_ERR(ptr)) {
-			__sys_munmap(sq->sqes, 1);
+			__sys_munmap(sq->sqes, buf_size);
 			return PTR_ERR(ptr);
 		}
 		sq->ring_ptr = ptr;


### PR DESCRIPTION
Use the actual mapping size (buf_size or ret) instead of 1 when unmapping on io_uring_setup failure or alloc_huge second-mmap failure.

Found with ZeroPath.


<!-- Explain your changes here... -->

----
## git request-pull output:
```
The following changes since commit fcc9cf4cffd41b38a30ea786bf911f25f3fe4ffe:

  Merge branch 'chillfish8/expand-docs-around-data-stability' of https://github.com/ChillFish8/liburing (2025-10-30 07:40:12 -0600)

are available in the Git repository at:

  git@github.com:MegaManSec/liburing.git bug2

for you to fetch changes up to 04f1c63be5a1f67bc09114be48cd8e8f2875f33a:

  setup: fix 1-byte munmap in NO_MMAP error paths (2025-11-07 23:41:51 +0800)

----------------------------------------------------------------
Joshua Rogers (1):
      setup: fix 1-byte munmap in NO_MMAP error paths

 src/setup.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
