### PR TITLE
recvmsg: compute cmsg nexthdr end without firsthdr

### DIFF
--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -1237,8 +1237,8 @@ io_uring_recvmsg_cmsg_nexthdr(struct io_uring_recvmsg_out *o, struct msghdr *msg
 
 	if (cmsg->cmsg_len < sizeof(struct cmsghdr))
 		return NULL;
-	end = (unsigned char *) io_uring_recvmsg_cmsg_firsthdr(o, msgh) +
-		o->controllen;
+	end = (unsigned char *) io_uring_recvmsg_name(o) +
+		msgh->msg_namelen + o->controllen;
 	cmsg = (struct cmsghdr *)((unsigned char *) cmsg +
 			CMSG_ALIGN(cmsg->cmsg_len));
 


### PR DESCRIPTION
Noticed io_uring_recvmsg_cmsg_nexthdr() computes the cmsg region end as
io_uring_recvmsg_cmsg_firsthdr(o, msgh) + o->controllen. firsthdr
returns NULL when o->controllen < sizeof(struct cmsghdr), so this
becomes a non-zero offset applied to a null pointer, which is undefined
behavior. Compute end directly as name + namelen + controllen so the
arithmetic is always on a real pointer; the value matches the old
expression when firsthdr would have succeeded.