### PR TITLE
[GIT PULL] man: Fix one typo

### DIFF
--- a/man/io_uring_register_eventfd.3
+++ b/man/io_uring_register_eventfd.3
@@ -30,7 +30,7 @@ is generated with the registered eventfd descriptor. If
 .BR io_uring_register_eventfd_async (3)
 is used, only events that completed out-of-line will trigger a notification.
 
-It notifications are no longer desired,
+If notifications are no longer desired,
 .BR io_uring_unregister_eventfd (3)
 may be called to remove the eventfd registration. No eventfd argument is
 needed, as a ring can only have a single eventfd registered.


### PR DESCRIPTION
Single-character change in _man/io_uring_register_eventfd.3_:
- From "__It__ notifications are no longer desired,"
- To "__If__ notifications are no longer desired,"

Fixes issue [#1604](https://github.com/axboe/liburing/issues/1604)

----
## git request-pull output:
```
The following changes since commit 650d8fb7acb5952a12530b617f09da75b95c979c:

  Merge branch 'harden-ci-workflow-security' of https://github.com/Alb3e3/liburing (2026-06-16 10:21:37 -0600)

are available in the Git repository at:

  https://github.com/sleiphan/liburing fix-typo

for you to fetch changes up to ce63d67ef1f2990d40d388faa5cf785706b369fc:

  man: Fix one typo (2026-06-27 23:17:00 +0000)

----------------------------------------------------------------
Håkon F. Fjellanger (1):
      man: Fix one typo

 man/io_uring_register_eventfd.3 | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```
----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
