### PR TITLE
queue: fix NULL deref in _io_uring_get_cqe() for EXT_ARG_REG path

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -101,10 +101,23 @@ static int _io_uring_get_cqe(struct io_uring *ring,
 		if (!need_enter)
 			break;
 		if (looped && data->has_ts) {
-			struct io_uring_getevents_arg *arg = data->arg;
+			/*
+			 * When IORING_ENTER_EXT_ARG_REG is set, data->arg
+			 * carries a register-wait offset (an integer), not a
+			 * pointer to io_uring_getevents_arg.  Dereferencing it
+			 * as a struct pointer causes a memory access violation.
+			 * For the registered-wait path the kernel enforces the
+			 * timeout, so treat any timeout the same as -ETIME here.
+			 */
+			if (data->get_flags & IORING_ENTER_EXT_ARG_REG) {
+				if (!cqe && !err)
+					err = -ETIME;
+			} else {
+				struct io_uring_getevents_arg *arg = data->arg;
 
-			if (!cqe && arg->ts && !err)
-				err = -ETIME;
+				if (!cqe && arg->ts && !err)
+					err = -ETIME;
+			}
 			break;
 		}
 


### PR DESCRIPTION
When io_uring_submit_and_wait_reg() is used, data->arg holds a register
offset cast to void *, not a pointer to io_uring_getevents_arg. If no CQE
is available on the first pass, the looped && has_ts branch dereferences
data->arg as a struct pointer, which causes a segfault.

Fix this by checking IORING_ENTER_EXT_ARG_REG in get_flags before the
dereference. For the registered-wait path the kernel handles the timeout,
so return -ETIME directly without touching data->arg.

Fixes #1567.