### PR TITLE
test/ringbuf-read: bound strcpy of argv[1] into fname

### DIFF
--- a/test/ringbuf-read.c
+++ b/test/ringbuf-read.c
@@ -137,7 +137,7 @@ int main(int argc, char *argv[])
 	int ret, fd, i, do_unlink;
 
 	if (argc > 1) {
-		strcpy(fname, argv[1]);
+		snprintf(fname, sizeof(fname), "%s", argv[1]);
 		do_unlink = 0;
 	} else {
 		sprintf(fname, ".ringbuf-read.%d", getpid());


### PR DESCRIPTION
Stack overflow in test/ringbuf-read.c main() — argv[1] is copied into the
80-byte fname[] with an unbounded strcpy. Running the test with a long
path argument trips a stack-buffer-overflow under ASan.

Replace the strcpy with snprintf() bounded by sizeof(fname). Full
context is in the commit message.