### PR TITLE
test/reg-fd-only: Relax io_uring_submit() return value check

### DIFF
--- a/test/reg-fd-only.c
+++ b/test/reg-fd-only.c
@@ -30,7 +30,7 @@ static int test_nops(struct io_uring *ring, int sq_size, int nr_nops)
 		}
 
 		ret = io_uring_submit(ring);
-		if (ret != todo) {
+		if (ret < todo) {
 			fprintf(stderr, "short submit %d\n", ret);
 			return T_EXIT_FAIL;
 		}


### PR DESCRIPTION
For SQPOLL rings the man page of io_uring_submit(3) states that the return value can be higher than the number of submitted SQEs and on a very slow overloaded system we sometimes see the test fail with:

| short submit 16
| test 8 failed

To fix this, allow the return value to be higher than expected.