### PR TITLE
liburing.h: fix integer overflow in recvmsg_cmsg_nexthdr

### DIFF
--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -1234,13 +1234,23 @@ io_uring_recvmsg_cmsg_nexthdr(struct io_uring_recvmsg_out *o, struct msghdr *msg
 	LIBURING_NOEXCEPT
 {
 	unsigned char *end;
+	unsigned long clen;
 
 	if (cmsg->cmsg_len < sizeof(struct cmsghdr))
 		return NULL;
 	end = (unsigned char *) io_uring_recvmsg_cmsg_firsthdr(o, msgh) +
 		o->controllen;
-	cmsg = (struct cmsghdr *)((unsigned char *) cmsg +
-			CMSG_ALIGN(cmsg->cmsg_len));
+	/*
+	 * Advance by the aligned length, but guard against cmsg_len being
+	 * large enough that CMSG_ALIGN() or the pointer addition wraps past
+	 * the end of the control buffer. Without this the bounds checks below
+	 * can be skipped and a wild cmsg pointer dereferenced.
+	 */
+	clen = CMSG_ALIGN(cmsg->cmsg_len);
+	if (clen < cmsg->cmsg_len ||
+	    clen > (unsigned long) (end - (unsigned char *) cmsg))
+		return NULL;
+	cmsg = (struct cmsghdr *)((unsigned char *) cmsg + clen);
 
 	if ((unsigned char *) (cmsg + 1) > end)
 		return NULL;

--- a/test/recv-multishot.c
+++ b/test/recv-multishot.c
@@ -533,6 +533,43 @@ static int test_recvmsg_validate(void)
 	return 0;
 }
 
+static int test_recvmsg_cmsg_nexthdr(void)
+{
+	struct io_uring_recvmsg_out *o;
+	unsigned char buf[256];
+	struct cmsghdr *cmsg;
+	struct msghdr msgh;
+
+	memset(buf, 0, sizeof(buf));
+	memset(&msgh, 0, sizeof(msgh));
+	o = (struct io_uring_recvmsg_out *)buf;
+	o->controllen = 128;
+	msgh.msg_namelen = 0;
+	msgh.msg_controllen = 128;
+
+	cmsg = io_uring_recvmsg_cmsg_firsthdr(o, &msgh);
+	if (!cmsg)
+		return -1;
+
+	/* cmsg_len whose CMSG_ALIGN() wraps must not loop in place or
+	 * return a wild pointer */
+	cmsg->cmsg_len = (size_t)-1;
+	if (io_uring_recvmsg_cmsg_nexthdr(o, &msgh, cmsg))
+		return -1;
+
+	/* a length past the remaining control space is rejected */
+	cmsg->cmsg_len = o->controllen + sizeof(struct cmsghdr);
+	if (io_uring_recvmsg_cmsg_nexthdr(o, &msgh, cmsg))
+		return -1;
+
+	/* a well-formed cmsg still yields an in-bounds next header */
+	cmsg->cmsg_len = sizeof(struct cmsghdr);
+	if (!io_uring_recvmsg_cmsg_nexthdr(o, &msgh, cmsg))
+		return -1;
+
+	return 0;
+}
+
 static int test_enobuf(void)
 {
 	struct io_uring ring;
@@ -626,6 +663,12 @@ int main(int argc, char *argv[])
 	ret = test_recvmsg_validate();
 	if (ret) {
 		fprintf(stderr, "test_recvmsg_validate() failed: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	ret = test_recvmsg_cmsg_nexthdr();
+	if (ret) {
+		fprintf(stderr, "test_recvmsg_cmsg_nexthdr() failed: %d\n", ret);
 		return T_EXIT_FAIL;
 	}
 


### PR DESCRIPTION
Noticed recvmsg_cmsg_nexthdr advances cmsg by CMSG_ALIGN(cmsg_len) before any bounds check. A cmsg_len near SIZE_MAX makes the align wrap to a small value, or the pointer add wrap past the control buffer, so the '> end' checks pass and the wild cmsg gets returned and dereferenced. Bound the aligned length against the remaining control space before advancing, the same way the recent recvmsg_validate fix did.