### PR TITLE
[GIT PULL] src/register: add query/zcrx_ctrl helpers and document them

### DIFF
--- a/man/io_uring_register_query.3
+++ b/man/io_uring_register_query.3
@@ -1,0 +1,114 @@
+.\" Copyright (C) 2026 Yitang Yang <yi1tang.yang@gmail.com>
+.\"
+.\" SPDX-License-Identifier: LGPL-2.0-or-later
+.\"
+.TH io_uring_register_query 3 "March 26, 2026" "liburing-2.15" "liburing Manual"
+.SH NAME
+io_uring_register_query \- query io_uring capabilities and feature support
+.SH SYNOPSIS
+.nf
+.B #include <liburing.h>
+.PP
+.BI "int io_uring_register_query(struct io_uring_query_hdr *" query ");"
+.fi
+.SH DESCRIPTION
+.PP
+The
+.BR io_uring_register_query (3)
+function queries io_uring capabilities and feature support. It provides
+information about supported opcodes, flags, and subsystem-specific
+capabilities.
+
+The
+.I query
+argument must point to a
+.I struct io_uring_query_hdr
+structure that describes the query to perform:
+
+.PP
+.in +4n
+.EX
+struct io_uring_query_hdr {
+    __u64 next_entry;
+    __u64 query_data;
+    __u32 query_op;
+    __u32 size;
+    __s32 result;
+    __u32 __resv[3];
+};
+.EE
+.in
+.PP
+
+The
+.I next_entry
+field can be used to chain multiple queries together. It should point to the
+next
+.I struct io_uring_query_hdr
+structure, or be set to 0 for the last entry in the chain.
+
+The
+.I query_data
+field must point to a data structure appropriate for the query type specified in
+.IR query_op .
+
+The
+.I query_op
+field specifies the type of query to perform and can be one of:
+
+.TP
+.B IO_URING_QUERY_OPCODES
+Returns information about supported opcodes and flags. The
+.I query_data
+field must point to a
+.I struct io_uring_query_opcode
+structure, which will be filled with information about supported request
+opcodes, register opcodes, feature flags, setup flags, enter flags, and SQE
+flags.
+
+.TP
+.B IO_URING_QUERY_ZCRX
+Returns information about zero-copy receive support. The
+.I query_data
+field must point to a
+.I struct io_uring_query_zcrx
+structure, which will be filled with information about supported zero-copy
+receive flags, features, and configuration details.
+
+.TP
+.B IO_URING_QUERY_SCQ
+Returns information about the SQ/CQ ring layout. The
+.I query_data
+field must point to a
+.I struct io_uring_query_scq
+structure, which will be filled with information about ring header size and
+alignment requirements.
+
+.PP
+The
+.I size
+field should be set to the size of the data structure pointed to by
+.IR query_data .
+
+Upon return, the
+.I result
+field will contain 0 on success, or a negative error code on failure.
+
+The reserved
+.I __resv
+fields must be cleared to zero.
+
+.SH RETURN VALUE
+Returns 0 on success. On error, a negative errno value is returned.
+
+.SH NOTES
+This function is available since Linux kernel 6.15.
+
+Multiple queries can be efficiently performed in a single system call by
+chaining them together using the
+.I next_entry
+field.
+
+.SH SEE ALSO
+.BR io_uring_register (2),
+.BR io_uring_setup (2)

--- a/man/io_uring_register_zcrx_ctrl.3
+++ b/man/io_uring_register_zcrx_ctrl.3
@@ -1,0 +1,84 @@
+.\" Copyright (C) 2026 Yitang Yang <yi1tang.yang@gmail.com>
+.\"
+.\" SPDX-License-Identifier: LGPL-2.0-or-later
+.\"
+.TH io_uring_register_zcrx_ctrl 3 "March 26, 2026" "liburing-2.15" "liburing Manual"
+.SH NAME
+io_uring_register_zcrx_ctrl \- perform control operations on a zero-copy receive context
+.SH SYNOPSIS
+.nf
+.B #include <liburing.h>
+.PP
+.BI "int io_uring_register_zcrx_ctrl(struct io_uring *" ring ","
+.BI "                                struct zcrx_ctrl *" ctrl ");"
+.fi
+.SH DESCRIPTION
+.PP
+The
+.BR io_uring_register_zcrx_ctrl (3)
+function performs control operations on a previously registered zero-copy
+receive context. See
+.BR io_uring_register_ifq (3)
+for details on registering a zero-copy receive context.
+
+The
+.I ctrl
+argument must point to a
+.I struct zcrx_ctrl
+structure that describes the control operation to perform:
+
+.PP
+.in +4n
+.EX
+struct zcrx_ctrl {
+    __u32 zcrx_id;
+    __u32 op;
+    __u64 __resv[2];
+    union {
+        struct zcrx_ctrl_export     zc_export;
+        struct zcrx_ctrl_flush_rq   zc_flush;
+    };
+};
+.EE
+.in
+.PP
+
+The
+.I zcrx_id
+field must be set to the ID of the zero-copy receive context returned from
+.BR io_uring_register_ifq (3).
+The
+.I op
+field specifies the control operation to perform and can be one of:
+
+.TP
+.B ZCRX_CTRL_FLUSH_RQ
+Flushes pending buffers from the refill queue. Uses the
+.I zc_flush
+member of the union.
+
+.TP
+.B ZCRX_CTRL_EXPORT
+Exports the zero-copy receive context for use by other rings. Uses the
+.I zc_export
+member of the union. Upon successful export, the
+.I zcrx_fd
+field in
+.I zc_export
+will contain the file descriptor that can be used to share this context
+with other io_uring instances.
+
+.PP
+The reserved
+.I __resv
+fields must be cleared to zero.
+
+.SH RETURN VALUE
+Returns 0 on success. On error, a negative errno value is returned.
+
+.SH NOTES
+This function is available since Linux kernel 6.15.
+
+.SH SEE ALSO
+.BR io_uring_register (2),
+.BR io_uring_register_ifq (3)

--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -354,6 +354,8 @@ int io_uring_unregister_napi(struct io_uring *ring, struct io_uring_napi *napi)
 	LIBURING_NOEXCEPT;
 int io_uring_register_ifq(struct io_uring *ring,
 			  struct io_uring_zcrx_ifq_reg *reg) LIBURING_NOEXCEPT;
+int io_uring_register_zcrx_ctrl(struct io_uring *ring, struct zcrx_ctrl *ctrl)
+	LIBURING_NOEXCEPT;
 
 int io_uring_register_clock(struct io_uring *ring,
 			    struct io_uring_clock_register *arg)

--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -365,6 +365,8 @@ int io_uring_register_bpf_filter(struct io_uring *ring,
 int io_uring_register_bpf_filter_task(struct io_uring_bpf *bpf)
 				 LIBURING_NOEXCEPT;
 
+int io_uring_register_query(struct io_uring_query_hdr *query) LIBURING_NOEXCEPT;
+
 int io_uring_get_events(struct io_uring *ring) LIBURING_NOEXCEPT;
 int io_uring_submit_and_get_events(struct io_uring *ring) LIBURING_NOEXCEPT;
 

--- a/src/liburing-ffi.map
+++ b/src/liburing-ffi.map
@@ -272,4 +272,5 @@ LIBURING_2.15 {
 		io_uring_cqe_iter_init;
 		io_uring_cqe_iter_next;
 		__io_uring_peek_cqe;
+		io_uring_register_zcrx_ctrl;
 } LIBURING_2.14;

--- a/src/liburing-ffi.map
+++ b/src/liburing-ffi.map
@@ -273,4 +273,5 @@ LIBURING_2.15 {
 		io_uring_cqe_iter_next;
 		__io_uring_peek_cqe;
 		io_uring_register_zcrx_ctrl;
+		io_uring_register_query;
 } LIBURING_2.14;

--- a/src/liburing.map
+++ b/src/liburing.map
@@ -143,4 +143,5 @@ LIBURING_2.15 {
 	global:
 		io_uring_register_bpf_filter;
 		io_uring_register_bpf_filter_task;
+		io_uring_register_zcrx_ctrl;
 } LIBURING_2.14;

--- a/src/liburing.map
+++ b/src/liburing.map
@@ -144,4 +144,5 @@ LIBURING_2.15 {
 		io_uring_register_bpf_filter;
 		io_uring_register_bpf_filter_task;
 		io_uring_register_zcrx_ctrl;
+		io_uring_register_query;
 } LIBURING_2.14;

--- a/src/register.c
+++ b/src/register.c
@@ -449,6 +449,11 @@ int io_uring_register_ifq(struct io_uring *ring,
 	return do_register(ring, IORING_REGISTER_ZCRX_IFQ, reg, 1);
 }
 
+int io_uring_register_zcrx_ctrl(struct io_uring *ring, struct zcrx_ctrl *ctrl)
+{
+	return do_register(ring, IORING_REGISTER_ZCRX_CTRL, ctrl, 0);
+}
+
 int io_uring_resize_rings(struct io_uring *ring, struct io_uring_params *p)
 {
 	unsigned sq_head, sq_tail;

--- a/src/register.c
+++ b/src/register.c
@@ -532,3 +532,8 @@ int io_uring_register_bpf_filter_task(struct io_uring_bpf *bpf)
 {
 	return __sys_io_uring_register(-1, IORING_REGISTER_BPF_FILTER, bpf, 1);
 }
+
+int io_uring_register_query(struct io_uring_query_hdr *query)
+{
+	return __sys_io_uring_register(-1, IORING_REGISTER_QUERY, query, 0);
+}


### PR DESCRIPTION
`IORING_REGISTER_ZCRX_CTRL` and `IORING_REGISTER_QUERY` have been synced to liburing but lacked wrapper functions. This series adds:

- `io_uring_register_zcrx_ctrl()` to wrap `IORING_REGISTER_ZCRX_CTRL`
- `io_uring_register_query()` and `io_uring_register_query_task()` to wrap `IORING_REGISTER_QUERY`, and
- Man pages for both APIs

----
## git request-pull output:
```
The following changes since commit 18c41594671ea5f5bde0f1b853a8e5fcf09e7efc:

  Merge branch 'buf-upgrade' (2026-03-26 06:26:19 -0600)

are available in the Git repository at:

  https://github.com/wokron/liburing register-zcrx-ctrl-and-query

for you to fetch changes up to afb0923962a0be01e117db875e16be02fa419b91:

  man: add io_uring_register_query.3 man page (2026-03-26 21:25:41 +0800)

----------------------------------------------------------------
Yitang Yang (4):
      src/register: add io_uring_register_zcrx_ctrl() helper
      man: add io_uring_register_zcrx_ctrl.3 man page
      src/register: add io_uring_register_query wrappers
      man: add io_uring_register_query.3 man page

 man/io_uring_register_query.3      | 130 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 man/io_uring_register_query_task.3 |   1 +
 man/io_uring_register_zcrx_ctrl.3  |  84 +++++++++++++++++++++++++++++++++++++++++
 src/include/liburing.h             |   6 +++
 src/liburing-ffi.map               |   3 ++
 src/liburing.map                   |   3 ++
 src/register.c                     |  15 ++++++++
 7 files changed, 242 insertions(+)
 create mode 100644 man/io_uring_register_query.3
 create mode 120000 man/io_uring_register_query_task.3
 create mode 100644 man/io_uring_register_zcrx_ctrl.3
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
