### PR TITLE
[GIT PULL] src/setup: fix incorrect ring_mem calculation in io_uring_alloc_huge

### DIFF
--- a/src/setup.c
+++ b/src/setup.c
@@ -227,15 +227,14 @@ static int io_uring_alloc_huge(unsigned entries, struct io_uring_params *p,
 	if (ret)
 		return ret;
 
-	ring_mem = KRING_SIZE;
-
 	sqes_mem = params_sqes_size(p, sq_entries);
 	if (!(p->flags & IORING_SETUP_NO_SQARRAY))
 		sqes_mem += sq_entries * sizeof(unsigned);
 	sqes_mem = (sqes_mem + page_size - 1) & ~(page_size - 1);
 
-	ring_mem += sqes_mem + params_cq_size(p, cq_entries);
-	mem_used = ring_mem;
+	ring_mem = KRING_SIZE;
+	ring_mem += params_cq_size(p, cq_entries);
+	mem_used = sqes_mem + ring_mem;
 	mem_used = (mem_used + page_size - 1) & ~(page_size - 1);
 
 	/*


### PR DESCRIPTION
The ring_mem variable in io_uring_alloc_huge() was incorrectly being accumulated with sqes_mem (ring_mem += sqes_mem + params_cq_size()) instead of representing just the CQ ring size.

Since sqes_mem is page-aligned, when ring_mem is calculated as KRING_SIZE + sqes_mem + params_cq_size(), it's always > page_size. This makes the condition "ring_mem <= page_size" always false, preventing the code from using a regular page for small CQ rings when a huge page would be wasteful.


<!-- Explain your changes here... -->

----
## git request-pull output:
```
The following changes since commit 669a89b880d08913652ec86239be02c026a20083:

  test/timestamp-buf: make internal function static (2025-12-16 19:57:00 -0700)

are available in the Git repository at:

  https://github.com/wokron/liburing fix-init-mem-non-huge-page

for you to fetch changes up to b916078cc3d0a908c6499f0da404fc8ad3f83a79:

  src/setup: fix incorrect ring_mem calculation in io_uring_alloc_huge (2025-12-20 22:31:36 +0800)

----------------------------------------------------------------
Yitang Yang (1):
      src/setup: fix incorrect ring_mem calculation in io_uring_alloc_huge

 src/setup.c | 7 +++----
 1 file changed, 3 insertions(+), 4 deletions(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
