### PR TITLE
liburing.h: reject negative op in io_uring_opcode_supported

### DIFF
--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -214,7 +214,7 @@ void io_uring_free_probe(struct io_uring_probe *probe) LIBURING_NOEXCEPT;
 IOURINGINLINE int io_uring_opcode_supported(const struct io_uring_probe *p,
 					    int op) LIBURING_NOEXCEPT
 {
-	if (op > p->last_op)
+	if (op < 0 || op > p->last_op)
 		return 0;
 	return (p->ops[op].flags & IO_URING_OP_SUPPORTED) != 0;
 }


### PR DESCRIPTION
io_uring_opcode_supported() guards only the upper bound, so a negative op slips past it and p->ops[op] reads before the probe allocation - op == -3 reads 8 bytes ahead of the 16-byte struct, which ASan reports as a heap-buffer-overflow. Add the op < 0 check. Full context is in the commit message.