### PR TITLE
tests: Add a helper to check the minimum required kernel version

### DIFF
--- a/test/helpers.h
+++ b/test/helpers.h
@@ -27,6 +27,11 @@ enum t_test_result {
 };
 
 /*
+ * Returns true if the running kernel version is >= min_kver ("x.y[.z]") e.g. "6.1".
+ */
+bool t_min_kver_required(const char *min_kver);
+
+/*
  * Some Android versions lack aligned_alloc in stdlib.h.
  * To avoid making large changes in tests, define a helper
  * function that wraps posix_memalign as our own aligned_alloc.
@@ -38,7 +43,6 @@ void *t_aligned_alloc(size_t alignment, size_t size);
  * The port number to be bound is returned in @addr->sin_port.
  */
 int t_bind_ephemeral_port(int fd, struct sockaddr_in *addr);
-
 
 /*
  * Helper for allocating memory in tests.

--- a/test/io-wq-exit.c
+++ b/test/io-wq-exit.c
@@ -115,6 +115,8 @@ int main(int argc, char *argv[])
 
 	if (argc > 1)
 		return T_EXIT_SKIP;
+	if (!t_min_kver_required("6.19"))
+		return T_EXIT_SKIP;
 
 	start = get_time_ns();
 	pthread_create(&thread, NULL, test, NULL);


### PR DESCRIPTION
io-wq-exit was added to liburing before the corresponding fix landed in the mainline kernel tree. Add a helper that checks whether the running kernel meets a minimum version and returns T_EXIT_SKIP if not.

Proposal to add a small helper which should make it easier to run tests in - for instance - any CI.
If you agree, we could slowly go towards some more formal structure of the tests, so that - for instance - sub-tests could emit some clear t1, t2 ... tx etc. 
That way it might be easier to run the tests and quickly process any failures etc.