### PR TITLE
Fix compiling of example in io_uring.7 due to missing "errno" variable.

### DIFF
--- a/man/io_uring.7
+++ b/man/io_uring.7
@@ -676,6 +676,7 @@ provides with its asynchronous processing of requests.
 #include <unistd.h>
 #include <string.h>
 #include <stdatomic.h>
+#include <errno.h>
 
 #include <linux/io_uring.h>
 


### PR DESCRIPTION
The io_uring.7 manpage has an example that uses the "errno" variable.
This variable is not known and leads to a compiler error, due to a missing #include <errno.h>. Add it to get the example compiled.

Contact: Hubert Feyrer <hubertf@gmx.de>

=== BEFORE ===

$ gcc 4manpage-original.c  -o 4manpage-original
4manpage-original.c: In function ‘io_uring_setup’: 4manpage-original.c:44:25: error: ‘errno’ undeclared (first use in this function)
   44 |     return (ret < 0) ? -errno : ret;
      |                         ^~~~~
4manpage-original.c:15:1: note: ‘errno’ is defined in header ‘<errno.h>’; this is probably fixable by adding ‘#include <errno.h>’
   14 | #include <linux/io_uring.h>
  +++ |+#include <errno.h>
   15 |
4manpage-original.c:44:25: note: each undeclared identifier is reported only once for each function it appears in
   44 |     return (ret < 0) ? -errno : ret;
      |                         ^~~~~
4manpage-original.c: In function ‘io_uring_enter’:
4manpage-original.c:53:25: error: ‘errno’ undeclared (first use in this function)
   53 |     return (ret < 0) ? -errno : ret;
      |                         ^~~~~
4manpage-original.c:53:25: note: ‘errno’ is defined in header ‘<errno.h>’; this is probably fixable by adding ‘#include <errno.h>’

==== PATCH ===

$ diff -u 4manpage-original.c 4manpage.c
--- 4manpage-original.c	2025-12-06 11:52:24.171027464 +0100 +++ 4manpage.c	2025-12-06 11:32:55.431256160 +0100 @@ -10,6 +10,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <stdatomic.h>
+#include <errno.h>

 #include <linux/io_uring.h>

=== AFTER ===

$ gcc 4manpage.c -o 4manpage
$ cat 4manpage.c | ./4manpage | diff -u 4manpage.c - $


<!-- Explain your changes here... -->

----
## git request-pull output:
```
<!-- START REPLACE ME -->

Generate your PR shortlog and diffstat with these commands:
   git remote add axboe-tree https://github.com/axboe/liburing
   git fetch axboe-tree
   git request-pull axboe-tree/master your_fork_URL your_branch_name

Then replace this with the output of `git request-pull` command.

<!-- END REPLACE ME -->
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
