### PR TITLE
[GIT PULL] setup: fully unmap single NO_MMAP region when SQE and rings share one mapping

### DIFF
--- a/src/setup.c
+++ b/src/setup.c
@@ -330,7 +330,7 @@ int __io_uring_queue_init_params(unsigned entries, struct io_uring *ring,
 	if (fd < 0) {
 		if ((p->flags & IORING_SETUP_NO_MMAP) &&
 		    !(ring->int_flags & INT_FLAG_APP_MEM)) {
-			__sys_munmap(ring->sq.sqes, 1);
+			__sys_munmap(ring->sq.sqes, ret);
 			io_uring_unmap_rings(&ring->sq, &ring->cq);
 		}
 		return fd;


### PR DESCRIPTION
Track and unmap the full contiguous allocation from sq->sqes so the ring portion is not left mapped on error or teardown.

Found with ZeroPath.


<!-- Explain your changes here... -->

----
## git request-pull output:
```
The following changes since commit fcc9cf4cffd41b38a30ea786bf911f25f3fe4ffe:

  Merge branch 'chillfish8/expand-docs-around-data-stability' of https://github.com/ChillFish8/liburing (2025-10-30 07:40:12 -0600)

are available in the Git repository at:

  git@github.com:MegaManSec/liburing.git bug1

for you to fetch changes up to 552cef5400534187374763e5a1ec93b463e8e89d:

  hppa: unregister buf ring if mmap fails in br_setup() (2025-11-07 23:39:00 +0800)

----------------------------------------------------------------
Joshua Rogers (1):
      hppa: unregister buf ring if mmap fails in br_setup()

 src/setup.c | 1 +
 1 file changed, 1 insertion(+)
```

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
