### PR TITLE
remove const from io_uring_prep_files_update

### DIFF
--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -947,7 +947,7 @@ IOURINGINLINE void io_uring_prep_epoll_wait(struct io_uring_sqe *sqe, int fd,
 }
 
 IOURINGINLINE void io_uring_prep_files_update(struct io_uring_sqe *sqe,
-					      const int *fds, unsigned nr_fds,
+					      int *fds, unsigned nr_fds,
 					      int offset)
 	LIBURING_NOEXCEPT
 {


### PR DESCRIPTION
Because io_uring writes to the fds array passed into io_uring_prep_files_update, it's incorrect to take the array by const pointer because it enables users to erroneously pass a pointer to an array-of-const.


<!-- Explain your changes here... -->

----
## git request-pull output:
```
The following changes since commit fdb99280e588dd0c1a58fd3f9a87cab1363e6f74:

  Merge branch 'fix_io_uring_prep_cmd_sock_man_page_file_name' of https://github.com/betelgeuse/liburing (2026-01-10 10:09:52 -0700)

are available in the Git repository at:

  git@github.com:cmazakas/liburing.git prep-files-update-const-correctness

for you to fetch changes up to 0ddbc0730b55bc109edbb722e24616e6b937e17c:

  remove const from io_uring_prep_files_update (2026-01-10 11:26:31 -0800)

----------------------------------------------------------------
Christian Mazakas (1):
      remove const from io_uring_prep_files_update

 src/include/liburing.h | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
