### PR TITLE
[GIT PULL] man: Fix use of dot on first column in example sections

### DIFF
--- a/man/io_uring_setup_flags.7
+++ b/man/io_uring_setup_flags.7
@@ -340,9 +340,9 @@ the SQPOLL thread is also shared.
 .PP
 .in +4n
 .EX
-.flags = IORING_SETUP_SINGLE_ISSUER |
-        IORING_SETUP_DEFER_TASKRUN |
-        IORING_SETUP_COOP_TASKRUN
+\&.flags = IORING_SETUP_SINGLE_ISSUER |
+         IORING_SETUP_DEFER_TASKRUN |
+         IORING_SETUP_COOP_TASKRUN
 .EE
 .in
 .PP
@@ -356,9 +356,9 @@ event loop.
 .PP
 .in +4n
 .EX
-.flags = IORING_SETUP_IOPOLL |
-        IORING_SETUP_SINGLE_ISSUER |
-        IORING_SETUP_DEFER_TASKRUN
+\&.flags = IORING_SETUP_IOPOLL |
+         IORING_SETUP_SINGLE_ISSUER |
+         IORING_SETUP_DEFER_TASKRUN
 .EE
 .in
 .PP
@@ -371,10 +371,10 @@ overhead. Combined with DEFER_TASKRUN for optimal completion handling.
 .PP
 .in +4n
 .EX
-.flags = IORING_SETUP_SQPOLL |
-        IORING_SETUP_SQ_AFF
-.sq_thread_cpu = preferred_cpu
-.sq_thread_idle = 1000
+\&.flags = IORING_SETUP_SQPOLL |
+         IORING_SETUP_SQ_AFF
+\&.sq_thread_cpu = preferred_cpu
+\&.sq_thread_idle = 1000
 .EE
 .in
 .PP


### PR DESCRIPTION
We need to use a zero-width space via \& to avoid the dot being interpreted as a roff command, as warned by groff:

  343: warning: macro 'flags' not defined (possibly missing space after 'fl')
  359: warning: macro 'flags' not defined (possibly missing space after 'fl')
  374: warning: macro 'flags' not defined (possibly missing space after 'fl')
  376: warning: macro 'sq_thread_cpu' not defined
  377: warning: macro 'sq_thread_idle' not defined

----
## git request-pull output:
```
The following changes since commit 8fd26b2261ca5d879724058fbb9fa76f3b5c26f9:

  test/recv-mshot-drain: kill only-written variables (2026-02-12 16:45:17 -0700)

are available in the Git repository at:

  https://github.com/guillemj/liburing.git pu/groff-warning

for you to fetch changes up to b478a020a1e6637ad5798b4c5cd2984800cb38d6:

  man: Fix use of dot on first column in example sections (2026-02-13 00:54:22 +0100)

----------------------------------------------------------------
Guillem Jover (1):
      man: Fix use of dot on first column in example sections

 man/io_uring_setup_flags.7 | 20 ++++++++++----------
 1 file changed, 10 insertions(+), 10 deletions(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
