### PR TITLE
[GIT PULL] man/io_uring_prep_read.3: Explain unsigned input vs. __s32 output

### DIFF
--- a/man/io_uring_prep_read.3
+++ b/man/io_uring_prep_read.3
@@ -62,6 +62,13 @@ Instead it returns the negated
 directly in the CQE
 .I res
 field.
+.SH NOTES
+This function accepts an unsigned number of bytes, but io_uring_cqe's result
+code is an __s32 value, so in theory a large enough nbytes value could generate
+an ambiguous return.  But the number of bytes actually transferred has the same
+limit as
+.BR read (2)
+so this cannot actually happen in practice.
 .SH SEE ALSO
 .BR io_uring_get_sqe (3),
 .BR io_uring_prep_readv (3),


### PR DESCRIPTION
io_uring_prep_read() reads an unsigned number of bytes, and for short reads it returns the actual number of bytes read. But the return value is __s32, so not all possible values can be represented.

Explain that it's impossible to allocate a buffer large enough for this to be a problem.

I'm submitting this as a PR with an answer I think is correct, but could just as easily have raised an issue asking a question.  Happy to resubmit if there's an actual bug here, like an architecture with a weird `PTRDIFF_MAX` or a way to pass very large buffers to `io_uring_prep_read()`.  Otherwise, this seems like the best way to avoid the next person spending an hour running this one to ground.

----
## git request-pull output:
```
The following changes since commit 457d6b0fc1e0fb29eb48b77bb50c31e9d946cac4:

  test/fd-pass: skip on older kernels without DEFER_TASKRUN (2026-04-21 16:09:50 -0600)

are available in the Git repository at:

  https://github.com/andrew-sayers/liburing master

for you to fetch changes up to 893bd7c27460bee0bf601d609e6e0ccd3e10ce04:

  man/io_uring_prep_read.3: Explain unsigned input vs. __s32 output (2026-04-23 15:38:28 +0100)

----------------------------------------------------------------
Andrew Sayers (1):
      man/io_uring_prep_read.3: Explain unsigned input vs. __s32 output

 man/io_uring_prep_read.3 | 5 +++++
 1 file changed, 5 insertions(+)
```

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
