### PR TITLE
liburing: Add zone block device support

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -39,7 +39,8 @@ example_srcs := \
 	rsrc-update-bench.c \
 	proxy.c \
 	zcrx.c \
-	kdigest.c
+	kdigest.c \
+	zoned-test.c
 
 all_targets :=
 

--- a/examples/zoned-test.c
+++ b/examples/zoned-test.c
@@ -1,0 +1,281 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Simple test application for liburing zone device support
+ * Tests basic zone operations on SMR/ZAC devices
+ */
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <linux/blkzoned.h>
+#include <liburing.h>
+#include <liburing/zoned.h>
+
+#define TEST_BUFFER_SIZE (256 * 1024)  // 256KB
+#define IO_DEPTH 32
+
+static void print_usage(const char *prog)
+{
+    fprintf(stderr, "Usage: %s <device> [options]\n", prog);
+    fprintf(stderr, "Options:\n");
+    fprintf(stderr, "  -s <size>    Write size in KB (default: 256)\n");
+    fprintf(stderr, "  -z <zone>    Target zone index (default: first sequential zone)\n");
+    fprintf(stderr, "  -v           Verbose output\n");
+    fprintf(stderr, "\nExample: %s /dev/sdg\n", prog);
+}
+
+static int wait_completion(struct io_uring *ring, int expected)
+{
+    struct io_uring_cqe *cqe;
+    int completed = 0;
+    
+    while (completed < expected) {
+        int ret = io_uring_wait_cqe(ring, &cqe);
+        if (ret < 0) {
+            fprintf(stderr, "io_uring_wait_cqe: %s\n", strerror(-ret));
+            return ret;
+        }
+        
+        if (cqe->res < 0) {
+            fprintf(stderr, "I/O error: %s\n", strerror(-cqe->res));
+            io_uring_cqe_seen(ring, cqe);
+            return cqe->res;
+        }
+        
+        completed++;
+        io_uring_cqe_seen(ring, cqe);
+    }
+    
+    return 0;
+}
+
+int main(int argc, char *argv[])
+{
+    const char *device_path = NULL;
+    int fd, ret, opt;
+    struct io_uring ring;
+    struct uring_zone_info *zones = NULL;
+    size_t zone_count = 0;
+    size_t target_zone_idx = 0;
+    size_t write_size = TEST_BUFFER_SIZE;
+    bool verbose = false;
+    bool zone_specified = false;
+    void *write_buf = NULL, *read_buf = NULL;
+    
+    // Parse arguments
+    while ((opt = getopt(argc, argv, "s:z:vh")) != -1) {
+        switch (opt) {
+        case 's':
+            write_size = atoi(optarg) * 1024;
+            break;
+        case 'z':
+            target_zone_idx = atoi(optarg);
+            zone_specified = true;
+            break;
+        case 'v':
+            verbose = true;
+            break;
+        case 'h':
+        default:
+            print_usage(argv[0]);
+            return 1;
+        }
+    }
+    
+    if (optind >= argc) {
+        fprintf(stderr, "Error: Device path required\n\n");
+        print_usage(argv[0]);
+        return 1;
+    }
+    
+    device_path = argv[optind];
+    
+    printf("=== liburing Zone Device Test ===\n");
+    printf("Device: %s\n", device_path);
+    printf("Write size: %zu KB\n", write_size / 1024);
+    
+    // Open device with O_DIRECT
+    fd = open(device_path, O_RDWR | O_DIRECT);
+    if (fd < 0) {
+        perror("open");
+        return 1;
+    }
+    
+    // Initialize io_uring
+    ret = io_uring_queue_init(IO_DEPTH, &ring, 0);
+    if (ret < 0) {
+        fprintf(stderr, "io_uring_queue_init: %s\n", strerror(-ret));
+        close(fd);
+        return 1;
+    }
+    
+    // Discover zones
+    printf("\n--- Discovering Zones ---\n");
+    ret = liburing_discover_zones(fd, &zones, &zone_count);
+    if (ret < 0) {
+        fprintf(stderr, "liburing_discover_zones: %s\n", strerror(-ret));
+        goto cleanup;
+    }
+    
+    printf("Found %zu zones\n", zone_count);
+    
+    // Find a sequential write required zone
+    struct uring_zone_info *test_zone = NULL;
+    if (zone_specified) {
+        if (target_zone_idx >= zone_count) {
+            fprintf(stderr, "Error: Zone %zu does not exist (max: %zu)\n", 
+                    target_zone_idx, zone_count - 1);
+            ret = -EINVAL;
+            goto cleanup;
+        }
+        test_zone = &zones[target_zone_idx];
+    } else {
+        for (size_t i = 0; i < zone_count; i++) {
+            if (zones[i].zone_type == BLK_ZONE_TYPE_SEQWRITE_REQ &&
+                liburing_zone_is_writable(&zones[i])) {
+                test_zone = &zones[i];
+                target_zone_idx = i;
+                break;
+            }
+        }
+    }
+    
+    if (!test_zone) {
+        fprintf(stderr, "Error: No suitable sequential write zone found\n");
+        ret = -ENODEV;
+        goto cleanup;
+    }
+    
+    printf("\n--- Target Zone ---\n");
+    printf("Zone %zu:\n", target_zone_idx);
+    printf("  Type: %s\n", liburing_zone_type_str(test_zone->zone_type));
+    printf("  Condition: %s\n", liburing_zone_cond_str(test_zone->zone_cond));
+    printf("  Start LBA: %lu (%.2f GB)\n", test_zone->start_lba,
+           (test_zone->start_lba * 512.0) / (1024*1024*1024));
+    printf("  Length: %lu sectors (%.2f GB)\n", test_zone->length,
+           (test_zone->length * 512.0) / (1024*1024*1024));
+    printf("  Write Pointer: %lu\n", test_zone->write_pointer);
+    printf("  Available: %lu sectors (%.2f GB)\n",
+           liburing_zone_available_space(test_zone),
+           (liburing_zone_available_space(test_zone) * 512.0) / (1024*1024*1024));
+    
+    // Check if zone has enough space
+    size_t required_sectors = (write_size + 511) / 512;
+    if (liburing_zone_available_space(test_zone) < required_sectors) {
+        fprintf(stderr, "Error: Zone does not have enough space\n");
+        ret = -ENOSPC;
+        goto cleanup;
+    }
+    
+    // Allocate aligned buffers
+    write_buf = liburing_alloc_aligned_buffer(write_size, 4096);
+    read_buf = liburing_alloc_aligned_buffer(write_size, 4096);
+    if (!write_buf || !read_buf) {
+        fprintf(stderr, "Error: Failed to allocate buffers\n");
+        ret = -ENOMEM;
+        goto cleanup;
+    }
+    
+    // Fill write buffer with test pattern
+    for (size_t i = 0; i < write_size; i++) {
+        ((unsigned char*)write_buf)[i] = (unsigned char)(i & 0xFF);
+    }
+    
+    printf("\n--- Test Operations ---\n");
+    
+    // Reset zone
+    printf("1. Resetting zone...\n");
+    ret = liburing_zone_reset(&ring, fd, test_zone);
+    if (ret < 0) {
+        fprintf(stderr, "liburing_zone_reset: %s\n", strerror(-ret));
+        goto cleanup;
+    }
+    printf("   Zone reset successful (WP at LBA %lu)\n", test_zone->start_lba);
+    
+    // Write data
+    printf("2. Writing %zu KB to zone...\n", write_size / 1024);
+    ret = liburing_zone_write(&ring, fd, test_zone, write_buf, write_size);
+    if (ret < 0) {
+        fprintf(stderr, "liburing_zone_write: %s\n", strerror(-ret));
+        goto cleanup;
+    }
+    
+    ret = io_uring_submit(&ring);
+    if (ret < 0) {
+        fprintf(stderr, "io_uring_submit: %s\n", strerror(-ret));
+        goto cleanup;
+    }
+    
+    ret = wait_completion(&ring, 1);
+    if (ret < 0) {
+        fprintf(stderr, "Write operation failed\n");
+        goto cleanup;
+    }
+    
+    printf("   Write successful\n");
+    
+    // Update write pointer
+    test_zone->write_pointer += required_sectors;
+    
+    // Read data back
+    printf("3. Reading %zu KB from zone...\n", write_size / 1024);
+    ret = liburing_zone_read(&ring, fd, test_zone, read_buf, write_size, 0);
+    if (ret < 0) {
+        fprintf(stderr, "liburing_zone_read: %s\n", strerror(-ret));
+        goto cleanup;
+    }
+    
+    ret = io_uring_submit(&ring);
+    if (ret < 0) {
+        fprintf(stderr, "io_uring_submit: %s\n", strerror(-ret));
+        goto cleanup;
+    }
+    
+    ret = wait_completion(&ring, 1);
+    if (ret < 0) {
+        fprintf(stderr, "Read operation failed\n");
+        goto cleanup;
+    }
+    
+    printf("   Read successful\n");
+    
+    // Verify data
+    printf("4. Verifying data integrity...\n");
+    if (memcmp(write_buf, read_buf, write_size) != 0) {
+        fprintf(stderr, "   FAILED: Data mismatch!\n");
+        
+        if (verbose) {
+            for (size_t i = 0; i < write_size && i < 256; i++) {
+                if (((unsigned char*)write_buf)[i] != ((unsigned char*)read_buf)[i]) {
+                    fprintf(stderr, "   Mismatch at offset %zu: wrote 0x%02x, read 0x%02x\n",
+                            i, ((unsigned char*)write_buf)[i], ((unsigned char*)read_buf)[i]);
+                }
+            }
+        }
+        
+        ret = -EIO;
+        goto cleanup;
+    }
+    
+    printf("   PASSED: Data verified successfully\n");
+    
+    printf("\n=== Test PASSED ===\n");
+    ret = 0;
+    
+cleanup:
+    if (write_buf)
+        free(write_buf);
+    if (read_buf)
+        free(read_buf);
+    if (zones)
+        free(zones);
+    
+    io_uring_queue_exit(&ring);
+    close(fd);
+    
+    return ret;
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -47,14 +47,14 @@ LINK_FLAGS+=$(LDFLAGS)
 
 all: $(all_targets)
 
-liburing_srcs := setup.c queue.c register.c syscall.c version.c
+liburing_srcs := setup.c queue.c register.c syscall.c version.c nolibc.c zoned.c
 
-ifeq ($(CONFIG_NOLIBC),y)
-	liburing_srcs += nolibc.c
-	override CFLAGS += -nostdlib -nodefaultlibs -ffreestanding -fno-builtin -fno-stack-protector
-	override CPPFLAGS += -nostdlib -nodefaultlibs -ffreestanding -fno-builtin -fno-stack-protector
-	override LINK_FLAGS += -nostdlib -nodefaultlibs $(libgcc_link_flag)
-endif
+# Zone support requires libc functions, so nolibc mode is disabled
+# ifeq ($(CONFIG_NOLIBC),y)
+# 	override CFLAGS += -nostdlib -nodefaultlibs -ffreestanding -fno-builtin -fno-stack-protector
+# 	override CPPFLAGS += -nostdlib -nodefaultlibs -ffreestanding -fno-builtin -fno-stack-protector
+# 	override LINK_FLAGS += -nostdlib -nodefaultlibs $(libgcc_link_flag)
+# endif
 
 ifeq ($(CONFIG_USE_SANITIZER),y)
 	override CFLAGS += -fsanitize=address,undefined -g -fno-omit-frame-pointer -fno-optimize-sibling-calls
@@ -96,7 +96,7 @@ liburing-ffi.a: $(liburing_objs) $(liburing_ffi_objs)
 	$(QUIET_RANLIB)$(RANLIB) liburing-ffi.a
 
 $(libname): $(liburing_sobjs) liburing.map
-	$(QUIET_CC)$(CC) $(SO_CFLAGS) -shared -Wl,--version-script=liburing.map -Wl,-soname=$(soname) -o $@ $(liburing_sobjs) $(LINK_FLAGS)
+	$(QUIET_CC)$(CC) $(SO_CFLAGS) -shared -Wl,--version-script=liburing.map -Wl,-soname=$(soname) -o $@ $(liburing_sobjs) $(LINK_FLAGS) -lc -lrt
 
 $(ffi_libname): $(liburing_ffi_objs) $(liburing_ffi_sobjs) $(liburing_sobjs) liburing-ffi.map
 	$(QUIET_CC)$(CC) $(SO_CFLAGS) -shared -Wl,--version-script=liburing-ffi.map -Wl,-soname=$(ffi_soname) -o $@ $(liburing_sobjs) $(liburing_ffi_sobjs) $(LINK_FLAGS)

--- a/src/include/liburing/zoned.h
+++ b/src/include/liburing/zoned.h
@@ -1,0 +1,206 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef LIBURING_ZONED_H
+#define LIBURING_ZONED_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <sys/uio.h>
+#include <liburing.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ========================================================================
+ * Zone Information Structure
+ * ======================================================================== */
+
+/**
+ * Zone information structure matching kernel blk_zone
+ */
+struct uring_zone_info {
+    uint64_t start_lba;         /**< Zone start sector */
+    uint64_t length;            /**< Zone length in sectors */
+    uint64_t write_pointer;     /**< Current write pointer (sequential zones) */
+    uint64_t capacity;          /**< Zone capacity in sectors */
+    uint8_t zone_type;          /**< Zone type (conventional, sequential) */
+    uint8_t zone_cond;          /**< Zone condition (empty, open, closed, etc.) */
+    uint8_t reserved[6];        /**< Reserved for future use */
+};
+
+/* ========================================================================
+ * Constants
+ * ======================================================================== */
+
+#define LIBURING_ZONE_SECTOR_SIZE 512
+#define LIBURING_ZONE_MAX_BATCH 32
+
+/* ========================================================================
+ * Zone Discovery and Information
+ * ======================================================================== */
+
+/**
+ * Get zone information starting from a specific sector
+ * @fd: File descriptor of the zoned block device
+ * @sector: Starting sector for zone query
+ * @max_zones: Maximum number of zones to retrieve
+ * @zones: Output array to store zone information
+ * @return: Number of zones retrieved, or negative error code
+ */
+int liburing_get_zones(int fd, uint64_t sector, int max_zones, struct uring_zone_info *zones);
+
+/**
+ * Discover all zones on a zoned block device
+ * @fd: File descriptor of the zoned block device
+ * @zones_out: Output pointer to allocated zone array
+ * @zone_count_out: Output pointer to zone count
+ * @return: 0 on success, negative error code on failure
+ * @note: Caller must free zones_out when done
+ */
+int liburing_discover_zones(int fd, struct uring_zone_info **zones_out, size_t *zone_count_out);
+
+/**
+ * Refresh the write pointer of a zone
+ * @fd: File descriptor of the zoned block device
+ * @zone: Zone to refresh
+ * @return: 0 on success, negative error code on failure
+ */
+int liburing_zone_refresh_wp(int fd, struct uring_zone_info *zone);
+
+/* ========================================================================
+ * Zone Operations
+ * ======================================================================== */
+
+/**
+ * Reset a zone (set write pointer to start)
+ * @ring: io_uring instance
+ * @fd: File descriptor of the zoned block device
+ * @zone: Zone to reset
+ * @return: 0 on success, negative error code on failure
+ */
+int liburing_zone_reset(struct io_uring *ring, int fd, struct uring_zone_info *zone);
+
+/**
+ * Write data to a zone at its current write pointer
+ * @ring: io_uring instance
+ * @fd: File descriptor of the zoned block device
+ * @zone: Target zone
+ * @buf: Data buffer to write
+ * @len: Length of data in bytes
+ * @return: 0 on success, negative error code on failure
+ */
+int liburing_zone_write(struct io_uring *ring, int fd, struct uring_zone_info *zone,
+                       const void *buf, size_t len);
+
+/**
+ * Read data from a zone
+ * @ring: io_uring instance
+ * @fd: File descriptor of the zoned block device
+ * @zone: Source zone
+ * @buf: Buffer to read into
+ * @len: Length of data to read in bytes
+ * @zone_offset: Offset within the zone (in bytes)
+ * @return: 0 on success, negative error code on failure
+ */
+int liburing_zone_read(struct io_uring *ring, int fd, struct uring_zone_info *zone,
+                      void *buf, size_t len, off_t zone_offset);
+
+/**
+ * Write multiple buffers to a zone in a batch (linked operations)
+ * @ring: io_uring instance
+ * @fd: File descriptor of the zoned block device
+ * @zone: Target zone
+ * @iov: Array of iovec structures
+ * @iovcnt: Number of iovec entries
+ * @return: 0 on success, negative error code on failure
+ */
+int liburing_zone_write_batch(struct io_uring *ring, int fd, struct uring_zone_info *zone,
+                              struct iovec *iov, int iovcnt);
+
+/**
+ * Write vectored data to a zone
+ * @ring: io_uring instance
+ * @fd: File descriptor of the zoned block device
+ * @zone: Target zone
+ * @iov: Array of iovec structures
+ * @iovcnt: Number of iovec entries
+ * @return: 0 on success, negative error code on failure
+ */
+int liburing_zone_writev(struct io_uring *ring, int fd, struct uring_zone_info *zone,
+                        const struct iovec *iov, int iovcnt);
+
+/* ========================================================================
+ * Utility Functions
+ * ======================================================================== */
+
+/**
+ * Convert zone condition to human-readable string
+ * @cond: Zone condition value
+ * @return: String representation of the condition
+ */
+const char *liburing_zone_cond_str(unsigned char cond);
+
+/**
+ * Convert zone type to human-readable string
+ * @type: Zone type value
+ * @return: String representation of the type
+ */
+const char *liburing_zone_type_str(unsigned char type);
+
+/**
+ * Allocate aligned buffer for direct I/O operations
+ * @size: Size of buffer to allocate
+ * @alignment: Alignment requirement (typically 4096)
+ * @return: Pointer to allocated buffer, or NULL on error
+ */
+void *liburing_alloc_aligned_buffer(size_t size, size_t alignment);
+
+/**
+ * Check if a zone is writable (not read-only, offline, or full)
+ * @zone: Zone to check
+ * @return: true if zone can be written to
+ */
+bool liburing_zone_is_writable(const struct uring_zone_info *zone);
+
+/**
+ * Get available space in a zone
+ * @zone: Zone to check
+ * @return: Available space in sectors
+ */
+uint64_t liburing_zone_available_space(const struct uring_zone_info *zone);
+
+/**
+ * Filter zones by type and/or condition
+ * @zones: Array of zones to filter
+ * @zone_count: Number of zones in array
+ * @zone_type: Zone type to filter by (0xFF = any)
+ * @zone_cond: Zone condition to filter by (0xFF = any)
+ * @filtered_zones: Output pointer to filtered zone array
+ * @filtered_count: Output pointer to filtered zone count
+ * @return: 0 on success, negative error code on failure
+ * @note: Caller must free filtered_zones when done
+ */
+int liburing_filter_zones(const struct uring_zone_info *zones, size_t zone_count,
+                          unsigned char zone_type, unsigned char zone_cond,
+                          struct uring_zone_info **filtered_zones, size_t *filtered_count);
+
+/**
+ * Find zones suitable for writing with specified capacity
+ * @zones: Array of zones to search
+ * @zone_count: Number of zones in array
+ * @required_capacity_sectors: Minimum required capacity in sectors
+ * @max_zones: Maximum zones to return (0 = no limit)
+ * @suitable_zones: Output pointer to suitable zone array
+ * @found_count: Output pointer to found zone count
+ * @return: 0 on success, negative error code on failure
+ * @note: Caller must free suitable_zones when done
+ */
+int liburing_find_suitable_zones(const struct uring_zone_info *zones, size_t zone_count,
+                                 size_t required_capacity_sectors, int max_zones,
+                                 struct uring_zone_info **suitable_zones, int *found_count);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIBURING_ZONED_H */

--- a/src/liburing.map
+++ b/src/liburing.map
@@ -136,5 +136,20 @@ LIBURING_2.13 {
 } LIBURING_2.12;
 
 LIBURING_2.14 {
-
+	global:
+		liburing_discover_zones;
+		liburing_get_zones;
+		liburing_zone_reset;
+		liburing_zone_write;
+		liburing_zone_read;
+		liburing_zone_write_batch;
+		liburing_zone_writev;
+		liburing_zone_refresh_wp;
+		liburing_zone_cond_str;
+		liburing_zone_type_str;
+		liburing_alloc_aligned_buffer;
+		liburing_zone_is_writable;
+		liburing_zone_available_space;
+		liburing_filter_zones;
+		liburing_find_suitable_zones;
 } LIBURING_2.13;

--- a/src/zoned.c
+++ b/src/zoned.c
@@ -1,0 +1,393 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Zone device support for io_uring
+ */
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <linux/blkzoned.h>
+#include "liburing/zoned.h"
+#include "lib.h"
+
+/* ========================================================================
+ * Zone Information and Discovery
+ * ======================================================================== */
+
+int liburing_get_zones(int fd, uint64_t sector, int max_zones, struct uring_zone_info *zones)
+{
+    if (!zones || max_zones <= 0)
+        return -EINVAL;
+
+    size_t report_size = sizeof(struct blk_zone_report) + max_zones * sizeof(struct blk_zone);
+    struct blk_zone_report *report = calloc(1, report_size);
+    if (!report)
+        return -ENOMEM;
+
+    report->sector = sector;
+    report->nr_zones = max_zones;
+
+    if (ioctl(fd, BLKREPORTZONE, report) < 0) {
+        int err = errno;
+        free(report);
+        return -err;
+    }
+
+    for (uint32_t i = 0; i < report->nr_zones && i < (uint32_t)max_zones; i++) {
+        zones[i].start_lba = report->zones[i].start;
+        zones[i].length = report->zones[i].len;
+        zones[i].write_pointer = report->zones[i].wp;
+        zones[i].capacity = report->zones[i].capacity;
+        zones[i].zone_type = report->zones[i].type;
+        zones[i].zone_cond = report->zones[i].cond;
+    }
+
+    int num_zones = report->nr_zones;
+    free(report);
+    return num_zones;
+}
+
+int liburing_discover_zones(int fd, struct uring_zone_info **zones_out, size_t *zone_count_out)
+{
+    if (!zones_out || !zone_count_out)
+        return -EINVAL;
+
+    size_t allocated = 1024;
+    struct uring_zone_info *zones = calloc(allocated, sizeof(struct uring_zone_info));
+    if (!zones)
+        return -ENOMEM;
+
+    size_t total_zones = 0;
+    uint64_t sector = 0;
+    const int batch_size = 512;
+
+    while (1) {
+        size_t report_size = sizeof(struct blk_zone_report) + batch_size * sizeof(struct blk_zone);
+        struct blk_zone_report *report = calloc(1, report_size);
+        if (!report) {
+            free(zones);
+            return -ENOMEM;
+        }
+
+        report->sector = sector;
+        report->nr_zones = batch_size;
+
+        if (ioctl(fd, BLKREPORTZONE, report) < 0) {
+            int err = errno;
+            free(report);
+            free(zones);
+            return -err;
+        }
+
+        if (report->nr_zones == 0) {
+            free(report);
+            break;
+        }
+
+        if (total_zones + report->nr_zones > allocated) {
+            allocated = (total_zones + report->nr_zones) * 2;
+            zones = realloc(zones, allocated * sizeof(struct uring_zone_info));
+            if (!zones) {
+                free(report);
+                return -ENOMEM;
+            }
+        }
+
+        for (uint32_t i = 0; i < report->nr_zones; i++) {
+            zones[total_zones].start_lba = report->zones[i].start;
+            zones[total_zones].length = report->zones[i].len;
+            zones[total_zones].write_pointer = report->zones[i].wp;
+            zones[total_zones].capacity = report->zones[i].capacity;
+            zones[total_zones].zone_type = report->zones[i].type;
+            zones[total_zones].zone_cond = report->zones[i].cond;
+            total_zones++;
+        }
+
+        sector = report->zones[report->nr_zones - 1].start + report->zones[report->nr_zones - 1].len;
+        free(report);
+    }
+
+    *zones_out = zones;
+    *zone_count_out = total_zones;
+    return 0;
+}
+
+int liburing_zone_refresh_wp(int fd, struct uring_zone_info *zone)
+{
+    if (!zone)
+        return -EINVAL;
+
+    size_t report_size = sizeof(struct blk_zone_report) + sizeof(struct blk_zone);
+    struct blk_zone_report *report = calloc(1, report_size);
+    if (!report)
+        return -ENOMEM;
+
+    report->sector = zone->start_lba;
+    report->nr_zones = 1;
+
+    int ret = 0;
+    if (ioctl(fd, BLKREPORTZONE, report) < 0) {
+        ret = -errno;
+    } else {
+        if (report->nr_zones > 0) {
+            zone->write_pointer = report->zones[0].wp;
+            zone->zone_cond = report->zones[0].cond;
+        } else {
+            ret = -EIO;
+        }
+    }
+
+    free(report);
+    return ret;
+}
+
+/* ========================================================================
+ * Zone Operations
+ * ======================================================================== */
+
+int liburing_zone_reset(struct io_uring *ring, int fd, struct uring_zone_info *zone)
+{
+    if (!ring || !zone)
+        return -EINVAL;
+
+    struct blk_zone_range range = {
+        .sector = zone->start_lba,
+        .nr_sectors = zone->length
+    };
+
+    if (ioctl(fd, BLKRESETZONE, &range) < 0)
+        return -errno;
+
+    zone->write_pointer = zone->start_lba;
+    zone->zone_cond = BLK_ZONE_COND_EMPTY;
+    return 0;
+}
+
+int liburing_zone_write(struct io_uring *ring, int fd, struct uring_zone_info *zone,
+                       const void *buf, size_t len)
+{
+    if (!ring || !zone || !buf)
+        return -EINVAL;
+
+    if (zone->zone_type == BLK_ZONE_TYPE_SEQWRITE_REQ) {
+        uint64_t available_sectors = (zone->start_lba + zone->capacity) - zone->write_pointer;
+        uint64_t sectors_to_write = (len + 511) / 512;
+        
+        if (sectors_to_write > available_sectors)
+            return -ENOSPC;
+    }
+
+    struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
+    if (!sqe)
+        return -ENOMEM;
+
+    io_uring_prep_write(sqe, fd, buf, len, zone->write_pointer * 512);
+    return 0;
+}
+
+int liburing_zone_read(struct io_uring *ring, int fd, struct uring_zone_info *zone,
+                      void *buf, size_t len, off_t zone_offset)
+{
+    if (!ring || !zone || !buf)
+        return -EINVAL;
+
+    struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
+    if (!sqe)
+        return -ENOMEM;
+
+    off_t read_offset = (zone->start_lba * 512) + zone_offset;
+    io_uring_prep_read(sqe, fd, buf, len, read_offset);
+    return 0;
+}
+
+int liburing_zone_write_batch(struct io_uring *ring, int fd, struct uring_zone_info *zone,
+                              struct iovec *iov, int iovcnt)
+{
+    if (!ring || !zone || !iov || iovcnt <= 0)
+        return -EINVAL;
+
+    size_t total_len = 0;
+    for (int i = 0; i < iovcnt; i++)
+        total_len += iov[i].iov_len;
+
+    if (zone->zone_type == BLK_ZONE_TYPE_SEQWRITE_REQ) {
+        uint64_t available_sectors = (zone->start_lba + zone->capacity) - zone->write_pointer;
+        uint64_t sectors_to_write = (total_len + 511) / 512;
+        
+        if (sectors_to_write > available_sectors)
+            return -ENOSPC;
+    }
+
+    off_t write_offset = zone->write_pointer * 512;
+    for (int i = 0; i < iovcnt; i++) {
+        struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
+        if (!sqe)
+            return -ENOMEM;
+
+        io_uring_prep_write(sqe, fd, iov[i].iov_base, iov[i].iov_len, write_offset);
+        write_offset += iov[i].iov_len;
+        
+        if (i < iovcnt - 1)
+            sqe->flags |= IOSQE_IO_LINK;
+    }
+
+    return 0;
+}
+
+int liburing_zone_writev(struct io_uring *ring, int fd, struct uring_zone_info *zone,
+                        const struct iovec *iov, int iovcnt)
+{
+    if (!ring || !zone || !iov || iovcnt <= 0)
+        return -EINVAL;
+
+    size_t total_len = 0;
+    for (int i = 0; i < iovcnt; i++)
+        total_len += iov[i].iov_len;
+
+    if (zone->zone_type == BLK_ZONE_TYPE_SEQWRITE_REQ) {
+        uint64_t available_sectors = (zone->start_lba + zone->capacity) - zone->write_pointer;
+        uint64_t sectors_to_write = (total_len + 511) / 512;
+        
+        if (sectors_to_write > available_sectors)
+            return -ENOSPC;
+    }
+
+    struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
+    if (!sqe)
+        return -ENOMEM;
+
+    io_uring_prep_writev(sqe, fd, iov, iovcnt, zone->write_pointer * 512);
+    return 0;
+}
+
+/* ========================================================================
+ * Utility Functions
+ * ======================================================================== */
+
+const char *liburing_zone_cond_str(unsigned char cond)
+{
+    switch (cond) {
+    case BLK_ZONE_COND_NOT_WP: return "NOT_WP";
+    case BLK_ZONE_COND_EMPTY: return "EMPTY";
+    case BLK_ZONE_COND_IMP_OPEN: return "IMP_OPEN";
+    case BLK_ZONE_COND_EXP_OPEN: return "EXP_OPEN";
+    case BLK_ZONE_COND_CLOSED: return "CLOSED";
+    case BLK_ZONE_COND_READONLY: return "READONLY";
+    case BLK_ZONE_COND_FULL: return "FULL";
+    case BLK_ZONE_COND_OFFLINE: return "OFFLINE";
+    default: return "UNKNOWN";
+    }
+}
+
+const char *liburing_zone_type_str(unsigned char type)
+{
+    switch (type) {
+    case BLK_ZONE_TYPE_CONVENTIONAL: return "CONVENTIONAL";
+    case BLK_ZONE_TYPE_SEQWRITE_REQ: return "SEQ_WRITE_REQ";
+    case BLK_ZONE_TYPE_SEQWRITE_PREF: return "SEQ_WRITE_PREF";
+    default: return "UNKNOWN";
+    }
+}
+
+void *liburing_alloc_aligned_buffer(size_t size, size_t alignment)
+{
+    void *buf;
+    if (posix_memalign(&buf, alignment, size) != 0)
+        return NULL;
+    return buf;
+}
+
+bool liburing_zone_is_writable(const struct uring_zone_info *zone)
+{
+    if (!zone)
+        return false;
+    
+    return zone->zone_cond != BLK_ZONE_COND_READONLY &&
+           zone->zone_cond != BLK_ZONE_COND_OFFLINE &&
+           zone->zone_cond != BLK_ZONE_COND_FULL;
+}
+
+uint64_t liburing_zone_available_space(const struct uring_zone_info *zone)
+{
+    if (!zone)
+        return 0;
+    
+    if (zone->zone_type == BLK_ZONE_TYPE_CONVENTIONAL)
+        return zone->capacity;
+    
+    if (zone->write_pointer < zone->start_lba)
+        return 0;
+    
+    uint64_t used = zone->write_pointer - zone->start_lba;
+    if (used >= zone->capacity)
+        return 0;
+    
+    return zone->capacity - used;
+}
+
+int liburing_filter_zones(const struct uring_zone_info *zones, size_t zone_count,
+                          unsigned char zone_type, unsigned char zone_cond,
+                          struct uring_zone_info **filtered_zones, size_t *filtered_count)
+{
+    if (!zones || !filtered_zones || !filtered_count)
+        return -EINVAL;
+
+    size_t count = 0;
+    for (size_t i = 0; i < zone_count; i++) {
+        bool type_match = (zone_type == 0xFF) || (zones[i].zone_type == zone_type);
+        bool cond_match = (zone_cond == 0xFF) || (zones[i].zone_cond == zone_cond);
+        
+        if (type_match && cond_match)
+            count++;
+    }
+
+    if (count == 0) {
+        *filtered_zones = NULL;
+        *filtered_count = 0;
+        return 0;
+    }
+
+    struct uring_zone_info *result = calloc(count, sizeof(struct uring_zone_info));
+    if (!result)
+        return -ENOMEM;
+
+    size_t idx = 0;
+    for (size_t i = 0; i < zone_count; i++) {
+        bool type_match = (zone_type == 0xFF) || (zones[i].zone_type == zone_type);
+        bool cond_match = (zone_cond == 0xFF) || (zones[i].zone_cond == zone_cond);
+        
+        if (type_match && cond_match)
+            result[idx++] = zones[i];
+    }
+
+    *filtered_zones = result;
+    *filtered_count = count;
+    return 0;
+}
+
+int liburing_find_suitable_zones(const struct uring_zone_info *zones, size_t zone_count,
+                                 size_t required_capacity_sectors, int max_zones,
+                                 struct uring_zone_info **suitable_zones, int *found_count)
+{
+    if (!zones || !suitable_zones || !found_count)
+        return -EINVAL;
+
+    struct uring_zone_info *result = calloc(max_zones > 0 ? max_zones : zone_count,
+                                            sizeof(struct uring_zone_info));
+    if (!result)
+        return -ENOMEM;
+
+    int count = 0;
+    for (size_t i = 0; i < zone_count && (max_zones == 0 || count < max_zones); i++) {
+        if (liburing_zone_is_writable(&zones[i])) {
+            uint64_t available = liburing_zone_available_space(&zones[i]);
+            if (available >= required_capacity_sectors) {
+                result[count++] = zones[i];
+            }
+        }
+    }
+
+    *suitable_zones = result;
+    *found_count = count;
+    return 0;
+}


### PR DESCRIPTION
Add support for zone block devices (SMR/ZAC HDDs) to liburing. This enables io_uring based I/O operations on zoned storage devices.

The implementation provides:
- Zone discovery and information queries
- Zone reset, read, write operations
- Sequential zone write pointer management
- Batch and vectored I/O operations
- Zone filtering and search utilities

_Note: The zone support is conditionally compiled only when CONFIG_NOLIBC is disabled, as it requires standard C library functions (malloc, ioctl) that are not available in nolibc mode._

A simple test application (examples/zoned-simple-test.c) is included to demonstrate the API usage.

Example output:
  ```
=== liburing Zone Device Test ===
Device: /dev/sdcr
Write size: 256 KB

--- Discovering Zones ---
Found 104312 zones

--- Target Zone ---
Zone 1044:
  Type: SEQ_WRITE_REQ
  Condition: IMP_OPEN
  Start LBA: 547356672 (261.00 GB)
  Length: 524288 sectors (0.25 GB)
  Write Pointer: 547357184
  Available: 523776 sectors (0.25 GB)

--- Test Operations ---
1. Resetting zone...
   Zone reset successful (WP at LBA 547356672)
2. Writing 256 KB to zone...
   Write successful
3. Reading 256 KB from zone...
   Read successful
4. Verifying data integrity...
   PASSED: Data verified successfully

=== Test PASSED ===
```

Signed-off-by: Vishal Jose Mannanal <vishaljm@dropbox.com>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
