### PR TITLE
[GIT PULL] Test: Introduce duration scale for upper timing bounds

### DIFF
--- a/test/helpers.c
+++ b/test/helpers.c
@@ -365,6 +365,33 @@ unsigned long long utime_since_now(struct timeval *tv)
 	return utime_since(tv, &end);
 }
 
+/*
+ * Scale a duration based on the environment variable LIBURING_DURATION_SCALE
+ * (default 1.0) that can be increased on slow platforms.
+ */
+unsigned long long t_scale_duration(unsigned long long duration)
+{
+	static float duration_factor = 0;
+	if (duration_factor > 0)
+		return (unsigned long long) (duration * duration_factor);
+
+	duration_factor = 1;
+	char *env_val = getenv("LIBURING_DURATION_SCALE");
+	if (env_val) {
+		char* endptr;
+		errno = 0;
+		float mul = strtof(env_val, &endptr);
+		if (mul <= 0 || errno)
+			fprintf(stderr, "Warn: LIBURING_DURATION_SCALE must be a positive, non-zero float, keep duration\n");
+		else if (*endptr != '\0')
+			fprintf(stderr, "Warn: LIBURING_DURATION_SCALE contains illegal characters: '%s', keep duration\n", endptr);
+		else
+			duration_factor = mul;
+	}
+
+	return (unsigned long long) (duration * duration_factor);
+}
+
 void *t_aligned_alloc(size_t alignment, size_t size)
 {
 	void *ret;

--- a/test/helpers.h
+++ b/test/helpers.h
@@ -122,6 +122,8 @@ unsigned long long mtime_since_now(struct timeval *tv);
 unsigned long long utime_since(const struct timeval *s, const struct timeval *e);
 unsigned long long utime_since_now(struct timeval *tv);
 
+unsigned long long t_scale_duration(unsigned long long duration);
+
 int t_submit_and_wait_single(struct io_uring *ring, struct io_uring_cqe **cqe);
 
 size_t t_iovec_data_length(struct iovec *iov, unsigned iov_len);

--- a/test/io-wq-exit.c
+++ b/test/io-wq-exit.c
@@ -122,7 +122,7 @@ int main(int argc, char *argv[])
 	end = get_time_ns();
 	end -= start;
 	end /= 1000000;
-	if (end >= 500) {
+	if (end >= t_scale_duration(500)) {
 		fprintf(stderr, "Test took too long: %lu msec\n", end);
 		return T_EXIT_FAIL;
 	}

--- a/test/min-timeout-wait.c
+++ b/test/min-timeout-wait.c
@@ -27,6 +27,8 @@ static int time_pass(struct timeval *start, unsigned long min_t,
 {
 	unsigned long elapsed;
 
+	max_t = t_scale_duration(max_t);
+
 	elapsed = mtime_since_now(start);
 	if (elapsed < min_t || elapsed > max_t) {
 		fprintf(stderr, "%s fails time check\n", name);

--- a/test/mshot-shutdown-race.c
+++ b/test/mshot-shutdown-race.c
@@ -118,7 +118,7 @@ static void sig_alrm(int sig)
 		exit(1);
 	}
 	last_received_bytes = received_bytes;
-	alarm(5);
+	alarm(t_scale_duration(5));
 }
 
 int main(int argc, char *argv[])
@@ -140,7 +140,7 @@ int main(int argc, char *argv[])
 	act.sa_handler = sig_alrm;
 	act.sa_flags = SA_RESTART;
 	sigaction(SIGALRM, &act, NULL);
-	alarm(5);
+	alarm(t_scale_duration(5));
 
 	use_af_inet = !!getenv("TEST_USE_INET");
 

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -9,6 +9,7 @@ SKIPPED=()
 TIMED_OUT=()
 TEST_FILES=""
 declare -A TEST_MAP
+: "${LIBURING_DURATION_SCALE:=1.0}" #specify >1 on slow platforms to scale upper time bounds
 
 # Only use /dev/kmsg if running as root
 DO_KMSG="1"


### PR DESCRIPTION
Hey there,

as we run the tests on slower platforms like Qemu, we've introduced an environment variable `LIBURING_DURATION_SCALE` that specifies a factor to scale upper time bounds of tests where we ran into timing issues. A default factor of `1.0` is specified, so the timing of the tests stays as is.  

I'm sending here a first patch set that introduces the test library function and the scaling for a few tests. We have a few more of these patches that we could follow up with.

Best,
Chris

----
## git request-pull output:
```
The following changes since commit 4cf73437863c2e492d2a1d0f24330f391c0f075b:

  test/iowait.t: Skip if system is not quiesced for too long (2026-08-31 17:00:18 -0600)

are available in the Git repository at:

  https://github.com/zeehha/liburing user/cge/duration-scale

for you to fetch changes up to fd5bf3fa9fdc39f5d877f823b3bb475ad972502f:

  test/mshot-shutdown-race: Scale period of hang detection (2026-09-03 16:03:20 +0200)

----------------------------------------------------------------
Chris Gellermann (4):
      test: Introduce duration scale for upper timing bounds
      test/min-timeout-wait: Scale upper time bound
      test/io-wq-exit: Relax thread exit deadline
      test/mshot-shutdown-race: Scale period of hang detection

 test/helpers.c             | 27 +++++++++++++++++++++++++++
 test/helpers.h             |  2 ++
 test/io-wq-exit.c          |  2 +-
 test/min-timeout-wait.c    |  2 ++
 test/mshot-shutdown-race.c |  4 ++--
 test/runtests.sh           |  1 +
```
----
<details>
<summary>Click to show/hide pull request guidelines</summary>

## Pull Request Guidelines
1. To make everyone easily filter pull request from the email
notification, use `[GIT PULL]` as a prefix in your PR title.
```
[GIT PULL] Your Pull Request Title
```
2. Follow the commit message format rules below.
3. Follow the Linux kernel coding style (see: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst).

### Commit message format rules:
1. The first line is title (don't be more than 72 chars if possible).
2. Then an empty line.
3. Then a description (may be omitted for truly trivial changes).
4. Then an empty line again (if it has a description).
5. Then a `Signed-off-by` tag with your real name and email. For example:
```
Signed-off-by: Foo Bar <foo.bar@gmail.com>
```

The description should be word-wrapped at 72 chars. Some things should
not be word-wrapped. They may be some kind of quoted text - long
compiler error messages, oops reports, Link, etc. (things that have a
certain specific format).

Note that all of this goes in the commit message, not in the pull
request text. The pull request text should introduce what this pull
request does, and each commit message should explain the rationale for
why that particular change was made. The git tree is canonical source
of truth, not github.

Each patch should do one thing, and one thing only. If you find yourself
writing an explanation for why a patch is fixing multiple issues, that's
a good indication that the change should be split into separate patches.

If the commit is a fix for an issue, add a `Fixes` tag with the issue
URL.

Don't use GitHub anonymous email like this as the commit author:
```
123456789+username@users.noreply.github.com
```

Use a real email address!

### Commit message example:
```
src/queue: don't flush SQ ring for new wait interface

If we have IORING_FEAT_EXT_ARG, then timeouts are done through the
syscall instead of by posting an internal timeout. This was done
to be both more efficient, but also to enable multi-threaded use
the wait side. If we touch the SQ state by flushing it, that isn't
safe without synchronization.

Fixes: https://github.com/axboe/liburing/issues/402
Signed-off-by: Jens Axboe <axboe@kernel.dk>
```

</details>

----
## By submitting this pull request, I acknowledge that:
1. I have followed the above pull request guidelines.
2. I have the rights to submit this work under the same license.
3. I agree to a Developer Certificate of Origin (see https://developercertificate.org for more information).
