### PR TITLE
test/conn-unreach: Accept -ENOTCONN from shutdown on unconnected socket

### DIFF
--- a/test/conn-unreach.c
+++ b/test/conn-unreach.c
@@ -36,7 +36,7 @@ static int check_cqe(struct io_uring *ring, struct io_uring_cqe *cqe)
 		}
 		break;
 	case 2:
-		if (cqe->res) {
+		if (cqe->res && cqe->res != -ENOTCONN) {
 			fprintf(stderr, "Unexpected shutdown: %d\n", cqe->res);
 			return T_EXIT_FAIL;
 		}


### PR DESCRIPTION
When the host has no route to the unreachable address (e.g., only loopback interface is up), connect never completes, and the subsequent shutdown(SHUT_RDWR) may return -ENOTCONN from the kernel.

Relax the check to accept both 0 and -ENOTCONN as valid results.