### PR TITLE
test: min-timeout: fail on unexpected CQE count

### DIFF
--- a/test/min-timeout.c
+++ b/test/min-timeout.c
@@ -133,8 +133,10 @@ static int test(int flags, int expected_ctx, int min_wait, int write_delay,
 		io_uring_cqe_seen(&ring, cqe);
 	}
 
-	if (i != nr_cqes)
+	if (i != nr_cqes) {
 		fprintf(stderr, "Got %d CQEs, expected %d\n", i, nr_cqes);
+		return T_EXIT_FAIL;
+	}
 
 	pthread_join(thread, &tret);
 


### PR DESCRIPTION
The min-timeout test currently logs a CQE count mismatch but still reports success. Make the test fail when the observed CQE count differs from the expected value.

This helps while running this test in a CI.

related to: https://github.com/axboe/liburing/issues/1477