### PR TITLE
examples/io_uring-udp: compute buffer size and offset in size_t

### DIFF
--- a/examples/io_uring-udp.c
+++ b/examples/io_uring-udp.c
@@ -36,12 +36,12 @@ struct ctx {
 
 static size_t buffer_size(struct ctx *ctx)
 {
-	return 1U << ctx->buf_shift;
+	return (size_t)1 << ctx->buf_shift;
 }
 
 static unsigned char *get_buffer(struct ctx *ctx, int idx)
 {
-	return ctx->buffer_base + (idx << ctx->buf_shift);
+	return ctx->buffer_base + ((size_t)idx << ctx->buf_shift);
 }
 
 static int setup_buffer_pool(struct ctx *ctx)


### PR DESCRIPTION
buffer_size() and get_buffer() take their shift count from the -b option but evaluate the shift in 32-bit before widening, so a large value is undefined behavior and otherwise truncates the result. Do both shifts in size_t. Building with -fsanitize=undefined and running with -b 40 flags the old code (shift exponent 40 too large for 32-bit type), and buffer_size() returns 256 instead of 2^40.