### PR TITLE
examples/napi-busy-poll: bound strcpy of -a/-p arguments

### DIFF
--- a/examples/napi-busy-poll-client.c
+++ b/examples/napi-busy-poll-client.c
@@ -305,7 +305,7 @@ int main(int argc, char *argv[])
 	while ((flag = getopt_long(argc, argv, ":hs:bua:n:p:t:6d:", longopts, NULL)) != -1) {
 		switch (flag) {
 		case 'a':
-			strcpy(opt.addr, optarg);
+			snprintf(opt.addr, sizeof(opt.addr), "%s", optarg);
 			break;
 		case 'b':
 			opt.busy_loop = true;
@@ -318,7 +318,7 @@ int main(int argc, char *argv[])
 			opt.num_pings = atoi(optarg) + 1;
 			break;
 		case 'p':
-			strcpy(opt.port, optarg);
+			snprintf(opt.port, sizeof(opt.port), "%s", optarg);
 			break;
 		case 's':
 			opt.sq_poll = !!atoi(optarg);

--- a/examples/napi-busy-poll-server.c
+++ b/examples/napi-busy-poll-server.c
@@ -266,7 +266,7 @@ int main(int argc, char *argv[])
 	while ((flag = getopt_long(argc, argv, ":lhs:bua:n:p:t:6d:", longopts, NULL)) != -1) {
 		switch (flag) {
 		case 'a':
-			strcpy(opt.addr, optarg);
+			snprintf(opt.addr, sizeof(opt.addr), "%s", optarg);
 			break;
 		case 'b':
 			opt.busy_loop = true;
@@ -282,7 +282,7 @@ int main(int argc, char *argv[])
 			opt.num_pings = atoi(optarg) + 1;
 			break;
 		case 'p':
-			strcpy(opt.port, optarg);
+			snprintf(opt.port, sizeof(opt.port), "%s", optarg);
 			break;
 		case 's':
 			opt.sq_poll = !!atoi(optarg);


### PR DESCRIPTION
## What

`examples/napi-busy-poll-client.c` and `examples/napi-busy-poll-server.c`
parse the `-a` (address) and `-p` (port) command-line arguments by
copying `optarg` into fixed-size fields with `strcpy()`:

- `examples/napi-busy-poll-client.c:308` and `:321`
- `examples/napi-busy-poll-server.c:269` and `:285`

The destination buffers are 80 bytes (`opt.addr[ADDRLEN]`) and 10 bytes
(`opt.port[PORTNOLEN]`) inside `struct options`. `strcpy()` is unbounded,
so any longer argument overwrites whatever follows the field — the rest
of `struct options`, and (since `opt` is a local in the client's
`main()`) the surrounding stack frame.

## How to observe

A small stub mirroring the layout demonstrates the overflow under
AddressSanitizer:

```
$ cat repro.c
#include <stdio.h>
#include <string.h>
#define PORTNOLEN 10
#define ADDRLEN   80
struct options {
    int num_pings; unsigned timeout;
    int sq_poll, defer_tw, busy_loop, prefer_busy_poll, ipv6;
    char port[PORTNOLEN]; char addr[ADDRLEN];
};
int main(int argc, char *argv[]) {
    struct options opt; memset(&opt, 0, sizeof(opt));
    strcpy(opt.addr, argv[1]);
    return 0;
}
$ clang -fsanitize=address -O0 -g repro.c -o repro
$ ./repro "$(python3 -c 'print("A"*256)')"
==ERROR: AddressSanitizer: stack-buffer-overflow ...
WRITE of size 257 at ... in strcpy
  #1 main repro.c:13
'opt' (line 11) <== Memory access at offset 152 overflows this variable
```

Replacing `strcpy` with the `snprintf` form from this patch makes the
report go away — the input is truncated to `sizeof(opt.addr) - 1` chars
and is always null-terminated.

## Fix

Replace both `strcpy(opt.addr, optarg)` / `strcpy(opt.port, optarg)`
sites in each file with `snprintf(opt.<field>, sizeof(opt.<field>),
"%s", optarg)`. The fix is local to the option-parsing switch in each
example's `main()` — no caller changes, no API/ABI change.

## Test plan
- [x] Build a minimal standalone reproducer that mirrors the field
      layout; confirm ASan reports stack-buffer-overflow with the
      original code and no error after the patch.