### PR TITLE
[GIT PULL] change description for IORING_SETUP_TASKRUN_FLAG in iouring.h

### DIFF
--- a/src/include/liburing/io_uring.h
+++ b/src/include/liburing/io_uring.h
@@ -184,7 +184,8 @@ enum io_uring_sqe_flags_bit {
 /*
  * If COOP_TASKRUN is set, get notified if task work is available for
  * running and a kernel transition would be needed to run it. This sets
- * IORING_SQ_TASKRUN in the sq ring flags. Not valid with COOP_TASKRUN.
+ * IORING_SQ_TASKRUN in the sq ring flags. Not valid without COOP_TASKRUN
+ * or DEFER_TASKRUN.
  */
 #define IORING_SETUP_TASKRUN_FLAG	(1U << 9)
 #define IORING_SETUP_SQE128		(1U << 10) /* SQEs are 128 byte */


### PR DESCRIPTION
In man, the description of IORING_SETUP_TASKRUN_FLAG is  "Used in conjunction with IORING_SETUP_COOP_TASKRUN or IORING_SETUP_DEFER_TASKRUN"

I believe there is an inconsistency between the man page and the  source comments.

----
## git request-pull output:
```
﻿﻿The following changes since commit 0931f6e72ec2a268865cbefc4cdb99cf21e2d7ed:

  Ensure __io_uring_peek_cqe() is exported for FFI purposes (2026-02-27 06:17:24 -0700)

are available in the Git repository at:

  https://github.com/mag1c1an1/liburing

for you to fetch changes up to 6e7d75b0bdfcb1e258cb1a558ff3e2d40a58394d:

  change description for IORING_SETUP_TASKRUN_FLAG in iouring.h (2026-02-28 08:46:30 +0000)

----------------------------------------------------------------
mag1c1an1 (1):
      change description for IORING_SETUP_TASKRUN_FLAG in iouring.h

 src/include/liburing/io_uring.h | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
