### PR TITLE
[GIT PULL] hppa: unregister buf ring if mmap fails in br_setup()

### DIFF
--- a/src/setup.c
+++ b/src/setup.c
@@ -630,6 +630,7 @@ static struct io_uring_buf_ring *br_setup(struct io_uring *ring,
 			MAP_SHARED | MAP_POPULATE, ring->ring_fd, off);
 	if (IS_ERR(br)) {
 		*err = PTR_ERR(br);
+		io_uring_unregister_buf_ring(ring, bgid);
 		return NULL;
 	}
 


### PR DESCRIPTION
Prevent leaking a registered buf ring when the mmap of the provided ring fails by calling io_uring_unregister_buf_ring before returning.

Found with ZeroPath.


----
## git request-pull output:
```
The following changes since commit fcc9cf4cffd41b38a30ea786bf911f25f3fe4ffe:

  Merge branch 'chillfish8/expand-docs-around-data-stability' of https://github.com/ChillFish8/liburing (2025-10-30 07:40:12 -0600)

are available in the Git repository at:

  git@github.com:MegaManSec/liburing.git bug3

for you to fetch changes up to f004be66f6bbfc503b3aa3fc527216c1e1d50808:

  setup: fully unmap single NO_MMAP region when SQE and rings share one mapping (2025-11-07 23:42:38 +0800)

----------------------------------------------------------------
Joshua Rogers (1):
      setup: fully unmap single NO_MMAP region when SQE and rings share one mapping

 src/setup.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

----

## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
