### PR TITLE
Replace unsafe strcpy calls in NAPI busy-poll examples

### DIFF
--- a/examples/napi-busy-poll-client.c
+++ b/examples/napi-busy-poll-client.c
@@ -305,7 +305,7 @@ int main(int argc, char *argv[])
 	while ((flag = getopt_long(argc, argv, ":hs:bua:n:p:t:6d:", longopts, NULL)) != -1) {
 		switch (flag) {
 		case 'a':
-			strcpy(opt.addr, optarg);
+			snprintf(opt.addr, sizeof(opt.addr), "%s", optarg);
 			break;
 		case 'b':
 			opt.busy_loop = true;
@@ -318,7 +318,7 @@ int main(int argc, char *argv[])
 			opt.num_pings = atoi(optarg) + 1;
 			break;
 		case 'p':
-			strcpy(opt.port, optarg);
+			snprintf(opt.port, sizeof(opt.port), "%s", optarg);
 			break;
 		case 's':
 			opt.sq_poll = !!atoi(optarg);

--- a/examples/napi-busy-poll-server.c
+++ b/examples/napi-busy-poll-server.c
@@ -266,7 +266,7 @@ int main(int argc, char *argv[])
 	while ((flag = getopt_long(argc, argv, ":lhs:bua:n:p:t:6d:", longopts, NULL)) != -1) {
 		switch (flag) {
 		case 'a':
-			strcpy(opt.addr, optarg);
+			snprintf(opt.addr, sizeof(opt.addr), "%s", optarg);
 			break;
 		case 'b':
 			opt.busy_loop = true;
@@ -282,7 +282,7 @@ int main(int argc, char *argv[])
 			opt.num_pings = atoi(optarg) + 1;
 			break;
 		case 'p':
-			strcpy(opt.port, optarg);
+			snprintf(opt.port, sizeof(opt.port), "%s", optarg);
 			break;
 		case 's':
 			opt.sq_poll = !!atoi(optarg);


### PR DESCRIPTION
This patch removes unsafe unbounded string copies in the NAPI busy-poll example client/server programs.

## Changes
### Updated:
- examples/napi-busy-poll-server.c
- examples/napi-busy-poll-client.c
### Replaced:
     strcpy(opt.X, optarg)

with:

     snprintf(opt.X, sizeof(opt.X), "%s", optarg)
## Security Impact

The previous implementation allowed oversized command-line arguments to overflow fixed-size stack buffers via strcpy. A crafted long -a argument could corrupt stack memory.

The new implementation performs bounded writes and safely truncates oversized input.

Signed-off-by: Metsw Max [metsw24-max@gmail.com](mailto:metsw24-max@gmail.com)