### PR TITLE
nolibc: fix integer overflow in __uring_malloc

### DIFF
--- a/src/nolibc.c
+++ b/src/nolibc.c
@@ -33,13 +33,18 @@ struct uring_heap {
 void *__uring_malloc(size_t len)
 {
 	struct uring_heap *heap;
+	size_t total = sizeof(*heap) + len;
 
-	heap = __sys_mmap(NULL, sizeof(*heap) + len, PROT_READ | PROT_WRITE,
+	/* check for overflow */
+	if (total < len)
+		return NULL;
+
+	heap = __sys_mmap(NULL, total, PROT_READ | PROT_WRITE,
 			  MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
 	if (IS_ERR(heap))
 		return NULL;
 
-	heap->len = sizeof(*heap) + len;
+	heap->len = total;
 	return heap->user_p;
 }
 


### PR DESCRIPTION
The addition of sizeof(*heap) and len can overflow size_t when len is
close to SIZE_MAX. This results in an undersized mmap allocation while
heap->len records the small wrapped value, leading to a heap buffer
overflow on subsequent writes to the returned pointer.

Add an overflow check before passing the computed size to mmap.

Signed-off-by: ```Naveed <dxbnaveed.k@gmail.com>```