### PR TITLE
[GIT PULL] Add IORING_REGISTER_CLONE_FILES support and tests

### DIFF
--- a/man/io_uring_clone_files.3
+++ b/man/io_uring_clone_files.3
@@ -1,0 +1,135 @@
+.\" Copyright (C) 2026 Harshal Chavan <harshal24.chavan@gmail.com>
+.\"
+.\" SPDX-License-Identifier: LGPL-2.0-or-later
+.\"
+.TH io_uring_clone_files 3 "June 24, 2026" "liburing-2.12" "liburing Manual"
+.SH NAME
+io_uring_clone_files \- Clones registered files between rings
+.SH SYNOPSIS
+.nf
+.B #include <liburing.h>
+.PP
+.BI "int io_uring_clone_files(struct io_uring *" dst ","
+.BI "                         struct io_uring * " src ");"
+.PP
+.BI "int __io_uring_clone_files(struct io_uring *" dst ","
+.BI "                           struct io_uring * " src ","
+.BI "                           unsigned int " flags ");"
+.PP
+.BI "int io_uring_clone_files_offset(struct io_uring *" dst ","
+.BI "                                struct io_uring * " src ","
+.BI "                                unsigned int " dst_off ","
+.BI "                                unsigned int " src_off ","
+.BI "                                unsigned int " nr ","
+.BI "                                unsigned int " flags ");"
+.PP
+.BI "int __io_uring_clone_files_offset(struct io_uring *" dst ","
+.BI "                                  struct io_uring * " src ","
+.BI "                                  unsigned int " dst_off ","
+.BI "                                  unsigned int " src_off ","
+.BI "                                  unsigned int " nr ","
+.BI "                                  unsigned int " flags ");"
+.PP
+.fi
+.SH DESCRIPTION
+.PP
+The
+.BR io_uring_clone_files (3)
+function clones registered file descriptors from the ring indicated by
+.IR src
+to the ring indicated by
+.IR dst .
+Upon successful completion of this operation,
+.IR src
+and
+.IR dst
+will have the same set of registered files.
+
+The
+.IR dst
+ring must not have any files currently registered. If files are currently
+registered on the destination ring, they must be unregistered with
+.BR io_uring_unregister_files (3)
+first or pass the IORING_REGISTER_DST_REPLACE flag to replace the old files in 
+.IR dst
+ring.
+
+
+Not yet available in the kernel.
+
+The
+.BR io_uring_clone_files_offset (3)
+function also clones files from the
+.IR src
+ring to the
+.IR dst
+ring, however it supports cloning only a subset of the files, where
+.BR io_uring_clone_files (3)
+always clones all of them.
+.IR dst_off
+indicates at what offset cloning should start in the destination,
+.IR src_off
+indicates at what offset cloning should start in the source, and
+.IR nr
+indicates how many files to clone at the given offset. If both
+.IR dst_off ,
+.IR src_off ,
+and
+.IR nr
+are given as
+.B 0 ,
+then
+.BR io_uring_clone_files_offset (3)
+performs the same action as
+.BR io_uring_clone_files (3) .
+
+.IR flags
+may be set to the following values:
+.TP
+.B IORING_REGISTER_SRC_REGISTERED
+If the source ring is registered AND the calling thread is the one that
+originally registered its ring fd, then this flag may be set to lookup the
+registered index rather than use the normal file descriptor. If the normal
+file descriptor wasn't closed after registering it, there's no need to set
+this flag.
+.TP
+.B IORING_REGISTER_DST_REPLACE
+If set, cloning may happen for a destination ring that already has a file
+table assigned. In that case, existing nodes that overlap with the specified
+range will be released and replaced.
+.PP
+
+.SH NOTES
+A ring cannot safely clone its file table into itself. Attempting to use the
+same ring for both
+.IR src
+and
+.IR dst
+will fail.
+.SH RETURN VALUE
+On success
+.BR io_uring_clone_files (3)
+and
+.BR io_uring_clone_files_offset (3)
+return 0.
+On failure, they return
+.BR -errno ,
+specifically
+.TP
+.B -EBUSY
+The destination ring already has files registered, and
+.B IORING_REGISTER_DST_REPLACE
+wasn't set.
+.TP
+.B -EINVAL
+An attempt was made to clone a ring into itself, or an invalid flag/offset was specified.
+.TP
+.B -ENOMEM
+The kernel ran out of memory.
+.TP
+.B -ENXIO
+The source ring doesn't have any files registered.
+.SH SEE ALSO
+.BR io_uring_register (2),
+.BR io_uring_unregister_files (3),
+.BR io_uring_register_files (3)

--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -279,6 +279,18 @@ int io_uring_clone_buffers(struct io_uring *dst, struct io_uring *src)
 	LIBURING_NOEXCEPT;
 int __io_uring_clone_buffers(struct io_uring *dst, struct io_uring *src,
 			     unsigned int flags) LIBURING_NOEXCEPT;
+int io_uring_clone_files_offset(struct io_uring *dst, struct io_uring *src,
+				  unsigned int dst_off, unsigned int src_off,
+				  unsigned int nr, unsigned int flags)
+	LIBURING_NOEXCEPT;
+int __io_uring_clone_files_offset(struct io_uring *dst, struct io_uring *src,
+				  unsigned int dst_off, unsigned int src_off,
+				  unsigned int nr, unsigned int flags)
+	LIBURING_NOEXCEPT;
+int io_uring_clone_files(struct io_uring *dst, struct io_uring *src)
+	LIBURING_NOEXCEPT;
+int __io_uring_clone_files(struct io_uring *dst, struct io_uring *src,
+			     unsigned int flags) LIBURING_NOEXCEPT;
 int io_uring_register_buffers(struct io_uring *ring, const struct iovec *iovecs,
 			      unsigned nr_iovecs) LIBURING_NOEXCEPT;
 int io_uring_register_buffers_tags(struct io_uring *ring,

--- a/src/include/liburing/io_uring.h
+++ b/src/include/liburing/io_uring.h
@@ -709,6 +709,9 @@ enum io_uring_register_op {
 	/* register bpf filtering programs */
 	IORING_REGISTER_BPF_FILTER		= 37,
 
+	/* clone file descriptors from another ring */
+	IORING_REGISTER_CLONE_FILES		= 38,
+
 	/* this goes last */
 	IORING_REGISTER_LAST,
 
@@ -838,6 +841,16 @@ struct io_uring_clone_buffers {
 	__u32	dst_off;
 	__u32	nr;
 	__u32	pad[3];
+};
+
+
+struct io_uring_clone_files {
+	__u32 src_fd;
+	__u32 flags;
+	__u32 src_off;
+	__u32 dst_off;
+	__u32 nr;
+	__u32 pad[3];
 };
 
 struct io_uring_buf {

--- a/src/liburing-ffi.map
+++ b/src/liburing-ffi.map
@@ -274,4 +274,8 @@ LIBURING_2.15 {
 		__io_uring_peek_cqe;
 		io_uring_register_zcrx_ctrl;
 		io_uring_register_query;
+    io_uring_clone_files;
+		__io_uring_clone_files;
+		io_uring_clone_files_offset;
+		__io_uring_clone_files_offset;
 } LIBURING_2.14;

--- a/src/liburing.map
+++ b/src/liburing.map
@@ -145,4 +145,8 @@ LIBURING_2.15 {
 		io_uring_register_bpf_filter_task;
 		io_uring_register_zcrx_ctrl;
 		io_uring_register_query;
+    io_uring_clone_files;
+		__io_uring_clone_files;
+		io_uring_clone_files_offset;
+		__io_uring_clone_files_offset;
 } LIBURING_2.14;

--- a/src/register.c
+++ b/src/register.c
@@ -443,6 +443,49 @@ int __io_uring_clone_buffers(struct io_uring *dst, struct io_uring *src,
 	return __io_uring_clone_buffers_offset(dst, src, 0, 0, 0, flags);
 }
 
+int __io_uring_clone_files_offset(struct io_uring *dst, struct io_uring *src,
+				    unsigned int dst_off, unsigned int src_off,
+				    unsigned int nr, unsigned int flags)
+{
+	struct io_uring_clone_files buf = {
+		.src_fd		= src->ring_fd,
+		.flags		= flags,
+		.src_off	= src_off,
+		.dst_off	= dst_off,
+		.nr		= nr,
+	};
+
+	if (flags & IORING_REGISTER_SRC_REGISTERED &&
+	    src->int_flags & INT_FLAG_REG_REG_RING) {
+		buf.src_fd = src->enter_ring_fd;
+	} else {
+		buf.src_fd = src->ring_fd;
+		buf.flags &= ~IORING_REGISTER_SRC_REGISTERED;
+	}
+
+	return do_register(dst, IORING_REGISTER_CLONE_FILES, &buf, 1);
+}
+
+int io_uring_clone_files_offset(struct io_uring *dst, struct io_uring *src,
+				  unsigned int dst_off, unsigned int src_off,
+				  unsigned int nr, unsigned int flags)
+{
+	return __io_uring_clone_files_offset(dst, src, dst_off, src_off, nr,
+						flags | IORING_REGISTER_SRC_REGISTERED);
+}
+
+int io_uring_clone_files(struct io_uring *dst, struct io_uring *src)
+{
+	return __io_uring_clone_files_offset(dst, src, 0, 0, 0, IORING_REGISTER_SRC_REGISTERED);
+}
+
+int __io_uring_clone_files(struct io_uring *dst, struct io_uring *src,
+			     unsigned int flags)
+{
+	return __io_uring_clone_files_offset(dst, src, 0, 0, 0, flags);
+}
+
+
 int io_uring_register_ifq(struct io_uring *ring,
 			  struct io_uring_zcrx_ifq_reg *reg)
 {

--- a/test/Makefile
+++ b/test/Makefile
@@ -84,6 +84,7 @@ test_srcs := \
 	cancel-race.c \
 	cbpf_filter.c \
 	ce593a6c480a.c \
+	clone-files.c \
 	close-opath.c \
 	conn-unreach.c \
 	connect.c \

--- a/test/clone-files.c
+++ b/test/clone-files.c
@@ -1,0 +1,347 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Description: test file descriptor cloning between rings
+ *
+ */
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+
+#include "liburing.h"
+#include "helpers.h"
+
+#define NR_FILES 64
+
+static int no_file_clone;
+static int no_file_offset;
+
+/* * Helper to test if a file is successfully registered at the given index.
+ * A 0-byte read using IOSQE_FIXED_FILE will return 0 if valid, or -EBADF if invalid.
+ */
+static int use_file(struct io_uring *ring, int index)
+{
+	struct io_uring_sqe *sqe;
+	struct io_uring_cqe *cqe;
+	char buf[1];
+	int ret;
+
+	sqe = io_uring_get_sqe(ring);
+	io_uring_prep_read(sqe, 0, buf, 0, 0); // 0-byte read
+	sqe->fd = index;
+	sqe->flags |= IOSQE_FIXED_FILE;
+	io_uring_submit(ring);
+
+	ret = io_uring_wait_cqe(ring, &cqe);
+	if (ret) {
+		fprintf(stderr, "wait_cqe: %d\n", ret);
+		return ret;
+	}
+
+	ret = cqe->res;
+	io_uring_cqe_seen(ring, cqe);
+	return ret;
+}
+
+static int test_offsets(void)
+{
+	struct io_uring src, dst;
+	int fds[NR_FILES];
+	unsigned int i, offset, nr;
+	int ret;
+
+	ret = io_uring_queue_init(1, &src, 0);
+	if (ret) {
+		fprintf(stderr, "ring_init: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+	ret = io_uring_queue_init(1, &dst, 0);
+	if (ret) {
+		fprintf(stderr, "ring_init: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	for (i = 0; i < NR_FILES; i++) {
+		int pipe_fds[2];
+		if (pipe(pipe_fds) < 0)
+			return T_EXIT_FAIL;
+		fds[i] = pipe_fds[0]; // Register the read end
+		close(pipe_fds[1]);   // Close write end, we only need to test FD existence
+	}
+
+	ret = io_uring_register_files(&src, fds, NR_FILES);
+	if (ret < 0) {
+		fprintf(stderr, "register files failed: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	/* clone half the files, src offset 0, but ask for too many */
+	offset = NR_FILES / 2;
+	nr = NR_FILES;
+	ret = io_uring_clone_files_offset(&dst, &src, 0, offset, nr, 0);
+	if (ret != -EINVAL) {
+		if (ret == -EBADF || ret == -ENOSYS) {
+			no_file_offset = 1;
+			return T_EXIT_SKIP;
+		}
+		fprintf(stderr, "Offset and too big total failed: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	/* ask for too many files */
+	nr = NR_FILES + 1;
+	ret = io_uring_clone_files_offset(&dst, &src, 0, 0, nr, 0);
+	if (ret != -EINVAL) {
+		fprintf(stderr, "Too many files total failed: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	/* clone half the files into start of dst offset */
+	nr = NR_FILES / 2;
+	ret = io_uring_clone_files_offset(&dst, &src, 0, nr, nr, 0);
+	if (ret) {
+		fprintf(stderr, "Half clone with offset failed: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	/* 'nr' offset should be 0 on the src side, valid on dst */
+	ret = use_file(&dst, 0);
+	if (ret < 0) {
+		fprintf(stderr, "1 use_file=%d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	ret = io_uring_unregister_files(&dst);
+	if (ret) {
+		fprintf(stderr, "Failed to unregister partial dst: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	ret = use_file(&dst, 0);
+	if (ret != -EBADF) {
+		fprintf(stderr, "2 use_file=%d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	/* clone half the files into middle of dst offset */
+	nr = NR_FILES / 2;
+	ret = io_uring_clone_files_offset(&dst, &src, nr, nr, nr, 0);
+	if (ret) {
+		fprintf(stderr, "Half files and middle offset failed: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	ret = use_file(&dst, 0);
+	if (ret != -EBADF) {
+		fprintf(stderr, "3 use_file=%d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	ret = use_file(&dst, nr);
+	if (ret < 0) {
+		fprintf(stderr, "4 use_file=%d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	/* should get -EBUSY now, REPLACE not set */
+	nr = NR_FILES / 2;
+	ret = io_uring_clone_files_offset(&dst, &src, nr, nr, nr, 0);
+	if (ret != -EBUSY) {
+		fprintf(stderr, "Replace files failed (expected -EBUSY): %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	/* now replace the initial 0..n in dst (which are dummy/empty nodes) */
+	ret = io_uring_clone_files_offset(&dst, &src, 0, 0, nr, IORING_REGISTER_DST_REPLACE);
+	if (ret) {
+		fprintf(stderr, "File replace failed: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	ret = use_file(&dst, 0);
+	if (ret < 0) {
+		fprintf(stderr, "5 use_file=%d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	ret = io_uring_unregister_files(&dst);
+	if (ret) {
+		fprintf(stderr, "Failed to unregister partial dst: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	for (i = 0; i < NR_FILES; i++)
+		close(fds[i]);
+
+	io_uring_queue_exit(&src);
+	io_uring_queue_exit(&dst);
+	return T_EXIT_PASS;
+}
+
+static int test(int reg_src, int reg_dst)
+{
+	struct io_uring src, dst;
+	int fds[NR_FILES];
+	int ret, i;
+
+	ret = io_uring_queue_init(1, &src, 0);
+	if (ret) return T_EXIT_FAIL;
+	
+	ret = io_uring_queue_init(1, &dst, 0);
+	if (ret) return T_EXIT_FAIL;
+	
+	if (reg_src) {
+		ret = io_uring_register_ring_fd(&src);
+		if (ret < 0 && ret != -EINVAL) return T_EXIT_FAIL;
+	}
+	if (reg_dst) {
+		ret = io_uring_register_ring_fd(&dst);
+		if (ret < 0 && ret != -EINVAL) return T_EXIT_FAIL;
+	}
+
+	/* test fail with no files in src */
+	ret = io_uring_clone_files(&dst, &src);
+	if (ret == -EINVAL) {
+		no_file_clone = 1;
+		return T_EXIT_SKIP;
+	} else if (ret != -ENXIO) {
+		fprintf(stderr, "empty copy: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	for (i = 0; i < NR_FILES; i++) {
+		int pipe_fds[2];
+		if (pipe(pipe_fds) < 0) return T_EXIT_FAIL;
+		fds[i] = pipe_fds[0];
+		close(pipe_fds[1]);
+	}
+
+	ret = io_uring_register_files(&src, fds, NR_FILES);
+	if (ret < 0) return T_EXIT_FAIL;
+
+	ret = use_file(&src, 0);
+	if (ret < 0) return T_EXIT_FAIL;
+
+	ret = use_file(&dst, 0);
+	if (ret != -EBADF) return T_EXIT_FAIL;
+
+	/* copy should work now */
+	ret = io_uring_clone_files(&dst, &src);
+	if (ret) {
+		fprintf(stderr, "file copy: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	ret = use_file(&dst, NR_FILES / 2);
+	if (ret < 0) return T_EXIT_FAIL;
+
+	ret = io_uring_clone_files(&dst, &src);
+	if (ret != -EBUSY) {
+		fprintf(stderr, "busy copy: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	ret = io_uring_unregister_files(&dst);
+	if (ret) return T_EXIT_FAIL;
+
+	ret = io_uring_unregister_files(&src);
+	if (ret) return T_EXIT_FAIL;
+
+	for (i = 0; i < NR_FILES; i++)
+		close(fds[i]);
+
+	io_uring_queue_exit(&src);
+	io_uring_queue_exit(&dst);
+	return T_EXIT_PASS;
+}
+
+static int test_same(void)
+{
+	struct io_uring src;
+	int fds[2] = { -1, -1 }; /* sparse files */
+	int ret;
+
+	ret = io_uring_queue_init(1, &src, 0);
+	if (ret) {
+		fprintf(stderr, "ring_init: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	ret = io_uring_register_files(&src, fds, 2);
+	if (ret) {
+		fprintf(stderr, "reg files: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	/* Self-cloning MUST fail with -EINVAL due to our kernel patch */
+	ret = io_uring_clone_files_offset(&src, &src, 1, 0, 2, IORING_REGISTER_DST_REPLACE);
+	if (ret != -EINVAL) {
+		fprintf(stderr, "clone offset on same ring: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	ret = io_uring_unregister_files(&src);
+	if (ret) {
+		fprintf(stderr, "src unregister files: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	io_uring_queue_exit(&src);
+	return T_EXIT_PASS;
+}
+
+int main(int argc, char *argv[])
+{
+	int ret;
+
+	if (argc > 1)
+		return T_EXIT_SKIP;
+
+	ret = test(0, 0);
+	if (ret == T_EXIT_SKIP) {
+		return T_EXIT_SKIP;
+	} else if (ret != T_EXIT_PASS) {
+		fprintf(stderr, "test 0 0 failed\n");
+		return T_EXIT_FAIL;
+	}
+	if (no_file_clone)
+		return T_EXIT_SKIP;
+
+	ret = test(0, 1);
+	if (ret != T_EXIT_PASS) {
+		fprintf(stderr, "test 0 1 failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	ret = test(1, 0);
+	if (ret != T_EXIT_PASS) {
+		fprintf(stderr, "test 1 0 failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	ret = test(1, 1);
+	if (ret != T_EXIT_PASS) {
+		fprintf(stderr, "test 1 1 failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	ret = test_offsets();
+	if (ret == T_EXIT_SKIP) {
+		return T_EXIT_PASS;
+	} else if (ret != T_EXIT_PASS) {
+		fprintf(stderr, "test_offset failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	ret = test_same();
+	if (ret == T_EXIT_SKIP) {
+		return T_EXIT_PASS;
+	} else if (ret != T_EXIT_PASS) {
+		fprintf(stderr, "test_same failed\n");
+		return T_EXIT_FAIL;
+	}
+
+	return T_EXIT_PASS;
+}


### PR DESCRIPTION
This pull request introduces the helper function implementation for the `IORING_REGISTER_CLONE_FILES` kernel opcode.

Changes included:
* `io_uring`: sync UAPI for `IORING_REGISTER_CLONE_FILES`
* `liburing`: add `IORING_REGISTER_CLONE_FILES` helpers and export symbols under `LIBURING_2.15`
* `tests`: add test cases for `IORING_REGISTER_CLONE_FILES`
* `man`: add `io_uring_clone_files(3)` and related man pages

This PR is related to the kernel patch currently under review on the io-uring mailing list.

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
