### PR TITLE
man: document IORING_SETUP_TASKRUN_FLAG + IORING_SETUP_DEFER_TASKRUN

### DIFF
--- a/man/io_uring_setup.2
+++ b/man/io_uring_setup.2
@@ -252,7 +252,9 @@ use cases, setting this flag will improve performance. Available since 5.19.
 .TP
 .B IORING_SETUP_TASKRUN_FLAG
 Used in conjunction with
-.BR IORING_SETUP_COOP_TASKRUN ,
+.BR IORING_SETUP_COOP_TASKRUN
+or
+.BR IORING_SETUP_DEFER_TASKRUN ,
 this provides a flag,
 .BR IORING_SQ_TASKRUN ,
 which is set in the SQ ring


### PR DESCRIPTION
The `io_uring_setup()` man page describes `IORING_SETUP_TASKRUN_FLAG` as being used with `IORING_SETUP_COOP_TASKRUN`. But `IORING_SETUP_TASKRUN_FLAG` can also be used with `IORING_SETUP_DEFER_TASKRUN`. So mention both flags.

----
## git request-pull output:
```
The following changes since commit 3756b3de4cf2e16a5a727c9feefafd7b8c026042:

  test/io-wq-exit: fix missing liburing test tweaks (2026-01-05 07:31:28 -0700)

are available in the Git repository at:

  git@github.com:calebsander/liburing.git doc/IORING_SETUP_DEFER_TASKRUN_FLAG

for you to fetch changes up to 1c3795041d9bea4c1bf748586af8b73d40425a12:

  man: document IORING_SETUP_TASKRUN_FLAG + IORING_SETUP_DEFER_TASKRUN (2026-01-05 16:40:20 -0700)

----------------------------------------------------------------
Caleb Sander Mateos (1):
      man: document IORING_SETUP_TASKRUN_FLAG + IORING_SETUP_DEFER_TASKRUN

 man/io_uring_setup.2 | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)
```
----
