### PR TITLE
queue: add opt-in requeue helper for SQ_REWIND

### DIFF
--- a/man/io_uring_sq_requeue.3
+++ b/man/io_uring_sq_requeue.3
@@ -1,0 +1,41 @@
+." SPDX-License-Identifier: MIT
+.TH io_uring_sq_requeue 3 "August 5, 2026" "liburing-2.15" "liburing Manual"
+.SH NAME
+io_uring_sq_requeue \- requeue unconsumed SQEs after an SQ_REWIND submit
+.SH SYNOPSIS
+.nf
+.B #include <liburing.h>
+.PP
+.BI "void io_uring_sq_requeue(struct io_uring *" ring ","
+.BI "                         unsigned " submitted ", int " submit_ret ");"
+.fi
+.SH DESCRIPTION
+The
+.BR io_uring_sq_requeue (3)
+function relocates entries left by a short or failed submission on a ring
+created with
+.BR IORING_SETUP_SQ_REWIND .
+It moves the unconsumed entries to the beginning of the submission queue and
+restores the local queue tail so that a later submit can retry them.
+.PP
+Before submitting, the application records
+.I submitted
+with
+.BR io_uring_sq_ready (3).
+After the submission returns, the application passes its return value as
+.IR submit_ret .
+A negative return value means that no entries were consumed. If all submitted
+entries were consumed, or if the ring does not use
+.BR IORING_SETUP_SQ_REWIND ,
+the function does nothing.
+.PP
+This function must be called immediately after the submission and before the
+application acquires any new SQEs. Requeueing is an explicit caller policy;
+short submissions are not requeued by default.
+.SH RETURN VALUE
+None.
+.SH SEE ALSO
+.BR io_uring_get_sqe (3),
+.BR io_uring_sq_ready (3),
+.BR io_uring_submit (3),
+.BR io_uring_setup (2)

--- a/src/include/liburing.h
+++ b/src/include/liburing.h
@@ -1757,6 +1757,37 @@ IOURINGINLINE unsigned io_uring_sqe_shift(const struct io_uring *ring)
 }
 
 /*
+ * Requeue entries left by a short or failed IORING_SETUP_SQ_REWIND submit.
+ * Call immediately after submitting and before acquiring any more SQEs.
+ */
+IOURINGINLINE void io_uring_sq_requeue(struct io_uring *ring,
+				       unsigned submitted, int submit_ret)
+	LIBURING_NOEXCEPT
+{
+	struct io_uring_sq *sq = &ring->sq;
+	unsigned consumed, remaining;
+
+	if (!(ring->flags & IORING_SETUP_SQ_REWIND) || !submitted)
+		return;
+
+	consumed = submit_ret > 0 ? submit_ret : 0;
+	if (consumed >= submitted)
+		return;
+	remaining = submitted - consumed;
+
+	if (consumed) {
+		unsigned shift = io_uring_sqe_shift(ring);
+		unsigned src = consumed << shift;
+		unsigned slots = remaining << shift;
+		unsigned dst;
+
+		for (dst = 0; dst < slots; dst++)
+			sq->sqes[dst] = sq->sqes[src + dst];
+	}
+	sq->sqe_tail = remaining;
+}
+
+/*
  * Only applicable when using SQPOLL - allows the caller to wait for space
  * to free up in the SQ ring, which happens when the kernel side thread has
  * consumed one or more entries. If the SQ ring is currently non-full, no

--- a/src/liburing-ffi.map
+++ b/src/liburing-ffi.map
@@ -274,4 +274,5 @@ LIBURING_2.15 {
 		__io_uring_peek_cqe;
 		io_uring_register_zcrx_ctrl;
 		io_uring_register_query;
+		io_uring_sq_requeue;
 } LIBURING_2.14;

--- a/src/queue.c
+++ b/src/queue.c
@@ -130,7 +130,11 @@ static int _io_uring_get_cqe(struct io_uring *ring,
 			break;
 		}
 
-		data->submit -= ret;
+		/* SQ_REWIND callers choose whether to requeue a short submit. */
+		if (ring->flags & IORING_SETUP_SQ_REWIND)
+			data->submit = 0;
+		else
+			data->submit -= ret;
 		if (cqe)
 			break;
 		if (!looped) {

--- a/test/Makefile
+++ b/test/Makefile
@@ -275,6 +275,7 @@ test_srcs := \
 	sq-poll-kthread.c \
 	sq-poll-share.c \
 	sqpoll-sleep.c \
+	sq-rewind-partial.c \
 	sq-space_left.c \
 	sqe-mixed-boundary.c \
 	sqe-mixed-nop.c \

--- a/test/sq-rewind-partial.c
+++ b/test/sq-rewind-partial.c
@@ -1,0 +1,285 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Verify optional requeueing after a short SQ_REWIND submission.
+ */
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "liburing.h"
+#include "helpers.h"
+
+static void prep_partial_batch(struct io_uring *ring)
+{
+	struct io_uring_sqe *sqe;
+
+	sqe = io_uring_get_sqe(ring);
+	io_uring_prep_nop(sqe);
+	sqe->user_data = 1;
+
+	sqe = io_uring_get_sqe(ring);
+	io_uring_prep_nop(sqe);
+	sqe->opcode = 0xff;
+	sqe->user_data = 2;
+
+	sqe = io_uring_get_sqe(ring);
+	io_uring_prep_nop(sqe);
+	sqe->user_data = 3;
+}
+
+static int consume_cqe(struct io_uring *ring, struct io_uring_cqe *cqe,
+		       unsigned *seen, unsigned *count)
+{
+	unsigned bit;
+
+	if (cqe->user_data < 1 || cqe->user_data > 3) {
+		fprintf(stderr, "unexpected user_data: %llu\n",
+			(unsigned long long) cqe->user_data);
+		return T_EXIT_FAIL;
+	}
+	bit = 1U << cqe->user_data;
+	if (*seen & bit) {
+		fprintf(stderr, "duplicate completion for user_data %llu\n",
+			(unsigned long long) cqe->user_data);
+		return T_EXIT_FAIL;
+	}
+	*seen |= bit;
+	(*count)++;
+	io_uring_cqe_seen(ring, cqe);
+	return T_EXIT_PASS;
+}
+
+static int test_partial_submit(unsigned flags, bool timed, bool requeue)
+{
+	struct __kernel_timespec ts = { .tv_sec = 1 };
+	struct io_uring_cqe *cqe = NULL;
+	struct io_uring ring;
+	unsigned submitted, seen = 0, count = 0, expected_count;
+	bool pending;
+	int ret;
+
+	ret = io_uring_queue_init(8, &ring, flags);
+	if (ret == -EINVAL && (flags & IORING_SETUP_SQ_REWIND))
+		return T_EXIT_SKIP;
+	if (ret) {
+		fprintf(stderr, "queue init failed: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	prep_partial_batch(&ring);
+	submitted = io_uring_sq_ready(&ring);
+
+	if (timed)
+		ret = io_uring_submit_and_wait_timeout(&ring, &cqe, 2, &ts,
+						       NULL);
+	else
+		ret = io_uring_submit(&ring);
+	if (ret != 2) {
+		fprintf(stderr, "first submit with flags %#x returned %d, expected 2\n",
+			flags, ret);
+		goto fail;
+	}
+
+	if (flags & IORING_SETUP_SQ_REWIND) {
+		if (io_uring_sq_ready(&ring) != 0) {
+			fprintf(stderr,
+				"SQ_REWIND kept a short submit without opt-in\n");
+			goto fail;
+		}
+		if (requeue)
+			io_uring_sq_requeue(&ring, submitted, ret);
+	}
+
+	pending = requeue || !(flags & IORING_SETUP_SQ_REWIND);
+	if (io_uring_sq_ready(&ring) != pending) {
+		fprintf(stderr,
+			"pending SQEs with flags %#x after partial submit: %u, expected %u\n",
+			flags, io_uring_sq_ready(&ring), pending);
+		goto fail;
+	}
+	if (cqe) {
+		if (consume_cqe(&ring, cqe, &seen, &count))
+			goto fail;
+	}
+
+	if (pending) {
+		ret = io_uring_submit(&ring);
+		if (ret != 1) {
+			fprintf(stderr,
+				"retry submit with flags %#x returned %d, expected 1\n",
+				flags, ret);
+			goto fail;
+		}
+	}
+
+	expected_count = pending ? 3 : 2;
+	while (count != expected_count) {
+		ret = io_uring_wait_cqe(&ring, &cqe);
+		if (ret) {
+			fprintf(stderr, "wait failed: %d\n", ret);
+			goto fail;
+		}
+		if (consume_cqe(&ring, cqe, &seen, &count))
+			goto fail;
+	}
+	if (seen != (expected_count == 3 ? 0xe : 0x6)) {
+		fprintf(stderr, "unexpected completion set: %#x\n", seen);
+		goto fail;
+	}
+	ret = io_uring_peek_cqe(&ring, &cqe);
+	if (!ret) {
+		fprintf(stderr, "unexpected extra completion after short submit\n");
+		goto fail;
+	}
+	if (ret != -EAGAIN) {
+		fprintf(stderr, "peek after short submit failed: %d\n", ret);
+		goto fail;
+	}
+
+	io_uring_queue_exit(&ring);
+	return T_EXIT_PASS;
+fail:
+	io_uring_queue_exit(&ring);
+	return T_EXIT_FAIL;
+}
+
+static int test_failed_submit(void)
+{
+	struct io_uring_params p = {
+		.flags = IORING_SETUP_R_DISABLED | IORING_SETUP_SQ_REWIND,
+	};
+	struct io_uring_cqe *cqe;
+	struct io_uring_sqe *sqe;
+	struct io_uring ring;
+	unsigned submitted;
+	int ret;
+
+	ret = io_uring_queue_init_params(8, &ring, &p);
+	if (ret == -EINVAL)
+		return T_EXIT_SKIP;
+	if (ret) {
+		fprintf(stderr, "disabled queue init failed: %d\n", ret);
+		return T_EXIT_FAIL;
+	}
+
+	sqe = io_uring_get_sqe(&ring);
+	io_uring_prep_nop(sqe);
+	sqe->user_data = 1;
+	submitted = io_uring_sq_ready(&ring);
+
+	ret = io_uring_submit(&ring);
+	if (ret != -EBADFD) {
+		fprintf(stderr, "disabled submit returned %d, expected %d\n",
+			ret, -EBADFD);
+		goto fail;
+	}
+	if (io_uring_sq_ready(&ring) != 0) {
+		fprintf(stderr, "failed submit was requeued without opt-in\n");
+		goto fail;
+	}
+	io_uring_sq_requeue(&ring, submitted, ret);
+	if (io_uring_sq_ready(&ring) != 1) {
+		fprintf(stderr, "pending SQEs after failed submit: %u, expected 1\n",
+			io_uring_sq_ready(&ring));
+		goto fail;
+	}
+
+	ret = io_uring_enable_rings(&ring);
+	if (ret) {
+		fprintf(stderr, "ring enable failed: %d\n", ret);
+		goto fail;
+	}
+	ret = io_uring_submit(&ring);
+	if (ret != 1) {
+		fprintf(stderr, "submit after enable returned %d, expected 1\n", ret);
+		goto fail;
+	}
+	ret = io_uring_wait_cqe(&ring, &cqe);
+	if (ret || cqe->user_data != 1 || cqe->res) {
+		fprintf(stderr, "unexpected completion after retry: ret=%d\n", ret);
+		goto fail;
+	}
+	io_uring_cqe_seen(&ring, cqe);
+
+	io_uring_queue_exit(&ring);
+	return T_EXIT_PASS;
+fail:
+	io_uring_queue_exit(&ring);
+	return T_EXIT_FAIL;
+}
+
+static int test_wait_preserves_pending(void)
+{
+	struct __kernel_timespec ts = { .tv_nsec = 1000000 };
+	struct io_uring_cqe *cqe;
+	struct io_uring_sqe *sqe;
+	struct io_uring ring;
+	int ret;
+
+	ret = io_uring_queue_init(8, &ring, IORING_SETUP_SQ_REWIND);
+	if (ret == -EINVAL)
+		return T_EXIT_SKIP;
+	if (ret)
+		return T_EXIT_FAIL;
+
+	sqe = io_uring_get_sqe(&ring);
+	io_uring_prep_nop(sqe);
+	ret = io_uring_wait_cqe_timeout(&ring, &cqe, &ts);
+	if (ret != -ETIME || io_uring_sq_ready(&ring) != 1) {
+		fprintf(stderr, "timed wait lost a pending SQE: ret=%d ready=%u\n",
+			ret, io_uring_sq_ready(&ring));
+		goto fail;
+	}
+
+	ret = io_uring_submit(&ring);
+	if (ret != 1) {
+		fprintf(stderr, "submit after timed wait failed: %d\n", ret);
+		goto fail;
+	}
+	ret = io_uring_wait_cqe(&ring, &cqe);
+	if (ret) {
+		fprintf(stderr, "wait after timed wait failed: %d\n", ret);
+		goto fail;
+	}
+	io_uring_cqe_seen(&ring, cqe);
+	io_uring_queue_exit(&ring);
+	return T_EXIT_PASS;
+fail:
+	io_uring_queue_exit(&ring);
+	return T_EXIT_FAIL;
+}
+
+int main(int argc, char *argv[])
+{
+	int ret;
+
+	if (argc > 1)
+		return T_EXIT_SKIP;
+
+	ret = test_partial_submit(0, false, false);
+	if (ret)
+		return ret;
+
+	ret = test_partial_submit(IORING_SETUP_SQ_REWIND, false, false);
+	if (ret)
+		return ret;
+
+	ret = test_partial_submit(IORING_SETUP_SQ_REWIND, false, true);
+	if (ret)
+		return ret;
+
+	ret = test_partial_submit(IORING_SETUP_SQ_REWIND |
+				  IORING_SETUP_SQE128, false, true);
+	if (ret)
+		return ret;
+
+	ret = test_partial_submit(IORING_SETUP_SQ_REWIND, true, true);
+	if (ret)
+		return ret;
+
+	ret = test_wait_preserves_pending();
+	if (ret)
+		return ret;
+
+	return test_failed_submit();
+}


### PR DESCRIPTION
`IORING_SETUP_SQ_REWIND` clears liburing's local SQ tail before entering the kernel. If a submission is short, the caller may either abandon the unconsumed entries or choose to retry them. Retrying requires relocating those entries to the beginning of the SQ.

This adds `io_uring_sq_requeue()` as an explicit opt-in helper. The application records `io_uring_sq_ready()` before submission, then passes that count and the submission return value to the helper before acquiring any new SQEs.

Submission-and-wait paths also stop internally resubmitting an unrelocated `SQ_REWIND` remainder. Without that guard, a short timed submission can submit already-consumed slots again.

The regression covers:

- the default abandon policy and explicit requeue policy;
- ordinary and fixed 128-byte SQEs;
- partial and fully failed submissions;
- timed submission with duplicate-completion detection;
- a pure wait with locally pending work; and
- the regular circular-ring behavior as a control.

Validation:

- Linux 7.0.0-28-generic
- normal GCC build and FFI symbol check
- ASan/UBSan build
- focused regression plus nine adjacent submission/SQ tests in both builds