### PR TITLE
test/fallocate: Accept -EOPNOTSUPP as unsupported

### DIFF
--- a/test/fallocate.c
+++ b/test/fallocate.c
@@ -116,7 +116,7 @@ static int test_fallocate(struct io_uring *ring)
 		goto err;
 	}
 
-	if (cqe->res == -EINVAL) {
+	if (cqe->res == -EINVAL || cqe->res == -EOPNOTSUPP) {
 		fprintf(stdout, "Fallocate not supported, skipping\n");
 		no_fallocate = 1;
 		goto skip;


### PR DESCRIPTION
When fallocate is not supported, return -EOPNOTSUPP instead of -EINVAL. Treat both as skip conditions.