### PR TITLE
queue: keep fallback timeout data alive until submission

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -52,10 +52,12 @@ static inline bool cq_ring_needs_enter(struct io_uring *ring)
 
 struct get_data {
 	unsigned submit;
+	unsigned submit_tail;
 	unsigned wait_nr;
 	unsigned get_flags;
 	int sz;
 	int has_ts;
+	bool wait_for_submit;
 	void *arg;
 };
 
@@ -98,8 +100,16 @@ static int _io_uring_get_cqe(struct io_uring *ring,
 		}
 		if (sq_ring_needs_enter(ring, data->submit, &flags))
 			need_enter = true;
-		if (!need_enter)
-			break;
+		if (!need_enter) {
+			if (!data->wait_for_submit ||
+			    io_uring_load_sq_head(ring) == data->submit_tail)
+				break;
+			/*
+			 * SQPOLL submission is asynchronous.  Keep the caller's
+			 * submission data alive until the SQ thread consumed it.
+			 */
+			continue;
+		}
 		if (looped && data->has_ts) {
 			/*
 			 * When IORING_ENTER_EXT_ARG_REG is set, data->arg
@@ -125,14 +135,41 @@ static int _io_uring_get_cqe(struct io_uring *ring,
 					    data->wait_nr, flags, data->arg,
 					    data->sz);
 		if (ret < 0) {
+			if (data->wait_for_submit &&
+			    !(ring->flags & IORING_SETUP_SQPOLL) &&
+			    io_uring_load_sq_head(ring) != data->submit_tail) {
+				unsigned tail = data->submit_tail - 1;
+
+				/*
+				 * The timeout is the last SQE and non-SQPOLL
+				 * submission is synchronous.  Retract it so a
+				 * later submit cannot use the caller's pointer.
+				 */
+				ring->sq.sqe_head = tail;
+				ring->sq.sqe_tail = tail;
+				*ring->sq.ktail = tail;
+			}
 			if (!err)
 				err = ret;
 			break;
 		}
 
-		data->submit -= ret;
-		if (cqe)
-			break;
+		if (data->wait_for_submit)
+			data->submit = data->submit_tail -
+					io_uring_load_sq_head(ring);
+		else
+			data->submit -= ret;
+		if (cqe) {
+			if (!data->wait_for_submit || !data->submit)
+				break;
+			/*
+			 * Preserve the return value from the point where the
+			 * CQE first became available.  The extra iterations
+			 * only keep submission data alive.
+			 */
+			looped = true;
+			continue;
+		}
 		if (!looped) {
 			looped = true;
 			err = ret;
@@ -329,7 +366,8 @@ static int io_uring_wait_cqes_new(struct io_uring *ring,
  * handling between two threads.
  */
 static int __io_uring_submit_timeout(struct io_uring *ring, unsigned wait_nr,
-				     struct __kernel_timespec *ts)
+				     struct __kernel_timespec *ts,
+				     unsigned *submit_tail)
 {
 	struct io_uring_sqe *sqe;
 	int ret;
@@ -348,7 +386,27 @@ static int __io_uring_submit_timeout(struct io_uring *ring, unsigned wait_nr,
 	}
 	io_uring_prep_timeout(sqe, ts, wait_nr, 0);
 	sqe->user_data = LIBURING_UDATA_TIMEOUT;
-	return __io_uring_flush_sq(ring);
+	ret = __io_uring_flush_sq(ring);
+	*submit_tail = ring->sq.sqe_tail;
+	return ret;
+}
+
+static int __io_uring_get_cqe_timeout(struct io_uring *ring,
+				      struct io_uring_cqe **cqe_ptr,
+				      unsigned submit, unsigned submit_tail,
+				      unsigned wait_nr, sigset_t *sigmask)
+{
+	struct get_data data = {
+		.submit		= submit,
+		.submit_tail	= submit_tail,
+		.wait_nr	= wait_nr,
+		.get_flags	= 0,
+		.sz		= _NSIG / 8,
+		.wait_for_submit = true,
+		.arg		= sigmask,
+	};
+
+	return _io_uring_get_cqe(ring, cqe_ptr, &data);
 }
 
 int io_uring_wait_cqes(struct io_uring *ring, struct io_uring_cqe **cqe_ptr,
@@ -356,16 +414,23 @@ int io_uring_wait_cqes(struct io_uring *ring, struct io_uring_cqe **cqe_ptr,
 		       sigset_t *sigmask)
 {
 	int to_submit = 0;
+	unsigned submit_tail = 0;
+	bool timeout_fallback = false;
 
 	if (ts) {
 		if (ring->features & IORING_FEAT_EXT_ARG)
 			return io_uring_wait_cqes_new(ring, cqe_ptr, wait_nr,
 							ts, 0, sigmask);
-		to_submit = __io_uring_submit_timeout(ring, wait_nr, ts);
+		to_submit = __io_uring_submit_timeout(ring, wait_nr, ts,
+						      &submit_tail);
 		if (to_submit < 0)
 			return to_submit;
+		timeout_fallback = true;
 	}
 
+	if (timeout_fallback)
+		return __io_uring_get_cqe_timeout(ring, cqe_ptr, to_submit,
+						  submit_tail, wait_nr, sigmask);
 	return __io_uring_get_cqe(ring, cqe_ptr, to_submit, wait_nr, sigmask);
 }
 
@@ -409,6 +474,8 @@ static int __io_uring_submit_and_wait_timeout(struct io_uring *ring,
 			unsigned int min_wait, sigset_t *sigmask)
 {
 	int to_submit;
+	unsigned submit_tail = 0;
+	bool timeout_fallback = false;
 
 	if (ts) {
 		if (ring->features & IORING_FEAT_EXT_ARG) {
@@ -429,12 +496,17 @@ static int __io_uring_submit_and_wait_timeout(struct io_uring *ring,
 
 			return _io_uring_get_cqe(ring, cqe_ptr, &data);
 		}
-		to_submit = __io_uring_submit_timeout(ring, wait_nr, ts);
+		to_submit = __io_uring_submit_timeout(ring, wait_nr, ts,
+						      &submit_tail);
 		if (to_submit < 0)
 			return to_submit;
+		timeout_fallback = true;
 	} else
 		to_submit = __io_uring_flush_sq(ring);
 
+	if (timeout_fallback)
+		return __io_uring_get_cqe_timeout(ring, cqe_ptr, to_submit,
+						  submit_tail, wait_nr, sigmask);
 	return __io_uring_get_cqe(ring, cqe_ptr, to_submit, wait_nr, sigmask);
 }
 

--- a/test/submit-and-wait.c
+++ b/test/submit-and-wait.c
@@ -75,10 +75,93 @@ err:
 	return ret;
 }
 
+static int test_sqpoll_timeout_consumed(void)
+{
+	struct io_uring_params p = {
+		.flags = IORING_SETUP_SQPOLL,
+		.sq_thread_idle = 10,
+	};
+	struct __kernel_timespec ts = { .tv_sec = 1 };
+	struct io_uring_cqe *cqe;
+	struct io_uring_sqe *sqe;
+	struct io_uring ring;
+	unsigned i;
+	int ret;
+
+	ret = t_create_ring_params(32768, &ring, &p);
+	if (ret == T_SETUP_SKIP)
+		return 0;
+	if (ret != T_SETUP_OK)
+		return 1;
+
+	sqe = io_uring_get_sqe(&ring);
+	if (!sqe) {
+		ret = 1;
+		goto out;
+	}
+	io_uring_prep_nop(sqe);
+	ret = io_uring_submit(&ring);
+	if (ret < 0)
+		goto out;
+	ret = io_uring_wait_cqe(&ring, &cqe);
+	if (ret)
+		goto out;
+
+	for (i = 0; i < 1000; i++) {
+		if (IO_URING_READ_ONCE(*ring.sq.kflags) &
+		    IORING_SQ_NEED_WAKEUP)
+			break;
+		usleep(1000);
+	}
+	if (i == 1000) {
+		fprintf(stderr, "SQPOLL thread did not go idle\n");
+		ret = 1;
+		goto out;
+	}
+
+	/*
+	 * Fill the ring without publishing the SQEs.  Waking the idle SQ
+	 * thread below then leaves a deterministic window where the timeout
+	 * SQE has been published but not consumed.
+	 */
+	for (i = 0; i < ring.sq.ring_entries - 1; i++) {
+		sqe = io_uring_get_sqe(&ring);
+		if (!sqe) {
+			fprintf(stderr, "failed to fill SQ ring at %u\n", i);
+			ret = 1;
+			goto out;
+		}
+		io_uring_prep_nop(sqe);
+	}
+
+	/* Exercise the pre-IORING_FEAT_EXT_ARG timeout fallback. */
+	ring.features &= ~IORING_FEAT_EXT_ARG;
+	ret = io_uring_wait_cqes(&ring, &cqe, 1, &ts, NULL);
+	if (ret) {
+		fprintf(stderr, "wait_cqes: %d\n", ret);
+		goto out;
+	}
+	if (io_uring_sq_ready(&ring)) {
+		fprintf(stderr, "returned with %u unconsumed SQEs\n",
+			io_uring_sq_ready(&ring));
+		ret = 1;
+	} else {
+		ret = 0;
+	}
+out:
+	io_uring_queue_exit(&ring);
+	return ret;
+}
+
 int main(int argc, char *argv[])
 {
+	int ret;
+
 	if (argc > 1)
 		return 0;
 
-	return test_ring();
+	ret = test_ring();
+	if (ret)
+		return ret;
+	return test_sqpoll_timeout_consumed();
 }


### PR DESCRIPTION
On kernels without IORING_FEAT_EXT_ARG, the timeout fallback places the caller-owned timespec pointer in an IORING_OP_TIMEOUT SQE. _io_uring_get_cqe() could return an already available CQE before SQPOLL consumed that SQE, or before a short non-SQPOLL submission reached it. The caller could then release stack storage while the ring still held the pointer.

Track the SQ tail containing the fallback timeout and keep submitting/waiting until the kernel SQ head reaches it. If a synchronous submission fails first, retract the last timeout SQE so a later submit cannot use the pointer. Other get-CQE paths retain their existing behavior and return values.

The regression test idles an SQPOLL thread, fills a 32K SQ without publishing it, forces the pre-EXT_ARG fallback, and verifies the call cannot return with unconsumed SQEs. It fails on current master with 32768 SQEs still ready and passes with this change.

Validation:
- Full liburing test suite on Linux 6.12: all tests passed
- ASan/UBSan: submit-and-wait, timeout, timeout-new, and defer-tw-timeout passed

Fixes #1164