### PR TITLE
[GIT PULL] i src/register: clean up ring state on failed resize mmap

### DIFF
--- a/src/register.c
+++ b/src/register.c
@@ -477,8 +477,26 @@ int io_uring_resize_rings(struct io_uring *ring, struct io_uring_params *p)
 	__sys_munmap(ring->sq.sqes, ring->sq.sqes_sz);
 	io_uring_unmap_rings(&ring->sq, &ring->cq);
 
-	ring->sq = sq;
-	ring->cq = cq;
+
+	memset(&ring->sq, 0, sizeof(ring->sq));
+	memset(&ring->cq, 0, sizeof(ring->cq));
+	ret = io_uring_mmap(ring->ring_fd, p, &ring->sq, &ring->cq);
+	if (ret) {
+		/*
+		 * The kernel has already committed to the new ring layout,
+		 * but we failed to mmap it. io_uring_mmap() cleaned up its
+		 * own partial mappings but may leave stale or error-encoded
+		 * pointers in sq/cq (e.g. ring_ptr = (void *)-ENOMEM).
+		 * Re-zero to scrub those so io_uring_queue_exit() won't
+		 * pass dangling pointers to munmap.  The ring is
+		 * unrecoverable — destroy it.
+		 */
+		memset(&ring->sq, 0, sizeof(ring->sq));
+		memset(&ring->cq, 0, sizeof(ring->cq));
+		io_uring_queue_exit(ring);
+		goto out;
+	}
+
 	ring->sq.sqe_head = sq_head;
 	ring->sq.sqe_tail = sq_tail;
 


### PR DESCRIPTION
src/register: clean up ring state on failed resize mmap

When io_uring_resize_rings() succeeds on the kernel side but the
subsequent mmap() fails (e.g. due to RLIMIT_AS), the old rings have
already been unmapped and the kernel has committed to the new layout.
This leaves ring->sq and ring->cq holding stale or error-encoded
pointers (e.g. ring_ptr = (void *)-ENOMEM).

Any subsequent call like io_uring_get_sqe() or io_uring_submit()
will crash with SIGSEGV, and a call to io_uring_queue_exit() will
pass those dangling pointers to munmap(), resulting in undefined
behaviour.

Fix this by zeroing ring->sq and ring->cq before calling
io_uring_queue_exit() in the error path, so the ring is fully and
safely destroyed instead of left in a partially corrupted state.

Fixes: https://github.com/axboe/liburing/issues/1574
Signed-off-by: Ahmed Abdelmoemen <ahmedabdelmoumen05@gmail.com>


❯ git request-pull axboe-tree/master https://github.com/bohmiiidd/liburing fix/register-resize-mmap-cleanup
The following changes since commit ce320c704db8f73272f3ba6a2a8eb70b72479c41:

  test/bind-listen: ensure 'ts' is set before io_uring_wait_cqe_timeout() (2026-05-11 13:50:15 -0600)

are available in the Git repository at:

  https://github.com/bohmiiidd/liburing fix/register-resize-mmap-cleanup

for you to fetch changes up to 79da9dba50668111189727f8935aed44ee642643:

  src/register: clean up ring state on failed resize mmap (2026-05-14 14:31:44 +0100)

----------------------------------------------------------------
Ahmed Abdelmoemen (1):
      src/register: clean up ring state on failed resize mmap

 src/register.c | 16 ++++++++++++++--
 1 file changed, 14 insertions(+), 2 deletions(-)
