### PR TITLE
test/poll-update-trigger: fix poll mask byte order

### DIFF
--- a/test/poll-update-trigger.c
+++ b/test/poll-update-trigger.c
@@ -51,9 +51,7 @@ int main(int argc, char *argv[])
 	 * writeable.
 	 */
 	sqe = io_uring_get_sqe(&ring);
-	io_uring_prep_poll_remove(sqe, 1);
-	sqe->len = IORING_POLL_UPDATE_EVENTS;
-	sqe->poll32_events = POLLOUT;
+	io_uring_prep_poll_update(sqe, 1, 0, POLLOUT, IORING_POLL_UPDATE_EVENTS);
 	sqe->user_data = 2;
 	io_uring_submit(&ring);
 


### PR DESCRIPTION
sqe->poll32_events is "word-reversed for BE", so assigning POLLOUT directly gives the kernel the wrong mask on s390 and the test hangs. Use io_uring_prep_poll_update() which handles the byte swap correctly.

Tested on s390;
before the test: 
`Running test poll-update-trigger.t Test poll-update-trigger.t timed out (may not be a failure)`
With the patch the test passes on s390.