### PR TITLE
examples/proxy: free cd[1] stat buckets in handle_close

### DIFF
--- a/examples/proxy.c
+++ b/examples/proxy.c
@@ -1791,6 +1791,8 @@ static int handle_close(struct io_uring *ring, struct io_uring_cqe *cqe)
 		free_msgs(&c->cd[1]);
 		free(c->cd[0].rcv_bucket);
 		free(c->cd[0].snd_bucket);
+		free(c->cd[1].rcv_bucket);
+		free(c->cd[1].snd_bucket);
 	}
 
 	return 0;


### PR DESCRIPTION
With -x (extended stats), each connection allocates rcv_bucket and snd_bucket for both c->cd[0] and c->cd[1] (examples/proxy.c:996), but handle_close only frees the cd[0] pair, leaking the cd[1] arrays on every teardown. Free them too, mirroring the existing cd[0] cleanup.