### PR TITLE
examples/link-cp: avoid misaligned struct io_data access

### DIFF
--- a/examples/link-cp.c
+++ b/examples/link-cp.c
@@ -67,13 +67,11 @@ static void queue_rw_pair(struct io_uring *ring, off_t size, off_t offset)
 {
 	struct io_uring_sqe *sqe;
 	struct io_data *data;
-	void *ptr;
 
-	ptr = malloc(size + sizeof(*data));
-	data = ptr + size;
+	data = malloc(size + sizeof(*data));
 	data->index = 0;
 	data->offset = offset;
-	data->iov.iov_base = ptr;
+	data->iov.iov_base = data + 1;
 	data->iov.iov_len = size;
 
 	sqe = io_uring_get_sqe(ring);
@@ -103,11 +101,8 @@ static int handle_cqe(struct io_uring *ring, struct io_uring_cqe *cqe)
 		}
 	}
 
-	if (data->index == 2) {
-		void *ptr = (void *) data - data->iov.iov_len;
-
-		free(ptr);
-	}
+	if (data->index == 2)
+		free(data);
 	io_uring_cqe_seen(ring, cqe);
 	return ret;
 }


### PR DESCRIPTION
queue_rw_pair() places struct io_data at ptr + size, so for any block size not a multiple of 8 (the partial tail block of most copies) the io_data members are accessed through a misaligned pointer, which is undefined behavior and faults under -fsanitize=alignment. Allocate the struct first and point iov_base at data + 1, matching io_uring-cp.c; the free in handle_cqe then drops the base recomputation.