### PR TITLE
harden ring sizing arithmetic against overflow

### DIFF
--- a/src/setup.c
+++ b/src/setup.c
@@ -95,26 +95,36 @@ void io_uring_setup_ring_pointers(struct io_uring_params *p,
 	cq->ring_entries = *cq->kring_entries;
 }
 
-static size_t params_sqes_size(const struct io_uring_params *p, unsigned sqes)
+static int params_sqes_size(const struct io_uring_params *p, unsigned sqes,
+			    size_t *out)
 {
-	sqes <<= io_uring_sqe_shift_from_flags(p->flags);
-	return sqes * sizeof(struct io_uring_sqe);
+	size_t s = (size_t)sqes << io_uring_sqe_shift_from_flags(p->flags);
+
+	return __size_mul(s, sizeof(struct io_uring_sqe), out);
 }
 
-static size_t params_cq_size(const struct io_uring_params *p, unsigned cqes)
+static int params_cq_size(const struct io_uring_params *p, unsigned cqes,
+			  size_t *out)
 {
-	cqes <<= io_uring_cqe_shift_from_flags(p->flags);
-	return cqes * sizeof(struct io_uring_cqe);
+	size_t c = (size_t)cqes << io_uring_cqe_shift_from_flags(p->flags);
+
+	return __size_mul(c, sizeof(struct io_uring_cqe), out);
 }
 
 int io_uring_mmap(int fd, struct io_uring_params *p, struct io_uring_sq *sq,
 		  struct io_uring_cq *cq)
 {
-	size_t sqes_sz;
+	size_t sqes_sz, sq_arr_sz, cq_sz;
 	int ret;
 
-	sq->ring_sz = p->sq_off.array + p->sq_entries * sizeof(unsigned);
-	cq->ring_sz = p->cq_off.cqes + params_cq_size(p, p->cq_entries);
+	ret = __size_mul(p->sq_entries, sizeof(unsigned), &sq_arr_sz);
+	if (ret)
+		return ret;
+	ret = params_cq_size(p, p->cq_entries, &cq_sz);
+	if (ret)
+		return ret;
+	sq->ring_sz = p->sq_off.array + sq_arr_sz;
+	cq->ring_sz = p->cq_off.cqes + cq_sz;
 
 	if (p->features & IORING_FEAT_SINGLE_MMAP) {
 		if (cq->ring_sz > sq->ring_sz)
@@ -140,7 +150,9 @@ int io_uring_mmap(int fd, struct io_uring_params *p, struct io_uring_sq *sq,
 		}
 	}
 
-	sqes_sz = params_sqes_size(p, p->sq_entries);
+	ret = params_sqes_size(p, p->sq_entries, &sqes_sz);
+	if (ret)
+		goto err;
 	sq->sqes_sz = (unsigned int) sqes_sz;
 	if (sq->sqes_sz != sqes_sz) {
 		ret = -EINVAL;
@@ -174,10 +186,11 @@ __cold int io_uring_queue_mmap(int fd, struct io_uring_params *p,
 	return io_uring_mmap(fd, p, &ring->sq, &ring->cq);
 }
 
-static size_t io_uring_sqes_size(const struct io_uring *ring)
+static int io_uring_sqes_size(const struct io_uring *ring, size_t *out)
 {
-	return (ring->sq.ring_entries << io_uring_sqe_shift(ring)) *
-	       sizeof(struct io_uring_sqe);
+	size_t s = (size_t)ring->sq.ring_entries << io_uring_sqe_shift(ring);
+
+	return __size_mul(s, sizeof(struct io_uring_sqe), out);
 }
 
 /*
@@ -192,7 +205,9 @@ __cold int io_uring_ring_dontfork(struct io_uring *ring)
 	if (!ring->sq.ring_ptr || !ring->sq.sqes || !ring->cq.ring_ptr)
 		return -EINVAL;
 
-	len = io_uring_sqes_size(ring);
+	ret = io_uring_sqes_size(ring, &len);
+	if (ret)
+		return ret;
 	ret = __sys_madvise(ring->sq.sqes, len, MADV_DONTFORK);
 	if (ret < 0)
 		return ret;
@@ -226,7 +241,7 @@ static int io_uring_alloc_huge(unsigned entries, struct io_uring_params *p,
 {
 	unsigned long page_size = get_page_size();
 	unsigned sq_entries, cq_entries;
-	size_t sqes_size = 0, ring_mem, sqes_mem;
+	size_t sqes_size = 0, ring_mem, sqes_mem, tmp;
 	unsigned long mem_used = 0;
 	void *ptr;
 	int ret;
@@ -235,13 +250,21 @@ static int io_uring_alloc_huge(unsigned entries, struct io_uring_params *p,
 	if (ret)
 		return ret;
 
-	sqes_mem = params_sqes_size(p, sq_entries);
-	if (!(p->flags & IORING_SETUP_NO_SQARRAY))
-		sqes_mem += sq_entries * sizeof(unsigned);
+	ret = params_sqes_size(p, sq_entries, &sqes_mem);
+	if (ret)
+		return ret;
+	if (!(p->flags & IORING_SETUP_NO_SQARRAY)) {
+		ret = __size_mul(sq_entries, sizeof(unsigned), &tmp);
+		if (ret)
+			return ret;
+		sqes_mem += tmp;
+	}
 	sqes_mem = (sqes_mem + page_size - 1) & ~(page_size - 1);
 
-	ring_mem = KRING_SIZE;
-	ring_mem += params_cq_size(p, cq_entries);
+	ret = params_cq_size(p, cq_entries, &tmp);
+	if (ret)
+		return ret;
+	ring_mem = KRING_SIZE + tmp;
 	mem_used = sqes_mem + ring_mem;
 	mem_used = (mem_used + page_size - 1) & ~(page_size - 1);
 
@@ -509,10 +532,11 @@ __cold void io_uring_free_probe(struct io_uring_probe *probe)
 	free(probe);
 }
 
-static size_t rings_size(struct io_uring_params *p, unsigned entries,
-			 unsigned cq_entries, long page_size)
+static ssize_t rings_size(struct io_uring_params *p, unsigned entries,
+			  unsigned cq_entries, long page_size)
 {
 	size_t pages, sq_size, cq_size;
+	int ret;
 
 	/*
 	 * CQ ring size is number of pages that we need for the
@@ -520,12 +544,16 @@ static size_t rings_size(struct io_uring_params *p, unsigned entries,
 	 * 32b if the ring is setup with IORING_SETUP_CQE32. We also need
 	 * room for the head/tail parts.
 	 */
-	cq_size = params_cq_size(p, cq_entries);
+	ret = params_cq_size(p, cq_entries, &cq_size);
+	if (ret)
+		return ret;
 	cq_size += KRING_SIZE;
 	cq_size = (cq_size + page_size - 1) & ~(page_size - 1);
 	pages = (size_t) cq_size / page_size;
 
-	sq_size = params_sqes_size(p, entries);
+	ret = params_sqes_size(p, entries, &sq_size);
+	if (ret)
+		return ret;
 	sq_size = (sq_size + page_size - 1) & ~(page_size - 1);
 	pages += sq_size / page_size;
 	return pages * page_size;
@@ -635,7 +663,11 @@ static struct io_uring_buf_ring *br_setup(struct io_uring *ring,
 	}
 
 	off = IORING_OFF_PBUF_RING | (unsigned long long) bgid << IORING_OFF_PBUF_SHIFT;
-	ring_size = nentries * sizeof(struct io_uring_buf);
+	if (__size_mul(nentries, sizeof(struct io_uring_buf), &ring_size)) {
+		io_uring_unregister_buf_ring(ring, bgid);
+		*err = -EOVERFLOW;
+		return NULL;
+	}
 	br = __sys_mmap(NULL, ring_size, PROT_READ | PROT_WRITE,
 			MAP_SHARED | MAP_POPULATE, ring->ring_fd, off);
 	if (IS_ERR(br)) {
@@ -657,7 +689,10 @@ static struct io_uring_buf_ring *br_setup(struct io_uring *ring,
 	int lret;
 
 	memset(&reg, 0, sizeof(reg));
-	ring_size = nentries * sizeof(struct io_uring_buf);
+	if (__size_mul(nentries, sizeof(struct io_uring_buf), &ring_size)) {
+		*err = -EOVERFLOW;
+		return NULL;
+	}
 	br = __sys_mmap(NULL, ring_size, PROT_READ | PROT_WRITE,
 			MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
 	if (IS_ERR(br)) {
@@ -698,12 +733,16 @@ struct io_uring_buf_ring *io_uring_setup_buf_ring(struct io_uring *ring,
 int io_uring_free_buf_ring(struct io_uring *ring, struct io_uring_buf_ring *br,
 			   unsigned int nentries, int bgid)
 {
+	size_t size;
 	int ret;
+
+	if (__size_mul(nentries, sizeof(struct io_uring_buf), &size))
+		return -EOVERFLOW;
 
 	ret = io_uring_unregister_buf_ring(ring, bgid);
 	if (ret)
 		return ret;
 
-	__sys_munmap(br, nentries * sizeof(struct io_uring_buf));
+	__sys_munmap(br, size);
 	return 0;
 }

--- a/src/setup.h
+++ b/src/setup.h
@@ -2,6 +2,9 @@
 #ifndef LIBURING_SETUP_H
 #define LIBURING_SETUP_H
 
+#include <errno.h>
+#include <stddef.h>
+
 int __io_uring_queue_init_params(unsigned entries, struct io_uring *ring,
 				 struct io_uring_params *p, void *buf,
 				 size_t buf_size);
@@ -11,5 +14,26 @@ int io_uring_mmap(int fd, struct io_uring_params *p, struct io_uring_sq *sq,
 void io_uring_setup_ring_pointers(struct io_uring_params *p,
 				  struct io_uring_sq *sq,
 				  struct io_uring_cq *cq);
+
+/*
+ * Multiply @count by @elem into *@out. Returns 0 on success and
+ * -EOVERFLOW if the multiplication would wrap; *@out is unspecified on
+ * error.
+ *
+ * Every product fed to mmap()/munmap() or used as a buffer size must go
+ * through this helper. The kernel caps most user-supplied counts before
+ * they reach these sites, but that invariant lives in a different
+ * function from the multiplication, so a reviewer cannot verify safety
+ * locally. Routing every `count * elem` through __size_mul makes the
+ * overflow check co-located with the operation it protects, and removes
+ * the silent-wrap-into-undersized-allocation class of bug regardless of
+ * what future callers or kernel changes do to the input ranges.
+ */
+static inline int __size_mul(size_t count, size_t elem, size_t *out)
+{
+	if (__builtin_mul_overflow(count, elem, out))
+		return -EOVERFLOW;
+	return 0;
+}
 
 #endif

--- a/test/Makefile
+++ b/test/Makefile
@@ -254,6 +254,7 @@ test_srcs := \
 	shutdown.c \
 	sigfd-deadlock.c \
 	single-issuer.c \
+	size-overflow.c \
 	skip-cqe.c \
 	socket.c \
 	socket-io-cmd.c \

--- a/test/size-overflow.c
+++ b/test/size-overflow.c
@@ -1,0 +1,174 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Description: regression test for the size_t multiplication overflow
+ * guards on size-sensitive call sites in src/setup.c.
+ *
+ * The contract is encoded in __size_mul(). This test pins both layers
+ * of that contract:
+ *
+ *   1. The helper itself: direct exercises with boundary inputs on
+ *      every supported architecture.
+ *
+ *   2. End-to-end: io_uring_setup_buf_ring() with an adversarial
+ *      nentries returns NULL with a non-zero error code, no crash and
+ *      no half-initialised ring left behind.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdint.h>
+
+#include "liburing.h"
+#include "helpers.h"
+
+static int test_size_mul_helper(void)
+{
+	size_t out;
+	int ret;
+
+	ret = __size_mul(2, 3, &out);
+	if (ret || out != 6) {
+		fprintf(stderr, "__size_mul(2,3) -> ret=%d out=%zu\n", ret, out);
+		return 1;
+	}
+
+	ret = __size_mul(SIZE_MAX, 0, &out);
+	if (ret || out != 0) {
+		fprintf(stderr, "__size_mul(SIZE_MAX,0) -> ret=%d out=%zu\n",
+			ret, out);
+		return 1;
+	}
+
+	ret = __size_mul(0, SIZE_MAX, &out);
+	if (ret || out != 0) {
+		fprintf(stderr, "__size_mul(0,SIZE_MAX) -> ret=%d out=%zu\n",
+			ret, out);
+		return 1;
+	}
+
+	ret = __size_mul(SIZE_MAX, 1, &out);
+	if (ret || out != SIZE_MAX) {
+		fprintf(stderr, "__size_mul(SIZE_MAX,1) -> ret=%d out=%zu\n",
+			ret, out);
+		return 1;
+	}
+
+	ret = __size_mul(SIZE_MAX, 2, &out);
+	if (ret != -EOVERFLOW) {
+		fprintf(stderr, "__size_mul(SIZE_MAX,2) -> ret=%d (want -EOVERFLOW)\n",
+			ret);
+		return 1;
+	}
+
+	ret = __size_mul(SIZE_MAX / 2 + 1, 2, &out);
+	if (ret != -EOVERFLOW) {
+		fprintf(stderr,
+			"__size_mul(SIZE_MAX/2+1,2) -> ret=%d (want -EOVERFLOW)\n",
+			ret);
+		return 1;
+	}
+
+	ret = __size_mul(SIZE_MAX / 2, 2, &out);
+	if (ret) {
+		fprintf(stderr, "__size_mul(SIZE_MAX/2,2) -> ret=%d (want 0)\n",
+			ret);
+		return 1;
+	}
+
+	/*
+	 * The exact shape callers depend on: count * sizeof(elem).
+	 * sizeof(struct io_uring_buf) is 16, so UINT_MAX * 16 overflows
+	 * 32-bit size_t but fits in 64-bit size_t. Both outcomes are
+	 * valid for the contract, but the helper must never return
+	 * silent garbage.
+	 */
+	ret = __size_mul(UINT_MAX, sizeof(struct io_uring_buf), &out);
+	if (ret && ret != -EOVERFLOW) {
+		fprintf(stderr,
+			"__size_mul(UINT_MAX,sizeof buf) -> ret=%d (want 0 or -EOVERFLOW)\n",
+			ret);
+		return 1;
+	}
+	if (ret == 0 && out != (size_t)UINT_MAX * sizeof(struct io_uring_buf)) {
+		fprintf(stderr,
+			"__size_mul(UINT_MAX,sizeof buf) silent wrap: out=%zu\n",
+			out);
+		return 1;
+	}
+
+	return 0;
+}
+
+static int test_setup_buf_ring_huge(void)
+{
+	struct io_uring_buf_ring *br;
+	struct io_uring ring;
+	int ret, err = 0;
+
+	ret = t_create_ring(1, &ring, 0);
+	if (ret == T_SETUP_SKIP)
+		return T_EXIT_SKIP;
+	if (ret != T_SETUP_OK)
+		return 1;
+
+	/*
+	 * UINT_MAX entries is far above any kernel cap and, on 32-bit
+	 * size_t, overflows the count * sizeof(struct io_uring_buf)
+	 * product. The library must turn either failure mode into a
+	 * clean NULL return with a non-zero err — no crash, no partial
+	 * registration left for the caller to leak.
+	 */
+	br = io_uring_setup_buf_ring(&ring, UINT_MAX, 0, 0, &err);
+	if (br != NULL) {
+		fprintf(stderr, "setup_buf_ring(UINT_MAX) returned %p\n", br);
+		io_uring_free_buf_ring(&ring, br, UINT_MAX, 0);
+		io_uring_queue_exit(&ring);
+		return 1;
+	}
+	if (err == 0) {
+		fprintf(stderr, "setup_buf_ring(UINT_MAX) NULL but err == 0\n");
+		io_uring_queue_exit(&ring);
+		return 1;
+	}
+
+	/*
+	 * Sanity: a legitimate setup at the same bgid still works after
+	 * the failed call — no state was leaked.
+	 */
+	err = 0;
+	br = io_uring_setup_buf_ring(&ring, 32, 0, 0, &err);
+	if (!br) {
+		fprintf(stderr, "follow-up setup_buf_ring(32) failed: %d\n", err);
+		io_uring_queue_exit(&ring);
+		return 1;
+	}
+	io_uring_free_buf_ring(&ring, br, 32, 0);
+
+	io_uring_queue_exit(&ring);
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
+	int ret;
+
+	if (argc > 1)
+		return T_EXIT_SKIP;
+
+	if (test_size_mul_helper()) {
+		fprintf(stderr, "size_mul helper test failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	ret = test_setup_buf_ring_huge();
+	if (ret == T_EXIT_SKIP)
+		return T_EXIT_SKIP;
+	if (ret) {
+		fprintf(stderr, "setup_buf_ring huge nentries test failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	return T_EXIT_PASS;
+}


### PR DESCRIPTION
setup: harden ring sizing arithmetic against overflow

Several setup-time size calculations relied on unchecked arithmetic
 for `count * sizeof(...)` products and shift-expanded entry counts.
 Large or malformed inputs could wrap these calculations and produce
 undersized mappings or allocations.

Introduce `__size_mul()` as a centralized checked multiplication
 helper and route all `mmap()/munmap()-relevant` sizing through it.
Convert the internal sizing helpers to explicit error-returning
 interfaces so overflow can be propagated consistently.

Also fix the shift-before-multiply overflow class by promoting
 counts to `size_t` before applying `SQE/CQE` size shifts.

Add regression coverage for both direct helper boundary behavior
 and end-to-end oversized `io_uring_setup_buf_ring()` handling,
including verification that failed setup attempts do not leave
 behind partial registration state.

Signed-off-by: Metsw Max [metsw24-max@gmail.com](mailto:metsw24-max@gmail.com)