### PR TITLE
test: min-timeout: Call io_uring_queue_exit

### DIFF
--- a/test/min-timeout.c
+++ b/test/min-timeout.c
@@ -140,6 +140,8 @@ static int test(int flags, int expected_ctx, int min_wait, int write_delay,
 
 	pthread_join(thread, &tret);
 
+	io_uring_queue_exit(&ring);
+
 	for (i = 0; i < NPIPES; i++) {
 		close(fds[i][0]);
 		close(fds[i][1]);


### PR DESCRIPTION
Call io_uring_queue_exit after each test to avoid request completions after the end of the test.