### PR TITLE
[GIT PULL] man: Explain transfer size limits

### DIFF
--- a/man/io_uring_buf_ring_add.3
+++ b/man/io_uring_buf_ring_add.3
@@ -54,6 +54,9 @@ matters is that the application knows what a given buffer ID in time corresponds
 to in terms of virtual memory. There's no liburing or kernel assumption that
 these mappings are persistent over time, they can very well be different every
 time a given buffer ID is added to the provided buffer ring.
+
+Note that no uring functions can write more than INT_MAX bytes to a buffer in a
+single call.  For details, see the man pages for individual functions.
 .SH SEE ALSO
 .BR io_uring_register_buf_ring (3),
 .BR io_uring_buf_ring_mask (3),

--- a/man/io_uring_prep_read.3
+++ b/man/io_uring_prep_read.3
@@ -64,11 +64,11 @@ directly in the CQE
 field.
 .SH NOTES
 This function accepts an unsigned number of bytes, but io_uring_cqe's result
-code is an __s32 value, so in theory a large enough nbytes value could generate
-an ambiguous return.  But the number of bytes actually transferred has the same
-limit as
+code is an __s32 value, so in theory a short read with a large enough nbytes
+value could generate an ambiguous return.  But the number of bytes actually
+transferred has the same limit as
 .BR read (2)
-so this cannot actually happen in practice.
+so this cannot happen in practice.
 .SH SEE ALSO
 .BR io_uring_get_sqe (3),
 .BR io_uring_prep_readv (3),

--- a/man/io_uring_prep_read_fixed.3
+++ b/man/io_uring_prep_read_fixed.3
@@ -67,6 +67,13 @@ Instead it returns the negated
 directly in the CQE
 .I res
 field.
+.SH NOTES
+This function accepts an unsigned number of bytes, but io_uring_cqe's result
+code is an __s32 value, so in theory a short read with a large enough nbytes
+value could generate an ambiguous return.  But the number of bytes actually
+transferred has the same limit as
+.BR read (2)
+so this cannot happen in practice.
 .SH SEE ALSO
 .BR io_uring_prep_read (3),
 .BR io_uring_register_buffers (3)

--- a/man/io_uring_prep_read_multishot.3
+++ b/man/io_uring_prep_read_multishot.3
@@ -92,6 +92,13 @@ Instead it returns the negated
 directly in the CQE
 .I res
 field.
+
+This function accepts an unsigned number of bytes, but io_uring_cqe's result
+code is an __s32 value, so in theory a short read with a large enough nbytes
+value could generate an ambiguous return.  But the number of bytes actually
+transferred has the same limit as
+.BR read (2)
+so this cannot happen in practice.
 .SH SEE ALSO
 .BR io_uring_get_sqe (3),
 .BR io_uring_prep_read (3),

--- a/man/io_uring_prep_readv.3
+++ b/man/io_uring_prep_readv.3
@@ -78,6 +78,13 @@ behavior by inspecting the
 .B IORING_FEAT_SUBMIT_STABLE
 flag passed back from
 .BR io_uring_queue_init_params (3).
+
+This function accepts an array of iovec's with a size_t number of bytes each,
+but io_uring_cqe's result code is an __s32 value, so in theory a short read
+with a large enough iov_len value could generate an ambiguous return.
+But the number of bytes actually transferred has the same limit as
+.BR read (2)
+so this cannot happen in practice.
 .SH SEE ALSO
 .BR io_uring_get_sqe (3),
 .BR io_uring_prep_read (3),

--- a/man/io_uring_prep_readv2.3
+++ b/man/io_uring_prep_readv2.3
@@ -104,6 +104,13 @@ behavior by inspecting the
 .B IORING_FEAT_SUBMIT_STABLE
 flag passed back from
 .BR io_uring_queue_init_params (3).
+
+This function accepts an array of iovec's with a size_t number of bytes each,
+but io_uring_cqe's result code is an __s32 value, so in theory a short read
+with a large enough iov_len value could generate an ambiguous return.
+But the number of bytes actually transferred has the same limit as
+.BR read (2)
+so this cannot happen in practice.
 .SH SEE ALSO
 .BR io_uring_get_sqe (3),
 .BR io_uring_prep_read (3),

--- a/man/io_uring_prep_readv_fixed.3
+++ b/man/io_uring_prep_readv_fixed.3
@@ -57,6 +57,13 @@ The CQE
 .I res
 field will contain the result of the operation, the number of bytes read
 on success. On error, a negative errno value is returned.
+.SH NOTES
+This function accepts an array of iovec's with a size_t number of bytes each,
+but io_uring_cqe's result code is an __s32 value, so in theory a short read
+with a large enough iov_len value could generate an ambiguous return.
+But the number of bytes actually transferred has the same limit as
+.BR read (2)
+so this cannot happen in practice.
 .SH SEE ALSO
 .BR io_uring_get_sqe (3),
 .BR io_uring_submit (3),

--- a/man/io_uring_prep_recv.3
+++ b/man/io_uring_prep_recv.3
@@ -131,6 +131,9 @@ Instead it returns the negated
 directly in the CQE
 .I res
 field.
+.SH NOTES
+Despite accepting a size_t number of bytes, these functions can transfer at most
+INT_MAX bytes per call (the maximum for the underlying syscall interface).
 .SH SEE ALSO
 .BR io_uring_get_sqe (3),
 .BR io_uring_submit (3),

--- a/man/io_uring_prep_recvmsg.3
+++ b/man/io_uring_prep_recvmsg.3
@@ -118,6 +118,10 @@ behavior by inspecting the
 .B IORING_FEAT_SUBMIT_STABLE
 flag passed back from
 .BR io_uring_queue_init_params (3).
+
+Despite accepting an array of iovec's with a size_t number of bytes each,
+these functions can transfer at most INT_MAX bytes per call (the maximum
+for the underlying syscall interface).
 .SH SEE ALSO
 .BR io_uring_get_sqe (3),
 .BR io_uring_submit (3),

--- a/man/io_uring_prep_send.3
+++ b/man/io_uring_prep_send.3
@@ -185,6 +185,9 @@ Instead it returns the negated
 directly in the CQE
 .I res
 field.
+.SH NOTES
+Despite accepting a size_t number of bytes, these functions can transfer at most
+INT_MAX bytes per call (the maximum for the underlying syscall interface).
 .SH SEE ALSO
 .BR io_uring_get_sqe (3),
 .BR io_uring_submit (3),

--- a/man/io_uring_prep_send_zc.3
+++ b/man/io_uring_prep_send_zc.3
@@ -129,6 +129,9 @@ Increasing the limit may help
 .B -ENOMEM
 The kernel ran out of memory.
 .P
+.SH NOTES
+Despite accepting a size_t number of bytes, these functions can transfer at most
+INT_MAX bytes per call (the maximum for the underlying syscall interface).
 .SH SEE ALSO
 .BR io_uring_get_sqe (3),
 .BR io_uring_submit (3),

--- a/man/io_uring_prep_sendmsg.3
+++ b/man/io_uring_prep_sendmsg.3
@@ -124,6 +124,10 @@ behavior by inspecting the
 .B IORING_FEAT_SUBMIT_STABLE
 flag passed back from
 .BR io_uring_queue_init_params (3).
+
+Despite accepting an array of iovec's with a size_t number of bytes each,
+these functions can transfer at most INT_MAX bytes per call (the maximum
+for the underlying syscall interface).
 .SH SEE ALSO
 .BR io_uring_get_sqe (3),
 .BR io_uring_submit (3),

--- a/man/io_uring_prep_sendmsg_zc_fixed.3
+++ b/man/io_uring_prep_sendmsg_zc_fixed.3
@@ -55,6 +55,10 @@ The CQE
 .I res
 field will contain the result of the operation, the number of bytes sent
 on success. On error, a negative errno value is returned.
+
+Despite accepting an array of iovec's with a size_t number of bytes each,
+this function can transfer at most INT_MAX bytes per call (the maximum
+for the underlying syscall interface).
 .SH SEE ALSO
 .BR io_uring_get_sqe (3),
 .BR io_uring_submit (3),

--- a/man/io_uring_prep_splice.3
+++ b/man/io_uring_prep_splice.3
@@ -118,3 +118,9 @@ refers to a pipe, the splice operation can still fail with
 .B EINVAL
 if one of the fd doesn't explicitly support splice operation, e.g. reading from
 terminal is unsupported from kernel 5.7 to 5.11.
+
+Despite accepting an unsigned number of bytes, this function can transfer at most
+INT_MAX bytes per call (the maximum for the underlying syscall interface).
+In practice, limits as low as 65536 have been observed (just like with
+.BR splice (2)
+itself).

--- a/man/io_uring_prep_splice.3
+++ b/man/io_uring_prep_splice.3
@@ -39,9 +39,9 @@ are modifier flags for the operation. See
 .BR splice (2)
 for the generic splice flags.
 
-If the
+If
 .I fd_out
-descriptor,
+is a direct descriptor,
 .B IOSQE_FIXED_FILE
 can be set in the SQE to indicate that. For the input file, the io_uring
 specific

--- a/man/io_uring_prep_tee.3
+++ b/man/io_uring_prep_tee.3
@@ -26,7 +26,7 @@ is setup to use as input the file descriptor
 .I fd_in
 and as output the file descriptor
 .I fd_out
-duplicating
+duplicating up to
 .I nbytes
 bytes worth of data.
 .I splice_flags
@@ -34,9 +34,9 @@ are modifier flags for the operation. See
 .BR tee (2)
 for the generic splice flags.
 
-If the
+If
 .I fd_out
-descriptor,
+is a direct descriptor,
 .B IOSQE_FIXED_FILE
 can be set in the SQE to indicate that. For the input file, the io_uring
 specific

--- a/man/io_uring_prep_tee.3
+++ b/man/io_uring_prep_tee.3
@@ -66,6 +66,12 @@ Instead it returns the negated
 directly in the CQE
 .I res
 field.
+.SH NOTES
+Despite accepting an unsigned number of bytes, this function can transfer at most
+INT_MAX bytes per call (the maximum for the underlying syscall interface).
+In practice, limits as low as 65536 have been observed (just like with
+.BR tee (2)
+itself).
 .SH SEE ALSO
 .BR io_uring_get_sqe (3),
 .BR io_uring_submit (3),

--- a/man/io_uring_prep_write.3
+++ b/man/io_uring_prep_write.3
@@ -62,6 +62,9 @@ Instead it returns the negated
 directly in the CQE
 .I res
 field.
+.SH NOTES
+Despite accepting an unsigned number of bytes, this function can transfer at most
+INT_MAX bytes per call (the maximum for the underlying syscall interface).
 .SH SEE ALSO
 .BR io_uring_get_sqe (3),
 .BR io_uring_submit (3)

--- a/man/io_uring_prep_write_fixed.3
+++ b/man/io_uring_prep_write_fixed.3
@@ -67,6 +67,9 @@ Instead it returns the negated
 directly in the CQE
 .I res
 field.
+.SH NOTES
+Despite accepting an unsigned number of bytes, this function can transfer at most
+INT_MAX bytes per call (the maximum for the underlying syscall interface).
 .SH SEE ALSO
 .BR io_uring_prep_write (3),
 .BR io_uring_register_buffers (3)

--- a/man/io_uring_prep_writev.3
+++ b/man/io_uring_prep_writev.3
@@ -78,6 +78,10 @@ behavior by inspecting the
 .B IORING_FEAT_SUBMIT_STABLE
 flag passed back from
 .BR io_uring_queue_init_params (3).
+
+Despite accepting an array of iovec's with a size_t number of bytes each,
+this function can transfer at most INT_MAX bytes per call (the maximum
+for the underlying syscall interface).
 .SH SEE ALSO
 .BR io_uring_get_sqe (3),
 .BR io_uring_prep_write (3),

--- a/man/io_uring_prep_writev2.3
+++ b/man/io_uring_prep_writev2.3
@@ -104,6 +104,10 @@ behavior by inspecting the
 .B IORING_FEAT_SUBMIT_STABLE
 flag passed back from
 .BR io_uring_queue_init_params (3).
+
+Despite accepting an array of iovec's with a size_t number of bytes each,
+this function can transfer at most INT_MAX bytes per call (the maximum
+for the underlying syscall interface).
 .SH SEE ALSO
 .BR io_uring_get_sqe (3),
 .BR io_uring_prep_write (3),

--- a/man/io_uring_prep_writev_fixed.3
+++ b/man/io_uring_prep_writev_fixed.3
@@ -57,6 +57,10 @@ The CQE
 .I res
 field will contain the result of the operation, the number of bytes written
 on success. On error, a negative errno value is returned.
+.SH NOTES
+Despite accepting an array of iovec's with a size_t number of bytes each,
+this function can transfer at most INT_MAX bytes per call (the maximum
+for the underlying syscall interface).
 .SH SEE ALSO
 .BR io_uring_get_sqe (3),
 .BR io_uring_submit (3),


### PR DESCRIPTION
This is the promised generalisation of #1570, explaining the transfer size limits for various functions.

I think I've found all the relevant pages now, but please let me know if I missed anything.

----
## git request-pull output:
```
The following changes since commit 0fbff3ed9be595d810f4c1217b163f0b5cb62d7b:

  Merge branch 'master' of https://github.com/andrew-sayers/liburing (2026-04-23 09:38:28 -0600)

are available in the Git repository at:

  https://github.com/andrew-sayers/liburing master

for you to fetch changes up to aadabf56d3bebbfbd11e13df3cfc8850ca609a45:

  man: Minor language improvements (2026-04-24 10:19:25 +0100)

----------------------------------------------------------------
Andrew Sayers (5):
      man: Explain transfer size limits in all read() functions
      man: Explain transfer size limits in all write() functions
      man: Explain transfer size limits in send() and recv() functions
      man: Explain transfer size limits in miscellaneous functions
      man: Minor language improvements

 man/io_uring_buf_ring_add.3          |  3 +++
 man/io_uring_prep_read.3             |  8 ++++----
 man/io_uring_prep_read_fixed.3       |  7 +++++++
 man/io_uring_prep_read_multishot.3   |  7 +++++++
 man/io_uring_prep_readv.3            |  7 +++++++
 man/io_uring_prep_readv2.3           |  7 +++++++
 man/io_uring_prep_readv_fixed.3      |  7 +++++++
 man/io_uring_prep_recv.3             |  3 +++
 man/io_uring_prep_recvmsg.3          |  4 ++++
 man/io_uring_prep_send.3             |  3 +++
 man/io_uring_prep_send_zc.3          |  3 +++
 man/io_uring_prep_sendmsg.3          |  4 ++++
 man/io_uring_prep_sendmsg_zc_fixed.3 |  4 ++++
 man/io_uring_prep_splice.3           | 10 ++++++++--
 man/io_uring_prep_tee.3              | 12 +++++++++---
 man/io_uring_prep_write.3            |  3 +++
 man/io_uring_prep_write_fixed.3      |  3 +++
 man/io_uring_prep_writev.3           |  4 ++++
 man/io_uring_prep_writev2.3          |  4 ++++
 man/io_uring_prep_writev_fixed.3     |  4 ++++
 20 files changed, 98 insertions(+), 9 deletions(-)
```
----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
