### PR TITLE
[GIT PULL] Unify date formats in manual files

### DIFF
--- a/man/io_uring.7
+++ b/man/io_uring.7
@@ -2,7 +2,7 @@
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
 
-.TH io_uring 7 2020-07-26 "Linux" "Linux Programmer's Manual"
+.TH io_uring 7 "July 26, 2020" "Linux" "Linux Programmer's Manual"
 .SH NAME
 io_uring \- Asynchronous I/O facility
 .SH SYNOPSIS

--- a/man/io_uring_enter.2
+++ b/man/io_uring_enter.2
@@ -3,7 +3,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_enter 2 2019-01-22 "Linux" "Linux Programmer's Manual"
+.TH io_uring_enter 2 "January 22, 2019" "Linux" "Linux Programmer's Manual"
 .SH NAME
 io_uring_enter \- initiate and/or complete asynchronous I/O
 .SH SYNOPSIS

--- a/man/io_uring_register.2
+++ b/man/io_uring_register.2
@@ -3,7 +3,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_register 2 2019-01-17 "Linux" "Linux Programmer's Manual"
+.TH io_uring_register 2 "January 17, 2019" "Linux" "Linux Programmer's Manual"
 .SH NAME
 io_uring_register \- register files or user buffers for asynchronous I/O 
 .SH SYNOPSIS

--- a/man/io_uring_setup.2
+++ b/man/io_uring_setup.2
@@ -4,7 +4,7 @@
 .\"
 .\" SPDX-License-Identifier: LGPL-2.0-or-later
 .\"
-.TH io_uring_setup 2 2019-01-29 "Linux" "Linux Programmer's Manual"
+.TH io_uring_setup 2 "January 29, 2019" "Linux" "Linux Programmer's Manual"
 .SH NAME
 io_uring_setup \- setup a context for performing asynchronous I/O
 .SH SYNOPSIS


### PR DESCRIPTION
Currently there are two different date formats in the headers. This commit unifies the formats to the one that is used more often.

----
## git request-pull output:
```
The following changes since commit 3756b3de4cf2e16a5a727c9feefafd7b8c026042:

  test/io-wq-exit: fix missing liburing test tweaks (2026-01-05 07:31:28 -0700)

are available in the Git repository at:

  git@github.com:betelgeuse/liburing.git unify_manual_page_date_formats

for you to fetch changes up to 88ca8ac0dab965ff297a4f5f019459cc01caaaed:

  Unify date formats in manual files (2026-01-10 12:23:37 +0200)

----------------------------------------------------------------
Petteri Räty (1):
      Unify date formats in manual files

 man/io_uring.7          | 2 +-
 man/io_uring_enter.2    | 2 +-
 man/io_uring_register.2 | 2 +-
 man/io_uring_setup.2    | 2 +-
 4 files changed, 4 insertions(+), 4 deletions(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
