### PR TITLE
[GIT PULL] build: Pass env CFLAGS through to make

### DIFF
--- a/configure
+++ b/configure
@@ -120,8 +120,9 @@ print_config() {
 }
 
 # Default CFLAGS
-CFLAGS="-D_GNU_SOURCE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -include config-host.h"
-BUILD_CFLAGS=""
+ENV_CFLAGS="${CFLAGS}"
+CFLAGS="${CFLAGS:+$CFLAGS }-D_GNU_SOURCE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -include config-host.h"
+BUILD_CFLAGS="${ENV_CFLAGS}"
 
 # Print configure header at the top of $config_host_h
 echo "/*" > $config_host_h
@@ -588,6 +589,7 @@ fi
 echo "CC=$cc" >> $config_host_mak
 print_config "CC" "$cc"
 echo "CXX=$cxx" >> $config_host_mak
+echo "BUILD_CFLAGS=$BUILD_CFLAGS" >> $config_host_mak
 print_config "CXX" "$cxx"
 
 # generate io_uring_version.h

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,6 +13,7 @@ override CPPFLAGS += -D_GNU_SOURCE \
 CFLAGS ?= -O3 -Wall -Wextra -fno-stack-protector
 override CFLAGS += -Wno-unused-parameter \
 	-DLIBURING_INTERNAL \
+	$(BUILD_CFLAGS) \
 	$(LIBURING_CFLAGS)
 SO_CFLAGS=-fPIC $(CFLAGS)
 L_CFLAGS=$(CFLAGS)


### PR DESCRIPTION
In our (envoy) build we use a sysroot to ensure hermetic builds.

This fixes a problem where configure is passed the sysroot flag and detects kernel headers for openat2.h but then make doesnt have the sysroot and fails.

----
## git request-pull output:
```
The following changes since commit 4235cf5db414884887e4b5599311c59c31d71085:

  test: remove t_sqe_prep_cmd() (2025-10-24 12:27:09 -0600)

are available in the Git repository at:

  origin/make-cflags 

for you to fetch changes up to 28123d5ef766c5d0dc5604187dfe57d624205dcf:

  build: Pass env CFLAGS through to make (2025-12-12 12:54:13 +0000)

----------------------------------------------------------------
Ryan Northey (1):
      build: Pass env CFLAGS through to make

 configure    | 10 ++++++++--
 src/Makefile |  2 +-
 2 files changed, 9 insertions(+), 3 deletions(-)

```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>


The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
