### PR TITLE
Improve buffers documentation

### DIFF
--- a/man/io_uring_register_buffers.3
+++ b/man/io_uring_register_buffers.3
@@ -95,6 +95,12 @@ return 0.
 return number of buffers updated.
 On failure they return
 .BR -errno .
+
+.SH NOTES
+When possible prefer to use the newer and more efficient
+.BR io_uring_register_buf_ring (3)
+API.
+
 .SH SEE ALSO
 .BR io_uring_register (2),
 .BR io_uring_get_sqe (3),

--- a/man/io_uring_setup_buf_ring.3
+++ b/man/io_uring_setup_buf_ring.3
@@ -80,12 +80,18 @@ returns a pointer to the buffer ring. On failure it returns
 and sets
 .I *err
 to -errno.
+
 .SH NOTES
 Note that even if the kernel supports this feature, registering a provided
 buffer ring may still fail with
 .B -EINVAL
 if the host is a 32-bit architecture and the memory being passed in resides in
 high memory.
+
+Remember that you need to call
+.BR io_uring_buf_ring_add (3)
+to make the allocated buffers available to the kernel.
+
 .SH SEE ALSO
 .BR io_uring_register_buf_ring (3),
 .BR io_uring_buf_ring_init (3),


### PR DESCRIPTION
Improve buf_ring_* and register_buffers man pages

Let me know if you prefer this PR to be split in 2. I was afraid of committing too many small PRs.

----
## git request-pull output:
```
The following changes since commit 35c0b3c34dda7c185ac91500a68a33374bbe24ee:

  Buffers documentation (2026-01-14 14:02:03 +0100)

are available in the Git repository at:

  git@github.com:espoal/liburing.git chore_improve_buf_api_man_pages

for you to fetch changes up to 35c0b3c34dda7c185ac91500a68a33374bbe24ee:

  Buffers documentation (2026-01-14 14:02:03 +0100)

```

## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
