### PR TITLE
man/io_uring_prep_send.3: fix broken links

### DIFF
--- a/man/io_uring_prep_send.3
+++ b/man/io_uring_prep_send.3
@@ -165,7 +165,7 @@ are available since kernel 6.10, and can be further identified by checking for
 the
 .B IORING_FEAT_SEND_BUF_SELECT
 flag returned in when using
-.BR io_uring_init_queue_params (3)
+.BR io_uring_queue_init_params (3)
 to setup the ring.
 
 .SH RETURN VALUE


### PR DESCRIPTION
Fix broken link in the io_uring_prep_send man page to io_uring_queue_init_params call

Fixes: b0749500fe7dc3cb573ac8c6cabb3f817a86109e ("Add man page for send bundle")

This is a very small PR because I'm trying to get familiar with the process. Hopefully I did everything right, because I have more man pages commits ready. If not let me know what I should have changed in the PR.

----
## git request-pull output:
```
The following changes since commit c788519640d58a9cd6d64611f6dcb881bf80ca61:

  man/io_uring_prep_send.3: fix broken links (2026-01-11 23:41:26 +0100)

are available in the Git repository at:

  git@github.com:espoal/liburing.git fix/send_man_pages_link

for you to fetch changes up to c788519640d58a9cd6d64611f6dcb881bf80ca61:

  man/io_uring_prep_send.3: fix broken links (2026-01-11 23:41:26 +0100)

```
----




----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
